### PR TITLE
Portuguese translation for Web3Auth and Openlogin

### DIFF
--- a/Openlogin-locale/locales-common.json
+++ b/Openlogin-locale/locales-common.json
@@ -1,321 +1,361 @@
 {
-	"common": {
-		"powered-by": {
-			"mandarin": "通过",
-			"german": "durch",
-			"english": "Powered by",
-			"korean": "으로",
-			"spanish": "por",
-			"japanese": "沿って"
-		},
-		"errors-mismatch-password": {
-			"mandarin": "密码必须匹配",
-			"german": "Passwort muss übereinstimmen",
-			"english": "Password must match",
-			"korean": "암호가 일치해야합니다",
-			"spanish": "Contraseña debe coincidir con",
-			"japanese": "パスワードが一致している必要があります"
-		},
-		"loader-secure-login": {
-			"mandarin": "使用tKey保护登录",
-			"german": "Anmeldung mit tKey sichern",
-			"english": "Securing login with tKey",
-			"korean": "tKey로 로그인 보안",
-			"spanish": "Asegurar el inicio de sesión con tKey",
-			"japanese": "tKeyでログインを保護する"
-		},
-		"copier-copy": {
-			"mandarin": "复制到剪贴板",
-			"german": "In die Zwischenablage kopieren",
-			"english": "Copy to clipboard",
-			"korean": "클립 보드에 복사",
-			"spanish": "Copiar al portapapeles",
-			"japanese": "クリップボードにコピー"
-		},
-		"errors-incorrect-password": {
-			"mandarin": "密码错误",
-			"german": "Falsches Passwort",
-			"english": "Incorrect password",
-			"korean": "잘못된 비밀번호",
-			"spanish": "Contraseña incorrecta",
-			"japanese": "パスワードが正しくありません"
-		},
-		"toast-backup-share-verification-fail": {
-			"mandarin": "备份共享验证失败",
-			"german": "Überprüfung der Sicherungsfreigabe fehlgeschlagen",
-			"english": "Backup Share verification failed",
-			"korean": "백업 공유 확인 실패",
-			"spanish": "Error en la verificación del recurso compartido de copia de seguridad",
-			"japanese": "バックアップ共有の検証に失敗しました"
-		},
-		"copier-copied": {
-			"mandarin": "复制！",
-			"german": "Kopiert!",
-			"english": "Copied!",
-			"korean": "복사되었습니다!",
-			"spanish": "Copiado!",
-			"japanese": "コピーしました！"
-		},
-		"errors-invalid-email": {
-			"mandarin": "不合规电邮",
-			"german": "Ungültige E-Mail",
-			"english": "Invalid email",
-			"korean": "잘못된 이메일",
-			"spanish": "Email inválido",
-			"japanese": "無効なメール"
-		},
-		"errors-required": {
-			"mandarin": "必需的",
-			"german": "Erforderlich",
-			"english": "Required",
-			"korean": "필수",
-			"spanish": "Requerido",
-			"japanese": "必須"
-		},
-		"toast-password-verification-fail": {
-			"mandarin": "密码验证失败",
-			"german": "Passwortüberprüfung fehlgeschlagen",
-			"english": "Password verification failed",
-			"korean": "비밀번호 확인 실패",
-			"spanish": "Falló la verificación de la contraseña",
-			"japanese": "パスワードの確認に失敗しました"
-		},
-		"toast-device-share-delete-fail": {
-			"mandarin": "设备共享删除失败",
-			"german": "Löschen der Gerätefreigabe nicht erfolgreich",
-			"english": "Device share deletion unsuccessful",
-			"korean": "기기 공유 삭제 실패",
-			"spanish": "No se pudo eliminar el dispositivo compartido",
-			"japanese": "デバイス共有の削除に失敗しました"
-		},
-		"learn-more": {
-			"mandarin": "更多详情",
-			"german": "Mehr erfahren",
-			"english": "Learn more",
-			"korean": "더 알아보기",
-			"spanish": "Aprende más",
-			"japanese": "もっと詳しく知る"
-		},
-		"or": {
-			"mandarin": "或者",
-			"german": "oder",
-			"english": "or",
-			"korean": "또는",
-			"spanish": "o",
-			"japanese": "または"
-		},
-		"errors-incorrect-mnemonic": {
-			"mandarin": "不正确的共享助记符",
-			"german": "Falsche Share-Mnemonik",
-			"english": "Incorrect share mnemonic",
-			"korean": "잘못된 공유 니모닉",
-			"spanish": "Mnemónico compartido incorrecto",
-			"japanese": "誤った共有ニーモニック"
-		},
-		"copier-terms-of-use": {
-			"mandarin": "使用条款",
-			"german": "Nutzungsbedingungen",
-			"english": "Terms of use",
-			"korean": "이용 약관",
-			"spanish": "Condiciones de uso",
-			"japanese": "利用規約"
-		},
-		"copier-privacy-policy": {
-			"mandarin": "隐私政策",
-			"german": "Datenschutz-Bestimmungen",
-			"english": "Privacy policy",
-			"korean": "개인 정보 정책",
-			"spanish": "Política de privacidad",
-			"japanese": "個人情報保護方針"
-		},
-		"toast-backup-phase-email-send-success": {
-			"mandarin": "备用词组已发送到您的电子邮件",
-			"german": "Sicherungssatz an Ihre E-Mail gesendet",
-			"english": "Backup Phrase sent to your email",
-			"korean": "이메일로 전송 된 백업 문구",
-			"spanish": "Frase de seguridad enviada a su correo electrónico",
-			"japanese": "メールに送信されたバックアップフレーズ"
-		},
-		"errors-invalid-mnemonic": {
-			"mandarin": "助记词短语无效",
-			"german": "Ungültige mnemonische Phrase",
-			"english": "Invalid mnemonic phrase",
-			"korean": "잘못된 니모닉 문구",
-			"spanish": "Frase mnemotécnica no válida",
-			"japanese": "ニーモニックフレーズが無効です"
-		},
-		"errors-invalid-password": {
-			"mandarin": "必须至少包含10个字符。 至少一个大写字母，一个小写字母，一个数字",
-			"german": "Muss mindestens 10 Zeichen enthalten. Mindestens ein Großbuchstabe, ein Kleinbuchstabe, eine Zahl",
-			"english": "Must contain at least 10 characters. At least one uppercase letter, one lowercase letter, one number",
-			"korean": "10 자 이상이어야합니다. 하나 이상의 대문자, 하나의 소문자, 하나의 숫자",
-			"spanish": "Debe contener al menos 10 caracteres. Al menos una letra mayúscula, una letra minúscula, un número",
-			"japanese": "10文字以上である必要があります。 少なくとも1つの大文字、1つの小文字、1つの数字"
-		},
-		"toast-password-change-fail": {
-			"mandarin": "密码更改失败",
-			"german": "Passwortänderung nicht erfolgreich",
-			"english": "Password change unsuccessful",
-			"korean": "비밀번호 변경 실패",
-			"spanish": "Cambio de contraseña fallido",
-			"japanese": "パスワードの変更に失敗しました"
-		},
-		"toast-something-went-wrong": {
-			"mandarin": "出问题了",
-			"german": "Etwas ist schief gelaufen",
-			"english": "Something went wrong",
-			"korean": "문제가 발생했습니다",
-			"spanish": "Algo salió mal",
-			"japanese": "何かがうまくいかなかった"
-		},
-		"toast-registration-failed": {
-			"mandarin": "注册失败",
-			"german": "Registrierung fehlgeschlagen",
-			"english": "Registration failed",
-			"korean": "등록 실패",
-			"spanish": "Registro fallido",
-			"japanese": "登録に失敗しました"
-		},
-		"close": {
-			"mandarin": "关闭",
-			"german": "Schließen",
-			"english": "Close",
-			"korean": "닫기",
-			"spanish": "Cerrar",
-			"japanese": "閉じる"
-		},
-		"loader-device-detecting": {
-			"mandarin": "检测您的设备",
-			"german": "Erkennen Ihres Geräts",
-			"english": "Detecting your device",
-			"korean": "장치 감지",
-			"spanish": "Detectando su dispositivo",
-			"japanese": "デバイスの検出"
-		},
-		"toast-backup-phase-send-success": {
-			"mandarin": "备份词组已成功发送",
-			"german": "Sicherungssatz erfolgreich gesendet",
-			"english": "Backup Phrase successfully sent",
-			"korean": "백업 문구를 성공적으로 보냈습니다.",
-			"spanish": "Frase de seguridad enviada con éxito",
-			"japanese": "バックアップフレーズが正常に送信されました"
-		},
-		"toast-backup-phase-send-fail": {
-			"mandarin": "无法发送备份短语",
-			"german": "Sicherungssatz kann nicht gesendet werden",
-			"english": "Unable to send Backup Phrase",
-			"korean": "백업 문구를 보낼 수 없습니다.",
-			"spanish": "No se pudo enviar la frase de respaldo",
-			"japanese": "バックアップフレーズを送信できません"
-		},
-		"toast-require-verification": {
-			"mandarin": "需要其他验证输入",
-			"german": "Benötigen Sie eine weitere Überprüfungseingabe",
-			"english": "Require another verification input",
-			"korean": "다른 확인 입력 필요",
-			"spanish": "Requerir otra entrada de verificación",
-			"japanese": "別の検証入力が必要"
-		},
-		"confirm": {
-			"mandarin": "确认",
-			"german": "Bestätigen",
-			"english": "Confirm",
-			"korean": "확인",
-			"spanish": "Confirmar",
-			"japanese": "確認"
-		},
-		"toast-recovery-share-delete-fail": {
-			"mandarin": "恢复共享删除失败",
-			"german": "Das Löschen der Wiederherstellungsfreigabe ist fehlgeschlagen",
-			"english": "Recovery share deletion failed",
-			"korean": "복구 공유 삭제 실패",
-			"spanish": "Error al eliminar el recurso compartido de recuperación",
-			"japanese": "リカバリ共有の削除に失敗しました"
-		},
-		"toast-recovery-share-delete-success": {
-			"mandarin": "恢复共享已成功删除",
-			"german": "Wiederherstellungsfreigabe erfolgreich gelöscht",
-			"english": "Recovery share deleted successfully",
-			"korean": "복구 공유가 성공적으로 삭제되었습니다.",
-			"spanish": "El recurso compartido de recuperación se eliminó correctamente",
-			"japanese": "リカバリ共有が正常に削除されました"
-		},
-		"toast-backup-phase-email-send-timeout": {
-			"english": "Timeout when sending Backup phrase to your email. Please download Backup phrase instead"
-		},
-		"copier-manage-account": {
-			"mandarin": "管理帐户",
-			"german": "Konto verwalten",
-			"english": "Manage account",
-			"korean": "계정 관리",
-			"spanish": "Administrar cuenta",
-			"japanese": "アカウントを管理する"
-		},
-		"cancel": {
-			"mandarin": "取消",
-			"german": "Stornieren",
-			"english": "Cancel",
-			"korean": "취소",
-			"spanish": "Cancelar",
-			"japanese": "キャンセル"
-		},
-		"toast-password-change-success": {
-			"mandarin": "密码修改成功",
-			"german": "Passwort erfolgreich geändert",
-			"english": "Password successfully changed",
-			"korean": "비밀번호가 성공적으로 변경되었습니다.",
-			"spanish": "Contraseña cambiada correctamente",
-			"japanese": "パスワードが正常に変更されました"
-		},
-		"secured-by": {
-			"mandarin": "担保人",
-			"german": "Gesichert durch",
-			"english": "Secured by",
-			"korean": "보안",
-			"spanish": "Asegurado por",
-			"japanese": "によって保護"
-		},
-		"referenceId": {
-			"mandarin": "参考编号：",
-			"german": "Referenz ID:",
-			"english": "Reference ID:",
-			"korean": "참조 ID :",
-			"spanish": "Identificación de referencia:",
-			"japanese": "参照ID："
-		},
-		"toast-share-transfer-fail": {
-			"mandarin": "股份转让失败",
-			"german": "Freigabeübertragung fehlgeschlagen",
-			"english": "Share transfer failed",
-			"korean": "공유 전송 실패",
-			"spanish": "Error al transferir el recurso compartido",
-			"japanese": "共有の転送に失敗しました"
-		},
-		"toast-device-share-delete-success": {
-			"mandarin": "设备共享已成功删除",
-			"german": "Gerätefreigabe erfolgreich gelöscht",
-			"english": "Device share successfully deleted",
-			"korean": "장치 공유가 성공적으로 삭제되었습니다.",
-			"spanish": "Dispositivo compartido eliminado correctamente",
-			"japanese": "デバイス共有が正常に削除されました"
-		},
-		"selfCustodial": {
-			"mandarin": "自托管登录由",
-			"german": "Selbstverwahrungs-Login durch",
-			"english": "Self-custodial login by",
-			"korean": "자가 관리 로그인",
-			"spanish": "Inicio de sesión con autocustodia por",
-			"japanese": "による自己管理ログイン"
-		}
-	},
-	"error-block": {
-		"required-fields-title": {
-			"mandarin": "以下一个或多个必需参数缺失/无效",
-			"german": "Einer oder mehrere der folgenden erforderlichen Parameter fehlen / sind ungültig",
-			"english": "One or more of the following required parameters is missing/invalid",
-			"korean": "다음 필수 매개 변수 중 하나 이상이 누락되었거나 유효하지 않습니다.",
-			"spanish": "Uno o más de los siguientes parámetros obligatorios faltan o no son válidos",
-			"japanese": "次の必須パラメーターの1つ以上が欠落/無効です"
-		}
-	}
+  "common": {
+    "powered-by": {
+      "mandarin": "通过",
+      "german": "durch",
+      "english": "Powered by",
+      "korean": "으로",
+      "spanish": "por",
+      "japanese": "沿って",
+      "portuguese": "Provido por"
+    },
+    "errors-mismatch-password": {
+      "mandarin": "密码必须匹配",
+      "german": "Passwort muss übereinstimmen",
+      "english": "Password must match",
+      "korean": "암호가 일치해야합니다",
+      "spanish": "Contraseña debe coincidir con",
+      "japanese": "パスワードが一致している必要があります",
+      "portuguese": "A senha deve ser igual"
+    },
+    "loader-secure-login": {
+      "mandarin": "使用tKey保护登录",
+      "german": "Anmeldung mit tKey sichern",
+      "english": "Securing login with tKey",
+      "korean": "tKey로 로그인 보안",
+      "spanish": "Asegurar el inicio de sesión con tKey",
+      "japanese": "tKeyでログインを保護する",
+      "portuguese": "Protegendo o login com tKey"
+    },
+    "copier-copy": {
+      "mandarin": "复制到剪贴板",
+      "german": "In die Zwischenablage kopieren",
+      "english": "Copy to clipboard",
+      "korean": "클립 보드에 복사",
+      "spanish": "Copiar al portapapeles",
+      "japanese": "クリップボードにコピー",
+      "portuguese": "Copiar para área de transferência"
+    },
+    "errors-incorrect-password": {
+      "mandarin": "密码错误",
+      "german": "Falsches Passwort",
+      "english": "Incorrect password",
+      "korean": "잘못된 비밀번호",
+      "spanish": "Contraseña incorrecta",
+      "japanese": "パスワードが正しくありません",
+      "portuguese": "Senha incorreta"
+    },
+    "toast-backup-share-verification-fail": {
+      "mandarin": "备份共享验证失败",
+      "german": "Überprüfung der Sicherungsfreigabe fehlgeschlagen",
+      "english": "Backup Share verification failed",
+      "korean": "백업 공유 확인 실패",
+      "spanish": "Error en la verificación del recurso compartido de copia de seguridad",
+      "japanese": "バックアップ共有の検証に失敗しました",
+      "portuguese": "Falha na verificação do compartilhamento de backup"
+    },
+    "copier-copied": {
+      "mandarin": "复制！",
+      "german": "Kopiert!",
+      "english": "Copied!",
+      "korean": "복사되었습니다!",
+      "spanish": "Copiado!",
+      "japanese": "コピーしました！",
+      "portuguese": "Copiado!"
+    },
+    "errors-invalid-email": {
+      "mandarin": "不合规电邮",
+      "german": "Ungültige E-Mail",
+      "english": "Invalid email",
+      "korean": "잘못된 이메일",
+      "spanish": "Email inválido",
+      "japanese": "無効なメール",
+      "portuguese": "E-mail inválido"
+    },
+    "errors-required": {
+      "mandarin": "必需的",
+      "german": "Erforderlich",
+      "english": "Required",
+      "korean": "필수",
+      "spanish": "Requerido",
+      "japanese": "必須",
+      "portuguese": "Requerido"
+    },
+    "toast-password-verification-fail": {
+      "mandarin": "密码验证失败",
+      "german": "Passwortüberprüfung fehlgeschlagen",
+      "english": "Password verification failed",
+      "korean": "비밀번호 확인 실패",
+      "spanish": "Falló la verificación de la contraseña",
+      "japanese": "パスワードの確認に失敗しました",
+      "portuguese": "A verificação da senha falhou"
+    },
+    "toast-device-share-delete-fail": {
+      "mandarin": "设备共享删除失败",
+      "german": "Löschen der Gerätefreigabe nicht erfolgreich",
+      "english": "Device share deletion unsuccessful",
+      "korean": "기기 공유 삭제 실패",
+      "spanish": "No se pudo eliminar el dispositivo compartido",
+      "japanese": "デバイス共有の削除に失敗しました",
+      "portuguese": "Falha na exclusão do compartilhamento do dispositivo"
+    },
+    "learn-more": {
+      "mandarin": "更多详情",
+      "german": "Mehr erfahren",
+      "english": "Learn more",
+      "korean": "더 알아보기",
+      "spanish": "Aprende más",
+      "japanese": "もっと詳しく知る",
+      "portuguese": "Saber mais"
+    },
+    "or": {
+      "mandarin": "或者",
+      "german": "oder",
+      "english": "or",
+      "korean": "또는",
+      "spanish": "o",
+      "japanese": "または",
+      "portuguese": "ou"
+    },
+    "errors-incorrect-mnemonic": {
+      "mandarin": "不正确的共享助记符",
+      "german": "Falsche Share-Mnemonik",
+      "english": "Incorrect share mnemonic",
+      "korean": "잘못된 공유 니모닉",
+      "spanish": "Mnemónico compartido incorrecto",
+      "japanese": "誤った共有ニーモニック",
+      "portuguese": "Mnemônico de compartilhamento incorreto"
+    },
+    "copier-terms-of-use": {
+      "mandarin": "使用条款",
+      "german": "Nutzungsbedingungen",
+      "english": "Terms of use",
+      "korean": "이용 약관",
+      "spanish": "Condiciones de uso",
+      "japanese": "利用規約",
+      "portuguese": "Termos de uso"
+    },
+    "copier-privacy-policy": {
+      "mandarin": "隐私政策",
+      "german": "Datenschutz-Bestimmungen",
+      "english": "Privacy policy",
+      "korean": "개인 정보 정책",
+      "spanish": "Política de privacidad",
+      "japanese": "個人情報保護方針",
+      "portuguese": "Política de privacidade"
+    },
+    "toast-backup-phase-email-send-success": {
+      "mandarin": "备用词组已发送到您的电子邮件",
+      "german": "Sicherungssatz an Ihre E-Mail gesendet",
+      "english": "Backup Phrase sent to your email",
+      "korean": "이메일로 전송 된 백업 문구",
+      "spanish": "Frase de seguridad enviada a su correo electrónico",
+      "japanese": "メールに送信されたバックアップフレーズ",
+      "portuguese": "Frase de segurança enviada para o seu e-mail"
+    },
+    "errors-invalid-mnemonic": {
+      "mandarin": "助记词短语无效",
+      "german": "Ungültige mnemonische Phrase",
+      "english": "Invalid mnemonic phrase",
+      "korean": "잘못된 니모닉 문구",
+      "spanish": "Frase mnemotécnica no válida",
+      "japanese": "ニーモニックフレーズが無効です",
+      "portuguese": "Frase mnemônica inválida"
+    },
+    "errors-invalid-password": {
+      "mandarin": "必须至少包含10个字符。 至少一个大写字母，一个小写字母，一个数字",
+      "german": "Muss mindestens 10 Zeichen enthalten. Mindestens ein Großbuchstabe, ein Kleinbuchstabe, eine Zahl",
+      "english": "Must contain at least 10 characters. At least one uppercase letter, one lowercase letter, one number",
+      "korean": "10 자 이상이어야합니다. 하나 이상의 대문자, 하나의 소문자, 하나의 숫자",
+      "spanish": "Debe contener al menos 10 caracteres. Al menos una letra mayúscula, una letra minúscula, un número",
+      "japanese": "10文字以上である必要があります。 少なくとも1つの大文字、1つの小文字、1つの数字",
+      "portuguese": "Deve conter pelo menos 10 caracteres. Pelo menos uma letra maiúscula, uma letra minúscula, um número"
+    },
+    "toast-password-change-fail": {
+      "mandarin": "密码更改失败",
+      "german": "Passwortänderung nicht erfolgreich",
+      "english": "Password change unsuccessful",
+      "korean": "비밀번호 변경 실패",
+      "spanish": "Cambio de contraseña fallido",
+      "japanese": "パスワードの変更に失敗しました",
+      "portuguese": "Falha na alteração da senha"
+    },
+    "toast-something-went-wrong": {
+      "mandarin": "出问题了",
+      "german": "Etwas ist schief gelaufen",
+      "english": "Something went wrong",
+      "korean": "문제가 발생했습니다",
+      "spanish": "Algo salió mal",
+      "japanese": "何かがうまくいかなかった",
+      "portuguese": "Algo deu errado"
+    },
+    "toast-registration-failed": {
+      "mandarin": "注册失败",
+      "german": "Registrierung fehlgeschlagen",
+      "english": "Registration failed",
+      "korean": "등록 실패",
+      "spanish": "Registro fallido",
+      "japanese": "登録に失敗しました",
+      "portuguese": "Registro falhou"
+    },
+    "close": {
+      "mandarin": "关闭",
+      "german": "Schließen",
+      "english": "Close",
+      "korean": "닫기",
+      "spanish": "Cerrar",
+      "japanese": "閉じる",
+      "portuguese": "Fechar"
+    },
+    "loader-device-detecting": {
+      "mandarin": "检测您的设备",
+      "german": "Erkennen Ihres Geräts",
+      "english": "Detecting your device",
+      "korean": "장치 감지",
+      "spanish": "Detectando su dispositivo",
+      "japanese": "デバイスの検出",
+      "portuguese": "Detectando seu dispositivo"
+    },
+    "toast-backup-phase-send-success": {
+      "mandarin": "备份词组已成功发送",
+      "german": "Sicherungssatz erfolgreich gesendet",
+      "english": "Backup Phrase successfully sent",
+      "korean": "백업 문구를 성공적으로 보냈습니다.",
+      "spanish": "Frase de seguridad enviada con éxito",
+      "japanese": "バックアップフレーズが正常に送信されました",
+      "portuguese": "Frase de backup enviada com sucesso"
+    },
+    "toast-backup-phase-send-fail": {
+      "mandarin": "无法发送备份短语",
+      "german": "Sicherungssatz kann nicht gesendet werden",
+      "english": "Unable to send Backup Phrase",
+      "korean": "백업 문구를 보낼 수 없습니다.",
+      "spanish": "No se pudo enviar la frase de respaldo",
+      "japanese": "バックアップフレーズを送信できません",
+      "portuguese": "Não foi possível enviar a frase de backup"
+    },
+    "toast-require-verification": {
+      "mandarin": "需要其他验证输入",
+      "german": "Benötigen Sie eine weitere Überprüfungseingabe",
+      "english": "Require another verification input",
+      "korean": "다른 확인 입력 필요",
+      "spanish": "Requerir otra entrada de verificación",
+      "japanese": "別の検証入力が必要",
+      "portuguese": "Exigir outra entrada de verificação"
+    },
+    "confirm": {
+      "mandarin": "确认",
+      "german": "Bestätigen",
+      "english": "Confirm",
+      "korean": "확인",
+      "spanish": "Confirmar",
+      "japanese": "確認",
+      "portuguese": "Confirmar"
+    },
+    "toast-recovery-share-delete-fail": {
+      "mandarin": "恢复共享删除失败",
+      "german": "Das Löschen der Wiederherstellungsfreigabe ist fehlgeschlagen",
+      "english": "Recovery share deletion failed",
+      "korean": "복구 공유 삭제 실패",
+      "spanish": "Error al eliminar el recurso compartido de recuperación",
+      "japanese": "リカバリ共有の削除に失敗しました",
+      "portuguese": "A exclusão do compartilhamento de recuperação falhou"
+    },
+    "toast-recovery-share-delete-success": {
+      "mandarin": "恢复共享已成功删除",
+      "german": "Wiederherstellungsfreigabe erfolgreich gelöscht",
+      "english": "Recovery share deleted successfully",
+      "korean": "복구 공유가 성공적으로 삭제되었습니다.",
+      "spanish": "El recurso compartido de recuperación se eliminó correctamente",
+      "japanese": "リカバリ共有が正常に削除されました",
+      "portuguese": "Compartilhamento de recuperação excluído com sucesso"
+    },
+    "toast-backup-phase-email-send-timeout": {
+      "english": "Timeout when sending Backup phrase to your email. Please download Backup phrase instead",
+      "portuguese": "Tempo limite ao enviar a frase de backup para o seu e-mail. Em vez disso, baixe a frase de backup"
+    },
+    "copier-manage-account": {
+      "mandarin": "管理帐户",
+      "german": "Konto verwalten",
+      "english": "Manage account",
+      "korean": "계정 관리",
+      "spanish": "Administrar cuenta",
+      "japanese": "アカウントを管理する",
+      "portuguese": "Gerenciar conta"
+    },
+    "cancel": {
+      "mandarin": "取消",
+      "german": "Stornieren",
+      "english": "Cancel",
+      "korean": "취소",
+      "spanish": "Cancelar",
+      "japanese": "キャンセル",
+      "portuguese": "Cancelar"
+    },
+    "toast-password-change-success": {
+      "mandarin": "密码修改成功",
+      "german": "Passwort erfolgreich geändert",
+      "english": "Password successfully changed",
+      "korean": "비밀번호가 성공적으로 변경되었습니다.",
+      "spanish": "Contraseña cambiada correctamente",
+      "japanese": "パスワードが正常に変更されました",
+      "portuguese": "Senha alterada com sucesso"
+    },
+    "secured-by": {
+      "mandarin": "担保人",
+      "german": "Gesichert durch",
+      "english": "Secured by",
+      "korean": "보안",
+      "spanish": "Asegurado por",
+      "japanese": "によって保護",
+      "portuguese": "Assegurado por"
+    },
+    "referenceId": {
+      "mandarin": "参考编号：",
+      "german": "Referenz ID:",
+      "english": "Reference ID:",
+      "korean": "참조 ID :",
+      "spanish": "Identificación de referencia:",
+      "japanese": "参照ID：",
+      "portuguese": "ID de referência:"
+    },
+    "toast-share-transfer-fail": {
+      "mandarin": "股份转让失败",
+      "german": "Freigabeübertragung fehlgeschlagen",
+      "english": "Share transfer failed",
+      "korean": "공유 전송 실패",
+      "spanish": "Error al transferir el recurso compartido",
+      "japanese": "共有の転送に失敗しました",
+      "portuguese": "Falha na transferência de compartilhamento"
+    },
+    "toast-device-share-delete-success": {
+      "mandarin": "设备共享已成功删除",
+      "german": "Gerätefreigabe erfolgreich gelöscht",
+      "english": "Device share successfully deleted",
+      "korean": "장치 공유가 성공적으로 삭제되었습니다.",
+      "spanish": "Dispositivo compartido eliminado correctamente",
+      "japanese": "デバイス共有が正常に削除されました",
+      "portuguese": "Compartilhamento de dispositivo excluído com sucesso"
+    },
+    "selfCustodial": {
+      "mandarin": "自托管登录由",
+      "german": "Selbstverwahrungs-Login durch",
+      "english": "Self-custodial login by",
+      "korean": "자가 관리 로그인",
+      "spanish": "Inicio de sesión con autocustodia por",
+      "japanese": "による自己管理ログイン",
+      "portuguese": "Login autocustodial por"
+    }
+  },
+  "error-block": {
+    "required-fields-title": {
+      "mandarin": "以下一个或多个必需参数缺失/无效",
+      "german": "Einer oder mehrere der folgenden erforderlichen Parameter fehlen / sind ungültig",
+      "english": "One or more of the following required parameters is missing/invalid",
+      "korean": "다음 필수 매개 변수 중 하나 이상이 누락되었거나 유효하지 않습니다.",
+      "spanish": "Uno o más de los siguientes parámetros obligatorios faltan o no son válidos",
+      "japanese": "次の必須パラメーターの1つ以上が欠落/無効です",
+      "portuguese": "Um ou mais dos seguintes parâmetros obrigatórios estão ausentes/inválidos"
+    }
+  }
 }

--- a/Openlogin-locale/locales-login.json
+++ b/Openlogin-locale/locales-login.json
@@ -1,1764 +1,1984 @@
 {
-	"login": {
-		"2fa-verify-share-send": {
-			"mandarin": "发送请求",
-			"spanish": "Enviar petición",
-			"english": "Send request",
-			"japanese": "リクエストを送信",
-			"korean": "요청 보내기",
-			"german": "Anfrage senden"
-		},
-		"2fa-setup-step5-return-app": {
-			"mandarin": "返回申请",
-			"spanish": "Volver a la aplicación",
-			"english": "Return to application",
-			"japanese": "アプリケーションに戻る",
-			"korean": "애플리케이션으로 돌아가기",
-			"german": "Zurück zur Anwendung"
-		},
-		"2fa-setup-step3-sub21": {
-			"mandarin": "粘贴您发送到 {0} 的辅助短语",
-			"spanish": "Pegue su frase de recuperación enviada a {0}",
-			"english": "Paste your recovery phrase sent to {0}",
-			"japanese": "{0}に送信されたリカバリフレーズを貼り付けます",
-			"korean": "{0}(으)로 전송된 복구 문구를 붙여넣으세요.",
-			"german": "Fügen Sie Ihren Wiederherstellungssatz ein, der an {0} gesendet wurde"
-		},
-		"reconstruct-backup-phrase-desc-2": {
-			"mandarin": "确认已设置的备份集",
-			"spanish": "Compruebe el conjunto de copia de seguridad establecido",
-			"english": "Verify with your backup phrase that was setup on",
-			"japanese": "セットしたバックアップセットを確認する",
-			"korean": "설정된 백업 세트 확인",
-			"german": "Bestätigen Sie mit Ihrem Backup-Satz, der eingerichtet wurde"
-		},
-		"2fa-verify-share-subhead": {
-			"mandarin": "您需要以下其中一项才能登录",
-			"spanish": "Necesita uno de los siguientes para iniciar sesión",
-			"english": "You need one of the following to login",
-			"japanese": "ログインするには、次のいずれかが必要です",
-			"korean": "로그인하려면 다음 중 하나가 필요합니다.",
-			"german": "Sie benötigen eine der folgenden Möglichkeiten, um sich anzumelden"
-		},
-		"reconstruct-biometrics-verify": {
-			"mandarin": "使用Touch ID / Face ID进行验证",
-			"spanish": "Verificar con Touch ID / Face ID",
-			"english": "Verify with Touch ID / Face ID",
-			"japanese": "Touch ID / FaceIDで確認する",
-			"korean": "Touch ID / Face ID로 확인",
-			"german": "Überprüfen Sie mit Touch ID / Face ID"
-		},
-		"reconstruct-multiple-transports-verify": {
-			"english": "Verify now",
-			"german": "Jetzt Prüfen",
-			"mandarin": "立即验证",
-			"korean": "지금 인증하십시오",
-			"japanese": "今すぐ確認してください",
-			"spanish": "Verifica ahora"
-		},
-		"2fa-setup-step3-next": {
-			"mandarin": "继续",
-			"spanish": "Continuar",
-			"english": "Continue",
-			"japanese": "継続する",
-			"korean": "계속하다",
-			"german": "Weitermachen"
-		},
-		"migrate-desc1": {
-			"mandarin": "最新版本的Torus Wallet由OpenLogin提供支持。",
-			"spanish": "La última versión de Torus Wallet funciona con OpenLogin.",
-			"english": "The latest version of Torus Wallet is powered by OpenLogin.",
-			"japanese": "Torus Walletの最新バージョンは、OpenLoginを利用しています。",
-			"korean": "최신 버전의 Torus Wallet은 OpenLogin에 의해 구동됩니다.",
-			"german": "Die neueste Version von Torus Wallet wird von OpenLogin unterstützt."
-		},
-		"2fa-setup-title1": {
-			"mandarin": "保护您的帐户",
-			"spanish": "Asegure su cuenta",
-			"english": "Secure your account",
-			"japanese": "アカウントを保護する",
-			"korean": "계정 보안",
-			"german": "Sichern Sie Ihr Konto"
-		},
-		"register-password-title": {
-			"mandarin": "设置帐号密码",
-			"spanish": "Configurar la contraseña de la cuenta",
-			"english": "Set up account password",
-			"japanese": "アカウントのパスワードを設定する",
-			"korean": "계정 비밀번호 설정",
-			"german": "Richten Sie das Kontokennwort ein"
-		},
-		"reconstruct-support": {
-			"mandarin": "联系支持",
-			"spanish": "Soporte de contacto",
-			"english": "Contact support",
-			"japanese": "サポート問い合わせ先",
-			"korean": "연락처 지원",
-			"german": "Kontaktieren Sie Support"
-		},
-		"returning-sign-in-header1": {
-			"mandarin": "使用其他帐户",
-			"spanish": "Usa otra cuenta",
-			"english": "Use another account",
-			"japanese": "別のアカウントを使用する",
-			"korean": "다른 계정 사용",
-			"german": "Benutze einen anderen Account"
-		},
-		"2fa-verify-multi-head": {
-			"mandarin": "允许从您保存的浏览器访问",
-			"spanish": "Permitir el acceso desde su navegador guardado",
-			"english": "Allow access from your saved browser",
-			"japanese": "保存したブラウザからのアクセスを許可する",
-			"korean": "저장된 브라우저에서 액세스 허용",
-			"german": "Erlauben Sie den Zugriff von Ihrem gespeicherten Browser"
-		},
-		"social-2fa-subtitle-1": {
-			"mandarin": "用任何社会帐户登录将其设置为恢复因素",
-			"spanish": "Inicie sesión con cualquiera de la cuenta social para establecerla como factor de recuperación",
-			"english": "Login with any of the social account to set it as recovery factor",
-			"japanese": "ソーシャルアカウントのいずれかでログインして、回復要因として設定します",
-			"korean": "소셜 계정에 로그인하여 복구 계수로 설정",
-			"german": "Melden Sie sich mit einem der sozialen Konto an, um es als Wiederherstellungsfaktor festzulegen"
-		},
-		"social-2fa-warning-text": {
-			"mandarin": "您正在使用同一电子邮件进行帐户登录和社会因素。这是不安全的。您还想继续吗？",
-			"spanish": "Está utilizando el mismo correo electrónico para el inicio de sesión de la cuenta y el factor social. Esto es inseguro. ¿Todavía te gustaría continuar?",
-			"english": "You are using the same email for account login and social factor. This is insecure. Would you still like to proceed?",
-			"japanese": "アカウントログインとソーシャルファクターに同じメールを使用しています。これは不安です。まだ進みたいですか？",
-			"korean": "계정 로그인 및 소셜 요소에 동일한 이메일을 사용하고 있습니다. 이것은 안전하지 않습니다. 아직도 진행하고 싶습니까?",
-			"german": "Sie verwenden dieselbe E -Mail für Kontoanmeldung und sozialer Faktor. Das ist unsicher. Möchten Sie immer noch fortfahren?"
-		},
-		"2fa-setup-step3-download-phrase": {
-			"mandarin": "下载短语",
-			"spanish": "Descargar frase",
-			"english": "Download phrase",
-			"japanese": "フレーズをダウンロード",
-			"korean": "구문 다운로드",
-			"german": "Redewendung herunterladen"
-		},
-		"2fa-setup-step1-sub2": {
-			"mandarin": "为您的帐户添加额外的安全层",
-			"spanish": "Agregue una capa adicional de seguridad a su cuenta",
-			"english": "Add an extra layer of security to your account",
-			"japanese": "アカウントにセキュリティの層を追加します",
-			"korean": "계정에 보안 계층 추가",
-			"german": "Fügen Sie Ihrem Konto eine zusätzliche Sicherheitsebene hinzu"
-		},
-		"2fa-verify-title2": {
-			"mandarin": "2FA 激活",
-			"spanish": "2FA activado",
-			"english": "2FA activated",
-			"japanese": "2FAがアクティブ化",
-			"korean": "2FA 활성화",
-			"german": "2FA aktiviert"
-		},
-		"2fa-setup-step5-next": {
-			"mandarin": "完毕",
-			"spanish": "Hecho",
-			"english": "Done",
-			"japanese": "終わり",
-			"korean": "완료",
-			"german": "Fertig"
-		},
-		"reconstruct-fail": {
-			"mandarin": "无法找回帐户？",
-			"spanish": "¿No puede recuperar la cuenta?",
-			"english": "Unable to recover account?",
-			"japanese": "アカウントを回復できませんか？",
-			"korean": "계정을 복구 할 수 없습니까?",
-			"german": "Konto kann nicht wiederhergestellt werden?"
-		},
-		"2fa-setup-step2-sub2": {
-			"mandarin": "使用当前浏览器批准来自新设备/浏览器的访问。",
-			"spanish": "Utilice el navegador actual para aprobar el acceso desde nuevos dispositivos / navegadores.",
-			"english": "Use the current browser to approve access from new devices/browsers.",
-			"japanese": "現在のブラウザを使用して、新しいデバイス/ブラウザからのアクセスを承認します。",
-			"korean": "현재 브라우저를 사용하여 새 장치/브라우저에서 액세스를 승인합니다.",
-			"german": "Verwenden Sie den aktuellen Browser, um den Zugriff von neuen Geräten/Browsern zu genehmigen."
-		},
-		"reconstruct-device-desc1": {
-			"mandarin": "登录到",
-			"spanish": "Iniciar sesión en",
-			"english": "Login to",
-			"japanese": "ログインする",
-			"korean": "로그인",
-			"german": "Einloggen in"
-		},
-		"migrate-title": {
-			"mandarin": "变得简单而安全",
-			"spanish": "hecho simple y seguro con",
-			"english": "made simple and secure with",
-			"japanese": "シンプルで安全に",
-			"korean": "간단하고 안전하게",
-			"german": "einfach und sicher gemacht mit"
-		},
-		"social-2fa-warn-text-2": {
-			"mandarin": "在登录页面上使用此社交因素签名将为您提供一个新帐户。",
-			"spanish": "Iniciar sesión con este factor social en la página de inicio de sesión le dará una nueva cuenta.",
-			"english": "Signing in with this Social factor at the login page will give you a new account.",
-			"japanese": "ログインページでこのソーシャルファクターにサインインすると、新しいアカウントが提供されます。",
-			"korean": "로그인 페이지 에서이 소셜 요소에 로그인하면 새 계정이 제공됩니다.",
-			"german": "Wenn Sie sich bei diesem sozialen Faktor auf der Anmeldeseite anmelden, erhalten Sie ein neues Konto."
-		},
-		"reconstruct-always-skip": {
-			"mandarin": "总是跳过",
-			"spanish": "Saltar siempre",
-			"english": "Always skip",
-			"japanese": "常にスキップする",
-			"korean": "항상 건너뛰기",
-			"german": "Immer überspringen"
-		},
-		"2fa-setup-step1-desc21": {
-			"mandarin": "我们强烈建议为像您这样的活跃用户设置 2FA。",
-			"spanish": "Recomendamos encarecidamente una configuración 2FA para un usuario activo como usted.",
-			"english": "We highly recommend a 2FA set up for an active user like yourself.",
-			"japanese": "あなたのようなアクティブユーザーには2FAを設定することを強くお勧めします。",
-			"korean": "귀하와 같은 활성 사용자를 위해 2FA 설정을 적극 권장합니다.",
-			"german": "Wir empfehlen dringend ein 2FA-Setup für einen aktiven Benutzer wie Sie."
-		},
-		"2fa-setup-step3-copy-phrase": {
-			"mandarin": "复制短语",
-			"spanish": "Copiar frase",
-			"english": "Copy phrase",
-			"japanese": "フレーズをコピーする",
-			"korean": "문구 복사",
-			"german": "Satz kopieren"
-		},
-		"2fa-verify-recovery-placeholder": {
-			"mandarin": "恢复短语",
-			"spanish": "Frase de recuperación",
-			"english": "Recovery phrase",
-			"japanese": "回復フレーズ",
-			"korean": "복구 문구",
-			"german": "Wiederherstellungsphrase"
-		},
-		"2fa-verify-share-resend": {
-			"mandarin": "重新发送请求",
-			"spanish": "Reenviar solicitud",
-			"english": "Resend request",
-			"japanese": "再送信リクエスト",
-			"korean": "재전송 요청",
-			"german": "Anfrage erneut senden"
-		},
-		"reconstruct-password-desc": {
-			"mandarin": "在此处输入您的帐户恢复密码",
-			"spanish": "Ingrese la contraseña de recuperación de su cuenta aquí",
-			"english": "Enter your account recovery password here",
-			"japanese": "ここにアカウント回復パスワードを入力してください",
-			"korean": "여기에 계정 복구 비밀번호를 입력하세요.",
-			"german": "Geben Sie hier Ihr Passwort für die Kontowiederherstellung ein"
-		},
-		"2fa-setup-step3-cancel": {
-			"mandarin": "后退",
-			"spanish": "atrás",
-			"english": "Back",
-			"japanese": "戻る",
-			"korean": "뒤",
-			"german": "Zurück"
-		},
-		"2fa-verify-step1-panel2": {
-			"mandarin": "恢复短语",
-			"spanish": "Frase de recuperación",
-			"english": "Recovery phrase",
-			"japanese": "回復フレーズ",
-			"korean": "복구 문구",
-			"german": "Wiederherstellungsphrase"
-		},
-		"popup-title": {
-			"mandarin": "欢迎登机",
-			"spanish": "La bienvenida a bordo",
-			"english": "Welcome onboard",
-			"japanese": "ご乗車（搭乗）ありがとうございます",
-			"korean": "보드에 오신 것을 환영합니다",
-			"german": "Willkommen an Bord"
-		},
-		"2fa-setup-step5-sub2": {
-			"mandarin": "在 app.openlogin.com 上管理未来的帐户设置",
-			"spanish": "Administre la configuración de la cuenta futura en app.openlogin.com",
-			"english": "Manage future account settings on app.openlogin.com",
-			"japanese": "app.openlogin.comで将来のアカウント設定を管理します",
-			"korean": "app.openlogin.com에서 향후 계정 설정 관리",
-			"german": "Verwalten Sie zukünftige Kontoeinstellungen auf app.openlogin.com"
-		},
-		"reconstruct-password-placeholder": {
-			"mandarin": "户口密码",
-			"spanish": "Contraseña de la cuenta",
-			"english": "Account password",
-			"japanese": "アカウントパスワード",
-			"korean": "계정 비밀번호",
-			"german": "Konto Passwort"
-		},
-		"reconstruct-device-title": {
-			"mandarin": "设备",
-			"spanish": "Dispositivos",
-			"english": "Device(s)",
-			"japanese": "デバイス",
-			"korean": "장치",
-			"german": "Geräte"
-		},
-		"2fa-verify-recovery-title": {
-			"mandarin": "恢复代码",
-			"spanish": "Código de recuperación",
-			"english": "Recovery code",
-			"japanese": "リカバリコード",
-			"korean": "복구 코드",
-			"german": "Wiederherstellungscode"
-		},
-		"migrate-list1": {
-			"mandarin": "支持面部识别/触摸识别",
-			"spanish": "Soporta Face ID / Touch ID",
-			"english": "Supports Face ID / Touch ID",
-			"japanese": "Face ID / TouchIDをサポート",
-			"korean": "Face ID / Touch ID 지원",
-			"german": "Unterstützt Face ID / Touch ID"
-		},
-		"register-biometrics-title": {
-			"mandarin": "继续使用Face ID或Touch ID",
-			"spanish": "Continuar con Face ID o Touch ID",
-			"english": "Continue with Face ID or Touch ID",
-			"japanese": "FaceIDまたはTouchIDに進む",
-			"korean": "Face ID 또는 Touch ID로 계속",
-			"german": "Fahren Sie mit Face ID oder Touch ID fort"
-		},
-		"register-multiple-transports-webauthn-title": {
-			"english": "Continue with Biometrics or any Web Authentication Methods",
-			"german": "Fahren Sie mit Biometrie oder Webauthentifizierungsmethoden fort",
-			"mandarin": "继续使用生物识别技术或任何Web身份验证方法",
-			"korean": "생체 인식 또는 웹 인증 방법을 계속하십시오",
-			"japanese": "生体認証またはWeb認証方法を継続します",
-			"spanish": "Continuar con biometría o cualquier método de autenticación web"
-		},
-		"register-external-transports-webauthn-title": {
-			"english": "Continue with any Web Authentication Methods",
-			"german": "Fahren Sie mit allen Webauthentifizierungsmethoden fort",
-			"mandarin": "继续使用任何Web身份验证方法",
-			"korean": "웹 인증 방법을 계속하십시오",
-			"japanese": "Web認証方法を続行します",
-			"spanish": "Continuar con cualquier método de autenticación web"
-		},
-		"popup-view-more": {
-			"mandarin": "查看更多选项",
-			"spanish": "Ver más opciones",
-			"english": "View more options",
-			"japanese": "その他のオプションを表示",
-			"korean": "더 많은 옵션보기",
-			"german": "Weitere Optionen anzeigen"
-		},
-		"returning-confirm-title": {
-			"mandarin": "我们只是想确定一下。",
-			"spanish": "Solo queremos estar seguros.",
-			"english": "We just want to be sure.",
-			"japanese": "確認したいだけです。",
-			"korean": "우리는 확신하고 싶습니다.",
-			"german": "Wir wollen nur sicher sein."
-		},
-		"migrate-subtitle": {
-			"mandarin": "迁移您的tKey",
-			"spanish": "Migrar su tKey",
-			"english": "Migrating your tKey",
-			"japanese": "tKeyの移行",
-			"korean": "tKey 마이그레이션",
-			"german": "Migrieren Sie Ihren tKey"
-		},
-		"2fa-setup-step4-recovery": {
-			"mandarin": "恢复短语",
-			"spanish": "Frase de recuperación",
-			"english": "Recovery phrase",
-			"japanese": "回復フレーズ",
-			"korean": "복구 문구",
-			"german": "Wiederherstellungsphrase"
-		},
-		"reconstruct-device-prev1": {
-			"mandarin": "登录到您的",
-			"spanish": "Inicie sesión en su",
-			"english": "Login to your",
-			"japanese": "あなたのログイン",
-			"korean": "귀하의",
-			"german": "Melden Sie sich bei Ihrem an"
-		},
-		"register-backup-phrase-confirm-desc3": {
-			"mandarin": "重新输入辅助邮箱",
-			"spanish": "vuelve a ingresar el correo de recuperación",
-			"english": "re-enter recovery email",
-			"japanese": "リカバリメールを再入力してください",
-			"korean": "복구 이메일 다시 입력",
-			"german": "wiederherstellungs-E-Mail erneut eingeben"
-		},
-		"2fa-verify-step1-rec-label": {
-			"mandarin": "输入恢复短语",
-			"spanish": "Ingrese la frase de recuperación",
-			"english": "Enter recovery phrase",
-			"japanese": "回復フレーズを入力してください",
-			"korean": "복구 문구 입력",
-			"german": "Geben Sie den Wiederherstellungssatz ein"
-		},
-		"migrate-continue": {
-			"mandarin": "继续",
-			"spanish": "Continuar",
-			"english": "Continue",
-			"japanese": "継続する",
-			"korean": "계속하다",
-			"german": "Fortsetzen"
-		},
-		"2fa-setup-step3-enter-email": {
-			"mandarin": "输入你的电子邮箱地址",
-			"spanish": "Ingrese su dirección de correo electrónico",
-			"english": "Enter your email address",
-			"japanese": "メールアドレスを入力してください",
-			"korean": "이메일 주소를 입력하세요",
-			"german": "Geben sie ihre E-Mailadresse ein"
-		},
-		"reconstruct-password-title": {
-			"mandarin": "找回密码",
-			"spanish": "Contraseña de recuperación",
-			"english": "Recovery password",
-			"japanese": "回復パスワード",
-			"korean": "복구 암호",
-			"german": "Passwort zum Zurücksetzen"
-		},
-		"2fa-setup-step5-sub1": {
-			"mandarin": "您的 2FA 已激活！",
-			"spanish": "¡Su 2FA ha sido activado!",
-			"english": "Your 2FA has been activated!",
-			"japanese": "2FAがアクティブになりました！",
-			"korean": "2FA가 활성화되었습니다!",
-			"german": "Ihre 2FA wurde aktiviert!"
-		},
-		"2fa-setup-title32": {
-			"mandarin": "第 3 步：验证恢复短语",
-			"spanish": "Paso 3: Verificar la frase de recuperación",
-			"english": "Step 3: Verify Recovery Phrase",
-			"japanese": "ステップ3：リカバリフレーズを確認する",
-			"korean": "3단계: 복구 문구 확인",
-			"german": "Schritt 3: Überprüfen Sie die Wiederherstellungsphrase"
-		},
-		"2fa-setup-step3-verified": {
-			"mandarin": "已验证",
-			"spanish": "Verificado",
-			"english": "Verified",
-			"japanese": "確認済み",
-			"korean": "확인됨",
-			"german": "Verifiziert"
-		},
-		"register-backup-phrase-additional-security-desc2": {
-			"mandarin": "如果您丢失带有 Touch ID / Face ID 的设备，它可以帮助您恢复帐户。",
-			"spanish": "Le ayuda con la recuperación de la cuenta en caso de que pierda su dispositivo con Touch ID / Face ID.",
-			"english": "It helps you with account recovery in case you lose your device with Touch ID / Face ID.",
-			"japanese": "Touch ID / Face ID でデバイスを紛失した場合のアカウント回復に役立ちます。",
-			"korean": "Touch ID / Face ID로 기기를 분실 한 경우 계정 복구에 도움이됩니다.",
-			"german": "Es hilft Ihnen bei der Kontowiederherstellung, falls Sie Ihr Gerät mit Touch ID / Face ID verlieren."
-		},
-		"2fa-setup-title2": {
-			"mandarin": "设置 2FA",
-			"spanish": "Configurar 2FA",
-			"english": "Set up 2FA",
-			"japanese": "2FAを設定する",
-			"korean": "2FA 설정",
-			"german": "2FA einrichten"
-		},
-		"2fa-verify-verify": {
-			"mandarin": "核实",
-			"spanish": "Verificar",
-			"english": "Verify",
-			"japanese": "確認",
-			"korean": "검증",
-			"german": "Verifizieren"
-		},
-		"2fa-setup-step3-enter-recovery": {
-			"mandarin": "输入您的辅助短语",
-			"spanish": "Introduce tu frase de recuperación",
-			"english": "Enter your recovery phrase",
-			"japanese": "回復フレーズを入力してください",
-			"korean": "복구 문구를 입력하세요",
-			"german": "Geben Sie Ihren Wiederherstellungssatz ein"
-		},
-		"social-2fa-heading": {
-			"mandarin": "设定社会恢复因素",
-			"spanish": "Establecer factor de recuperación social",
-			"english": "Set Social recovery factor",
-			"japanese": "社会的回復要因を設定します",
-			"korean": "사회 복구 요인을 설정하십시오",
-			"german": "Setzen Sie den sozialen Genesungsfaktor"
-		},
-		"mpc-2fa-verify-step1-rec-label": {
-			"mandarin": "输入恢复系数",
-			"spanish": "Ingrese el factor de recuperación",
-			"english": "Enter recovery factor",
-			"japanese": "回復係数を入力してください",
-			"korean": "회복 계수 입력",
-			"german": "Erholungsfaktor eingeben"
-		},
-		"reconstruct-device-desc": {
-			"mandarin": "从下面存储的浏览器登录到{0}以验证您的身份。",
-			"spanish": "Inicie sesión en {0} desde el navegador almacenado a continuación para verificar su identidad.",
-			"english": "Login to {0} from the stored browser below to verify your identity.",
-			"japanese": "以下の保存されているブラウザから{0}にログインして、本人確認を行ってください。",
-			"korean": "아래 저장된 브라우저에서 {0}에 로그인하여 신원을 확인하세요.",
-			"german": "Melden Sie sich über den unten gespeicherten Browser bei {0} an, um Ihre Identität zu überprüfen."
-		},
-		"2fa-setup-step2-current-browser": {
-			"mandarin": "当前浏览器",
-			"spanish": "Navegador actual",
-			"english": "Current browser",
-			"japanese": "現在のブラウザ",
-			"korean": "현재 브라우저",
-			"german": "Aktueller Browser"
-		},
-		"2fa-setup-step4-cancel": {
-			"mandarin": "后退",
-			"spanish": "atrás",
-			"english": "Back",
-			"japanese": "戻る",
-			"korean": "뒤",
-			"german": "Zurück"
-		},
-		"social-2fa-view-less": {
-			"mandarin": "少查看",
-			"spanish": "Ver menos",
-			"english": "View less",
-			"japanese": "表示が少なくなります",
-			"korean": "덜보십시오",
-			"german": "Weniger anzeigen"
-		},
-		"2fa-verify-success-title": {
-			"mandarin": "2FA 验证",
-			"spanish": "2FA verificado",
-			"english": "2FA verified",
-			"japanese": "2FA検証済み",
-			"korean": "2FA 인증",
-			"german": "2FA verifiziert"
-		},
-		"popup-terms": {
-			"mandarin": "使用条款",
-			"spanish": "Condiciones de uso",
-			"english": "Terms of use",
-			"japanese": "利用規約",
-			"korean": "이용 약관",
-			"german": "Nutzungsbedingungen"
-		},
-		"migrate-list3": {
-			"mandarin": "受保护的用户数据和隐私",
-			"spanish": "Privacidad y datos de usuario protegidos",
-			"english": "Protected user Data and Privacy",
-			"japanese": "保護されたユーザーデータとプライバシー",
-			"korean": "보호 된 사용자 데이터 및 개인 정보",
-			"german": "Geschützte Benutzerdaten und Datenschutz"
-		},
-		"popup-continue": {
-			"mandarin": "继续",
-			"spanish": "Continuar",
-			"english": "Continue",
-			"japanese": "継続する",
-			"korean": "계속하다",
-			"german": "Fortsetzen"
-		},
-		"reconstruct-backup-phrase-title": {
-			"mandarin": "备用词组",
-			"spanish": "Frase de respaldo",
-			"english": "Backup phrase",
-			"japanese": "バックアップフレーズ",
-			"korean": "백업 문구",
-			"german": "Sicherungssatz"
-		},
-		"2fa-verify-save-nosave": {
-			"mandarin": "下次吧",
-			"spanish": "Quizás la próxima vez",
-			"english": "Maybe next time",
-			"japanese": "また今度",
-			"korean": "아마 다음 번에",
-			"german": "Vielleicht nächstes Mal"
-		},
-		"2fa-setup-step2-save-device": {
-			"mandarin": "保存当前设备",
-			"spanish": "Guardar dispositivo actual",
-			"english": "Save current device",
-			"japanese": "現在のデバイスを保存",
-			"korean": "현재 장치 저장",
-			"german": "Aktuelles Gerät speichern"
-		},
-		"2fa-setup-step4-sub22": {
-			"mandarin": "粘贴发送到您的电子邮件的恢复短语 {0}",
-			"spanish": "Pega la frase de recuperación enviada a tu correo electrónico {0}",
-			"english": "Paste the recovery phrase sent to your email {0}",
-			"japanese": "メールに送信されたリカバリフレーズを貼り付けます{0}",
-			"korean": "이메일로 전송된 복구 문구를 붙여넣으세요 {0}",
-			"german": "Fügen Sie den Wiederherstellungssatz ein, der an Ihre E-Mail-Adresse {0} gesendet wurde."
-		},
-		"returning-sign-in-header2": {
-			"mandarin": "您似乎尚未登录帐户",
-			"spanish": "Parece que aún no ha iniciado sesión en una cuenta",
-			"english": "It seems like you are not signed in to an account yet",
-			"japanese": "アカウントにまだサインインしていないようです",
-			"korean": "아직 계정에 로그인하지 않은 것 같습니다.",
-			"german": "Anscheinend bist du noch nicht bei einem Konto angemeldet"
-		},
-		"register-backup-phrase-confirm-desc1": {
-			"mandarin": "我确认我已收到恢复电子邮件。",
-			"spanish": "Confirmo que he recibido el correo de recuperación.",
-			"english": "I confirm that I have received the recovery email.",
-			"japanese": "復旧メールを受信したことを確認しました。",
-			"korean": "我确认我已收到恢复电子邮件。",
-			"german": "Ich bestätige, dass ich die Wiederherstellungs-E-Mail erhalten habe."
-		},
-		"2fa-verify-recovery-label": {
-			"mandarin": "输入恢复短语",
-			"spanish": "Ingrese la frase de recuperación",
-			"english": "Enter recovery phrase",
-			"japanese": "回復フレーズを入力してください",
-			"korean": "복구 문구 입력",
-			"german": "Geben Sie den Wiederherstellungssatz ein"
-		},
-		"constructYourKey": {
-			"mandarin": "构建您的密钥",
-			"spanish": "Construyendo tu clave en",
-			"english": "Constructing your key on",
-			"japanese": "キーを作成する",
-			"korean": "키 구성",
-			"german": "Bauen Sie Ihren Schlüssel auf"
-		},
-		"2fa-verify-save-head": {
-			"mandarin": "帐户已恢复",
-			"spanish": "Cuenta recuperada",
-			"english": "Account recovered",
-			"japanese": "アカウントが回復しました",
-			"korean": "계정 복구됨",
-			"german": "Konto wiederhergestellt"
-		},
-		"register-backup-phrase-desc": {
-			"mandarin": "包含备用短语的电子邮件将发送给您。如果您丢失了设备，它将帮助您进行帐户恢复。",
-			"spanish": "Se le enviará un correo electrónico con la frase de respaldo. Le ayuda con la recuperación de la cuenta en caso de que pierda su dispositivo.",
-			"english": "An email will be sent to you containing the backup phrase. It helps you with account recovery in case you lose your device.",
-			"japanese": "バックアップフレーズを記載したメールが送信されます。デバイスを紛失した場合のアカウントの復旧に役立ちます。",
-			"korean": "백업 문구가 포함 된 이메일이 전송됩니다.  기기 분실시 계정 복구에 도움이됩니다.",
-			"german": "Sie erhalten eine E-Mail mit der Sicherungsphrase. Sie hilft Ihnen bei der Wiederherstellung des Kontos, falls Sie Ihr Gerät verlieren."
-		},
-		"2fa-setup-step3-note11": {
-			"mandarin": "笔记：",
-			"spanish": "Nota:",
-			"english": "Note:",
-			"japanese": "ノート：",
-			"korean": "메모:",
-			"german": "Notiz:"
-		},
-		"verifier-webauth-desc": {
-			"mandarin": "继续使用WebAuthn",
-			"spanish": "Continuar con WebAuthn",
-			"english": "Continue with WebAuthn",
-			"japanese": "WebAuthnを続行します",
-			"korean": "WebAuthn으로 계속",
-			"german": "Fahren Sie mit WebAuthn fort"
-		},
-		"2fa-setup-step4-not-received": {
-			"mandarin": "没有收到吗？",
-			"spanish": "¿No lo recibiste?",
-			"english": "Did not receive it?",
-			"japanese": "受け取りませんでしたか？",
-			"korean": "받지 못하셨나요?",
-			"german": "Nicht erhalten?"
-		},
-		"reconstruct-biometrics-title": {
-			"mandarin": "支持面部识别/触摸识别的设备*",
-			"spanish": "Dispositivos habilitados con Face ID / Touch ID *",
-			"english": "Face ID / Touch ID enabled device(s) *",
-			"japanese": "Face ID / TouchID対応デバイス*",
-			"korean": "Face ID / Touch ID 지원 장치 *",
-			"german": "Face ID / Touch ID-fähige Geräte *"
-		},
-		"reconstruct-multiple-transports-title": {
-			"english": "Web Authentication Enabled Device(s)",
-			"german": "Webauthentifizierung aktiviertes Geräte (en)",
-			"mandarin": "Web身份验证启用设备",
-			"korean": "웹 인증 활성화 장치",
-			"japanese": "Web認証有効化デバイス",
-			"spanish": "Dispositivo (s) de autenticación web"
-		},
-		"returning-sign-in-desc": {
-			"mandarin": "继续执行以下操作之一以继续",
-			"spanish": "Continúe con uno de los siguientes para continuar",
-			"english": "Continue with one of the following to proceed",
-			"japanese": "次のいずれかを続行して続行します",
-			"korean": "계속하려면 다음 중 하나를 계속하십시오.",
-			"german": "Fahren Sie mit einem der folgenden Schritte fort, um fortzufahren"
-		},
-		"2fa-verify-step1-sub2": {
-			"mandarin": "您需要以下其中一项才能登录",
-			"spanish": "Necesita uno de los siguientes para iniciar sesión",
-			"english": "You need one of the following to login",
-			"japanese": "ログインするには、次のいずれかが必要です",
-			"korean": "로그인하려면 다음 중 하나가 필요합니다.",
-			"german": "Sie benötigen eine der folgenden Möglichkeiten, um sich anzumelden"
-		},
-		"2fa-setup-step3-email": {
-			"mandarin": "电子邮件",
-			"spanish": "Correo electrónico",
-			"english": "Email",
-			"japanese": "Eメール",
-			"korean": "이메일",
-			"german": "Email"
-		},
-		"2fa-setup-title4": {
-			"mandarin": "恢复验证",
-			"spanish": "Verificación de recuperación",
-			"english": "Recovery verification",
-			"japanese": "回復の検証",
-			"korean": "복구 확인",
-			"german": "Wiederherstellungsüberprüfung"
-		},
-		"2fa-setup-step4-resend": {
-			"mandarin": "重发",
-			"spanish": "Reenviar",
-			"english": "Resend",
-			"japanese": "再送",
-			"korean": "재전송",
-			"german": "Erneut senden"
-		},
-		"2fa-setup-step1-sub1": {
-			"mandarin": "启用 2 因素身份验证 (2FA)",
-			"spanish": "Habilitar la autenticación de 2 factores (2FA)",
-			"english": "Enable 2 Factor Authentication (2FA)",
-			"japanese": "2要素認証（2FA）を有効にする",
-			"korean": "2단계 인증(2FA) 활성화",
-			"german": "2-Faktor-Authentifizierung (2FA) aktivieren"
-		},
-		"2fa-verify-multi-title": {
-			"mandarin": "{0} 台设备可用",
-			"spanish": "{0} dispositivos disponibles",
-			"english": "{0} devices available",
-			"japanese": "利用可能な{0}デバイス",
-			"korean": "사용 가능한 기기 {0}대",
-			"german": "{0} Geräte verfügbar"
-		},
-		"start": {
-			"mandarin": "开始使用",
-			"spanish": "Empezar",
-			"english": "Get Started",
-			"japanese": "はじめに",
-			"korean": "시작하다",
-			"german": "Loslegen"
-		},
-		"2fa-setup-step4-sub1": {
-			"mandarin": "验证您的恢复短语",
-			"spanish": "Verifica tu frase de recuperación",
-			"english": "Verify your recovery phrase",
-			"japanese": "回復フレーズを確認する",
-			"korean": "복구 문구 확인",
-			"german": "Bestätigen Sie Ihren Wiederherstellungssatz"
-		},
-		"popup-already": {
-			"mandarin": "已经有账户？",
-			"spanish": "¿Ya tienes una cuenta?",
-			"english": "Already have an account?",
-			"japanese": "すでにアカウントをお持ちですか？",
-			"korean": "이미 계정이 있습니까?",
-			"german": "Sie haben bereits ein Konto?"
-		},
-		"social-2fa-continue-text": {
-			"mandarin": "选择您喜欢如何继续",
-			"spanish": "Seleccione cómo le gusta continuar",
-			"english": "Select how you like to continue",
-			"japanese": "続行する方法を選択してください",
-			"korean": "계속하는 방법을 선택하십시오",
-			"german": "Wählen Sie, wie Sie fortfahren möchten"
-		},
-		"social-2fa-view-more": {
-			"mandarin": "查看更多",
-			"spanish": "Ver más",
-			"english": "View more",
-			"japanese": "もっと見る",
-			"korean": "더보기",
-			"german": "Mehr sehen"
-		},
-		"2fa-setup-step3-confirm-phrase": {
-			"mandarin": "作为高级用户，我知道如果我丢失了此恢复短语，我将承担丢失帐户的风险。",
-			"spanish": "Como usuario avanzado, sé que si pierdo esta frase de recuperación, corro el riesgo de perder mi cuenta.",
-			"english": "As an advanced user, I know that if I lose this recovery phrase, I bear the risk of losing my account.",
-			"japanese": "上級ユーザーとして、この回復フレーズを失うと、アカウントを失うリスクがあることを私は知っています。",
-			"korean": "고급 사용자로서 나는 이 복구 문구를 잃어버리면 내 계정을 잃을 위험을 감수해야 한다는 것을 알고 있습니다.",
-			"german": "Als fortgeschrittener Benutzer weiß ich, dass ich das Risiko trage, mein Konto zu verlieren, wenn ich diesen Wiederherstellungssatz verliere."
-		},
-		"2fa-setup-step1-cancel": {
-			"mandarin": "下次吧",
-			"spanish": "Quizás la próxima vez",
-			"english": "Maybe next time",
-			"japanese": "また今度",
-			"korean": "아마 다음 번에",
-			"german": "Vielleicht nächstes Mal"
-		},
-		"2fa-setup-step2-cancel": {
-			"mandarin": "后退",
-			"spanish": "atrás",
-			"english": "Back",
-			"japanese": "戻る",
-			"korean": "뒤",
-			"german": "Zurück"
-		},
-		"popup-privacy": {
-			"mandarin": "隐私政策",
-			"spanish": "Política de privacidad",
-			"english": "Privacy policy",
-			"japanese": "個人情報保護方針",
-			"korean": "개인 정보 정책",
-			"german": "Datenschutz-Bestimmungen"
-		},
-		"2fa-setup-step3-toggle1": {
-			"mandarin": "无需电子邮件即可保存我的恢复短语",
-			"spanish": "Guardar mi frase de recuperación sin correo electrónico",
-			"english": "Save my recovery phrase without email",
-			"japanese": "メールなしで回復フレーズを保存する",
-			"korean": "이메일 없이 내 복구 문구 저장",
-			"german": "Meine Wiederherstellungsphrase ohne E-Mail speichern"
-		},
-		"register-backup-phrase-confirm-desc2": {
-			"mandarin": "如果不，",
-			"spanish": "Que no,",
-			"english": "If not,",
-			"japanese": "そうでない場合は、",
-			"korean": "如果不，",
-			"german": "Wenn nicht,"
-		},
-		"register-backup-phrase-desc2": {
-			"mandarin": "它可以帮助您在丢失设备时恢复帐户。",
-			"spanish": "Le ayuda con la recuperación de la cuenta en caso de que pierda su dispositivo.",
-			"english": "It helps you with account recovery in case you lose your device.",
-			"japanese": "デバイスを紛失した場合のアカウントの回復に役立ちます。",
-			"korean": "기기 분실시 계정 복구에 도움이됩니다.",
-			"german": "Es hilft Ihnen bei der Kontowiederherstellung, falls Sie Ihr Gerät verlieren."
-		},
-		"mpc-2fa-setup-step4-sub1": {
-			"mandarin": "验证您的恢复系数",
-			"spanish": "Verifique su factor de recuperación",
-			"english": "Verify your recovery factor",
-			"japanese": "回復率を確認する",
-			"korean": "회복 계수 확인",
-			"german": "Überprüfen Sie Ihren Erholungsfaktor"
-		},
-		"register-continue": {
-			"mandarin": "继续",
-			"spanish": "Continuar",
-			"english": "Continue",
-			"japanese": "継続する",
-			"korean": "계속하다",
-			"german": "Fortsetzen"
-		},
-		"social-2fa-warning-cta-2": {
-			"mandarin": "不，使用另一封电子邮件",
-			"spanish": "No, usa otro correo electrónico",
-			"english": "No, use another email",
-			"japanese": "いいえ、別のメールを使用してください",
-			"korean": "아니요, 다른 이메일을 사용하십시오",
-			"german": "Nein, verwenden Sie eine andere E -Mail"
-		},
-		"reconstruct-always-skip-note": {
-			"mandarin": "通过选择“始终跳过”，您将不会收到再次登录 OpenLogin 帐户的提示。 如果您改变主意，您可以随时在“设置”中更改此首选项。",
-			"spanish": "Si selecciona 'Omitir siempre', no se le pedirá que vuelva a iniciar sesión en su cuenta de OpenLogin. Si cambia de opinión, puede cambiar esta preferencia en cualquier momento en 'Configuración'.",
-			"english": "By selecting 'Always skip', you will not be prompted to login to your OpenLogin account again. If you change your mind, you may change this preference anytime in 'Settings'.",
-			"japanese": "[常にスキップ]を選択すると、OpenLoginアカウントに再度ログインするように求められることはありません。 気が変わった場合は、「設定」でいつでもこの設定を変更できます。",
-			"korean": "'항상 건너뛰기'를 선택하면 OpenLogin 계정에 다시 로그인하라는 메시지가 표시되지 않습니다. 마음이 바뀌면 '설정'에서 언제든지 이 환경설정을 변경할 수 있습니다.",
-			"german": "Wenn Sie „Immer überspringen“ auswählen, werden Sie nicht aufgefordert, sich erneut bei Ihrem OpenLogin-Konto anzumelden. Wenn Sie Ihre Meinung ändern, können Sie diese Einstellung jederzeit in den \"Einstellungen\" ändern."
-		},
-		"2fa-setup-step1-desc1": {
-			"mandarin": "每次登录需要 2 个身份验证因素",
-			"spanish": "Cada inicio de sesión requiere 2 factores para la autenticación",
-			"english": "Each login requires 2 factors for authentication",
-			"japanese": "各ログインには、認証のために2つの要素が必要です",
-			"korean": "각 로그인에는 인증을 위해 2가지 요소가 필요합니다.",
-			"german": "Jede Anmeldung erfordert 2 Faktoren zur Authentifizierung"
-		},
-		"mpc-2fa-setup-step4-sub22": {
-			"mandarin": "粘贴发送到您的电子邮件 {0} 的恢复因素",
-			"spanish": "Pegue el factor de recuperación enviado a su correo electrónico {0}",
-			"english": "Paste the recovery factor sent to your email {0}",
-			"japanese": "メール {0} に送信された回復係数を貼り付けます",
-			"korean": "이메일로 전송된 복구 요소를 붙여넣습니다. {0}",
-			"german": "Fügen Sie den an Ihre E-Mail gesendeten Wiederherstellungsfaktor ein {0}"
-		},
-		"2fa-setup-step2-next": {
-			"mandarin": "继续",
-			"spanish": "Continuar",
-			"english": "Continue",
-			"japanese": "継続する",
-			"korean": "계속하다",
-			"german": "Weitermachen"
-		},
-		"migrate-desc21": {
-			"mandarin": "享受Torus钱包的最新功能",
-			"spanish": "Para disfrutar de las últimas funciones de Torus Wallet",
-			"english": "To enjoy the latest features of the Torus Wallet",
-			"japanese": "トーラスウォレットの最新機能をお楽しみください",
-			"korean": "Torus Wallet의 최신 기능을 즐기려면",
-			"german": "Genießen Sie die neuesten Funktionen der Torus-Brieftasche"
-		},
-		"mpc-2fa-verify-step1-panel2": {
-			"mandarin": "恢复系数",
-			"spanish": "Factor de recuperación",
-			"english": "Recovery factor",
-			"japanese": "回収率",
-			"korean": "회복 계수",
-			"german": "Erholungsfaktor"
-		},
-		"social-2fa-warn-text-1": {
-			"mandarin": "这个社会因素仅充当备份共享，以恢复您的帐户链接到“ abcd@xyz.com”。",
-			"spanish": "Este factor social solo actúa como una participación de respaldo para recuperar su cuenta vinculada a \"abcd@xyz.com\".",
-			"english": "This Social factor only acts as a backup share to recover your account linked to “abcd@xyz.com”.",
-			"japanese": "このソーシャルファクターは、「abcd@xyz.com」にリンクされたアカウントを回復するためのバックアップ共有としてのみ機能します。",
-			"korean": "이 사회적 요소는 \"abcd@xyz.com\"에 링크 된 계정을 복구하기위한 백업 공유 역할을합니다.",
-			"german": "Dieser soziale Faktor fungiert nur als Sicherungsanteil, um Ihr mit „abcd@xyz.com“ verknüpfter Konto wiederherzustellen."
-		},
-		"mpc-2fa-setup-step3-download": {
-			"mandarin": "下载我的恢复因子",
-			"spanish": "Descargar mi factor de recuperación",
-			"english": "Download my recovery factor",
-			"japanese": "私のリカバリーファクターをダウンロードする",
-			"korean": "내 회복 인자 다운로드",
-			"german": "Laden Sie meinen Wiederherstellungsfaktor herunter"
-		},
-		"returning-exist-title": {
-			"mandarin": "欢迎回来，{0}",
-			"spanish": "Bienvenido de nuevo, {0}",
-			"english": "Welcome back, {0}",
-			"japanese": "おかえりなさい、{0}",
-			"korean": "다시 오신 것을 환영합니다. {0}",
-			"german": "Willkommen zurück, {0}"
-		},
-		"returning-header-title": {
-			"mandarin": "登入",
-			"spanish": "Registrarse",
-			"english": "Sign in",
-			"japanese": "サインイン",
-			"korean": "로그인",
-			"german": "Einloggen"
-		},
-		"2fa-verify-success-head": {
-			"mandarin": "成功的",
-			"spanish": "Exitoso",
-			"english": "Successful",
-			"japanese": "成功",
-			"korean": "성공적인",
-			"german": "Erfolgreich"
-		},
-		"2fa-setup-step3-next1": {
-			"mandarin": "完成设置",
-			"spanish": "Terminar de configurar",
-			"english": "Finish setting up",
-			"japanese": "セットアップを完了します",
-			"korean": "설정 완료",
-			"german": "Beenden Sie die Einrichtung"
-		},
-		"reconstruct-device-desc2": {
-			"mandarin": "从以下任何设备中完成安全性验证。",
-			"spanish": "desde cualquiera de los siguientes dispositivos para completar la verificación de seguridad.",
-			"english": "from any of the following devices to complete the security verification.",
-			"japanese": "次のいずれかのデバイスからセキュリティ検証を完了します。",
-			"korean": "다음 장치 중 하나에서 보안 확인을 완료하십시오.",
-			"german": "von einem der folgenden Geräte, um die Sicherheitsüberprüfung abzuschließen."
-		},
-		"reconstruct-backup-phrase-desc": {
-			"mandarin": "输入先前发送到您的辅助邮箱的备份短语。",
-			"spanish": "Ingrese la frase de respaldo enviada a su correo electrónico de recuperación anteriormente.",
-			"english": "Enter the backup phrase sent to your recovery email previously.",
-			"japanese": "以前にリカバリメールに送信されたバックアップフレーズを入力します。",
-			"korean": "이전에 복구 이메일로 전송 된 백업 문구를 입력하십시오.",
-			"german": "Geben Sie den Sicherungssatz ein, der zuvor an Ihre Wiederherstellungs-E-Mail gesendet wurde."
-		},
-		"returning-continue": {
-			"mandarin": "继续{0}",
-			"spanish": "Continuar con {0}",
-			"english": "Continue with {0}",
-			"japanese": "{0}に進む",
-			"korean": "{0}로 계속",
-			"german": "Weiter mit {0}"
-		},
-		"register-password-password-confirm": {
-			"mandarin": "重新输入密码",
-			"spanish": "reingresa tu contraseña",
-			"english": "Re-enter your password",
-			"japanese": "パスワードを再入力してください",
-			"korean": "비밀번호 재 입력",
-			"german": "Wiederhole die Eingabe deines Passwortes"
-		},
-		"2fa-setup-step4-contact-support": {
-			"mandarin": "联系支持",
-			"spanish": "Soporte de contacto",
-			"english": "Contact Support",
-			"japanese": "サポート問い合わせ先",
-			"korean": "연락처 지원",
-			"german": "Kontaktieren Sie Support"
-		},
-		"reconstruct-backup-phrase-placeholder": {
-			"mandarin": "输入备用词组",
-			"spanish": "Ingrese la frase de respaldo",
-			"english": "Enter backup phrase",
-			"japanese": "バックアップフレーズを入力してください",
-			"korean": "백업 문구 입력",
-			"german": "Geben Sie die Sicherungsphrase ein"
-		},
-		"register-subtitle-try-webauth": {
-			"mandarin": "您要在此设备上启用Touch ID / Face ID吗？",
-			"spanish": "¿Le gustaría habilitar Touch ID / Face ID en este dispositivo?",
-			"english": "Would you like to enable Touch ID / Face ID on this device?",
-			"japanese": "このデバイスでTouchID / Face IDを有効にしますか？",
-			"korean": "이 장치에서 Touch ID / Face ID를 활성화 하시겠습니까?",
-			"german": "Möchten Sie die Touch ID / Face ID auf diesem Gerät aktivieren?"
-		},
-		"2fa-setup-step3-note12": {
-			"mandarin": "您需要在下一个屏幕上确认此短语",
-			"spanish": "Deberá confirmar esta frase en la siguiente pantalla",
-			"english": "You will need to confirm this phrase on the next screen",
-			"japanese": "次の画面でこのフレーズを確認する必要があります",
-			"korean": "다음 화면에서 이 문구를 확인해야 합니다.",
-			"german": "Sie müssen diesen Satz auf dem nächsten Bildschirm bestätigen"
-		},
-		"2fa-setup-title31": {
-			"mandarin": "第 2 步：保存恢复短语",
-			"spanish": "Paso 2: Guarda la frase de recuperación",
-			"english": "Step 2: Save recovery phrase",
-			"japanese": "ステップ2：リカバリフレーズを保存する",
-			"korean": "2단계: 복구 문구 저장",
-			"german": "Schritt 2: Speichern Sie die Wiederherstellungsphrase"
-		},
-		"2fa-verify-step1-go-app": {
-			"mandarin": "转到应用程序",
-			"spanish": "Ir a la aplicación",
-			"english": "Go to App",
-			"japanese": "アプリに行きます",
-			"korean": "앱으로 이동",
-			"german": "Gehe zu App"
-		},
-		"2fa-setup-step3-sub2": {
-			"mandarin": "如果您无法访问保存的浏览器，您可以使用恢复短语进行身份验证。",
-			"spanish": "En caso de que pierda el acceso a su navegador guardado, puede autenticarse con su frase de recuperación.",
-			"english": "In case you lose access to your saved browser, you can authenticate with your recovery phrase.",
-			"japanese": "保存したブラウザにアクセスできなくなった場合は、リカバリフレーズで認証できます。",
-			"korean": "저장된 브라우저에 액세스할 수 없는 경우 복구 문구로 인증할 수 있습니다.",
-			"german": "Falls Sie den Zugriff auf Ihren gespeicherten Browser verlieren, können Sie sich mit Ihrer Wiederherstellungsphrase authentifizieren."
-		},
-		"2fa-verify-save-save": {
-			"mandarin": "保存此设备",
-			"spanish": "Guardar este dispositivo",
-			"english": "Save this device",
-			"japanese": "このデバイスを保存します",
-			"korean": "이 기기 저장",
-			"german": "Speichern Sie dieses Gerät"
-		},
-		"2fa-verify-share-head": {
-			"mandarin": "选择以下之一",
-			"spanish": "Selecciona uno de los siguientes",
-			"english": "Select one of the following",
-			"japanese": "次のいずれかを選択してください",
-			"korean": "다음 중 하나를 선택하십시오.",
-			"german": "Wählen Sie eine der folgenden Optionen"
-		},
-		"mpc-2fa-setup-step4-recovery": {
-			"mandarin": "恢复系数",
-			"spanish": "Factor de recuperación",
-			"english": "Recovery factor",
-			"japanese": "回収率",
-			"korean": "회복 계수",
-			"german": "Erholungsfaktor"
-		},
-		"2fa-verify-reference-id": {
-			"mandarin": "参考编号",
-			"spanish": "Identificación de referencia",
-			"english": "Reference ID",
-			"japanese": "参照ID",
-			"korean": "참조 ID",
-			"german": "Referenz ID"
-		},
-		"2fa-setup-step4-sub21": {
-			"mandarin": "粘贴恢复短语",
-			"spanish": "Pega la frase de recuperación",
-			"english": "Paste the recovery phrase",
-			"japanese": "回復フレーズを貼り付けます",
-			"korean": "복구 문구 붙여넣기",
-			"german": "Fügen Sie den Wiederherstellungssatz ein"
-		},
-		"2fa-verify-recovery-note": {
-			"mandarin": "如果您无法验证上述任何一项，则无法登录您的帐户。",
-			"spanish": "Si no puede verificar ninguno de los anteriores, no puede iniciar sesión en su cuenta.",
-			"english": "If you are unable to verify any of the above, you are unable to login to your account.",
-			"japanese": "上記のいずれかを確認できない場合は、アカウントにログインできません。",
-			"korean": "위의 항목 중 하나라도 확인할 수 없으면 계정에 로그인할 수 없습니다.",
-			"german": "Wenn Sie keinen der oben genannten Punkte bestätigen können, können Sie sich nicht bei Ihrem Konto anmelden."
-		},
-		"register-backup-phrase-placeholder": {
-			"mandarin": "输入辅助邮箱",
-			"spanish": "Ingresa el correo de recuperación",
-			"english": "Enter recovery email",
-			"japanese": "復旧メールを入力してください",
-			"korean": "복구 이메일 입력",
-			"german": "Geben Sie die Wiederherstellungs-E-Mail ein"
-		},
-		"2fa-setup-step3-sub1": {
-			"mandarin": "提供电子邮件以接收恢复短语",
-			"spanish": "Proporcione un correo electrónico para recibir la frase de recuperación",
-			"english": "Provide an email to receive recovery phrase",
-			"japanese": "回復フレーズを受け取るための電子メールを提供する",
-			"korean": "복구 문구를 받을 이메일 제공",
-			"german": "Geben Sie eine E-Mail an, um die Wiederherstellungsphrase zu erhalten"
-		},
-		"register-skip": {
-			"mandarin": "立即跳过",
-			"spanish": "Saltar por ahora",
-			"english": "Skip for Now",
-			"japanese": "今はスキップ",
-			"korean": "일단은 스킵",
-			"german": "Für jetzt überspringen"
-		},
-		"returning-confirm-desc": {
-			"mandarin": "继续通过生物识别登录？",
-			"spanish": "¿Continuar con el inicio de sesión mediante datos biométricos?",
-			"english": "Continue your sign in via biometrics?",
-			"japanese": "生体認証を介してサインインを続行しますか？",
-			"korean": "생체 인식을 통해 계속 로그인 하시겠습니까?",
-			"german": "Mit der Anmeldung über Biometrie fortfahren?"
-		},
-		"register-biometrics-enable": {
-			"mandarin": "启用触摸ID /面部ID",
-			"spanish": "Habilitar Touch ID / Face ID",
-			"english": "Enable Touch ID / Face ID",
-			"japanese": "Touch ID / FaceIDを有効にする",
-			"korean": "Touch ID / Face ID 활성화",
-			"german": "Aktivieren Sie Touch ID / Face ID"
-		},
-		"register-multiple-transports-cta": {
-			"english": "Set it up",
-			"german": "Es einrichten",
-			"mandarin": "设置它",
-			"korean": "설정하십시오",
-			"japanese": "準備する",
-			"spanish": "Prepararlo"
-		},
-		"reconstruct-backup-phrase-desc-3": {
-			"mandarin": "并发送到电子邮件：",
-			"spanish": "y enviado al correo electrónico:",
-			"english": "and sent to email: ",
-			"japanese": "そして電子メールに送られる：",
-			"korean": "이메일로 전송:",
-			"german": "und an E-Mail gesendet:"
-		},
-		"2fa-verify-share-browser": {
-			"mandarin": "浏览器",
-			"spanish": "Navegador",
-			"english": "Browser",
-			"japanese": "ブラウザ",
-			"korean": "브라우저",
-			"german": "Browser"
-		},
-		"2fa-setup-step4-check-time": {
-			"mandarin": "没有收到吗？ 反感。 再次签入{0}",
-			"spanish": "¿No lo recibiste? Resentirse de. Vuelve a comprobar en {0}",
-			"english": "Did not receive it? Resent. Check again in {0}",
-			"japanese": "受け取りませんでしたか？ 憤る。 {0}でもう一度確認してください",
-			"korean": "받지 못하셨나요? 화내다. {0}에서 다시 확인",
-			"german": "Nicht erhalten? Übelnehmen. Erneut einchecken in {0}"
-		},
-		"2fa-verify-multi-subhead": {
-			"mandarin": "登录到以下已保存的浏览器以批准访问",
-			"spanish": "Inicie sesión en el siguiente navegador guardado para aprobar el acceso",
-			"english": "Login to the following saved browser to approve access",
-			"japanese": "次の保存されたブラウザにログインして、アクセスを承認します",
-			"korean": "액세스를 승인하려면 다음 저장된 브라우저에 로그인하십시오.",
-			"german": "Melden Sie sich beim folgenden gespeicherten Browser an, um den Zugriff zu genehmigen"
-		},
-		"2fa-setup-title12": {
-			"mandarin": "设置 2 因素身份验证",
-			"spanish": "Configurar autenticación de 2 factores",
-			"english": "Set up 2 Factor Authentication",
-			"japanese": "2要素認証を設定する",
-			"korean": "2단계 인증 설정",
-			"german": "2-Faktor-Authentifizierung einrichten"
-		},
-		"verifier-google-desc": {
-			"mandarin": "继续使用Google",
-			"spanish": "Continuar con Google",
-			"english": "Continue with Google",
-			"japanese": "Googleで続行",
-			"korean": "Google로 계속",
-			"german": "Fahren Sie mit Google fort"
-		},
-		"2fa-setup-step3-manual-save": {
-			"mandarin": "手动保存您的短语",
-			"spanish": "Guarde manualmente su frase",
-			"english": "Manually save your phrase",
-			"japanese": "フレーズを手動で保存する",
-			"korean": "수동으로 문구 저장",
-			"german": "Speichern Sie Ihren Satz manuell"
-		},
-		"2fa-setup-step3-toggle2": {
-			"mandarin": "通过电子邮件向我发送恢复短语",
-			"spanish": "Envíame mi frase de recuperación por correo electrónico",
-			"english": "Email me my recovery phrase",
-			"japanese": "私の回復フレーズを私にメールしてください",
-			"korean": "내 복구 문구를 이메일로 보내주세요",
-			"german": "Senden Sie mir meinen Wiederherstellungssatz per E-Mail"
-		},
-		"2fa-setup-step1-next": {
-			"mandarin": "设置 2FA",
-			"spanish": "Configurar 2FA",
-			"english": "Set up 2FA",
-			"japanese": "2FAを設定する",
-			"korean": "2FA 설정",
-			"german": "2FA einrichten"
-		},
-		"2fa-setup-step2-confirm-note": {
-			"mandarin": "我了解清除浏览器历史记录和 cookie 将删除我浏览器上的这个因素。",
-			"spanish": "Entiendo que borrar el historial del navegador y las cookies eliminará este factor en mi navegador.",
-			"english": "I understand that clearing browser history and cookies will delete this factor on my browser.",
-			"japanese": "ブラウザの履歴とCookieをクリアすると、ブラウザのこの要素が削除されることを理解しています。",
-			"korean": "브라우저 기록 및 쿠키를 지우면 내 브라우저에서 이 요소가 삭제된다는 것을 이해합니다.",
-			"german": "Mir ist bewusst, dass das Löschen des Browserverlaufs und der Cookies diesen Faktor in meinem Browser löscht."
-		},
-		"2fa-verify-step1-panel1": {
-			"mandarin": "保存的浏览器/设备",
-			"spanish": "Navegadores / dispositivos guardados",
-			"english": "Saved browser(s) / devices",
-			"japanese": "保存されたブラウザ/デバイス",
-			"korean": "저장된 브라우저/기기",
-			"german": "Gespeicherte(r) Browser/Geräte"
-		},
-		"mpc-2fa-verify-step1-rec-placeholder": {
-			"mandarin": "恢复系数",
-			"spanish": "Factor de recuperación",
-			"english": "Recovery factor",
-			"japanese": "回収率",
-			"korean": "회복 계수",
-			"german": "Erholungsfaktor"
-		},
-		"social-2fa-verify-email": {
-			"mandarin": "通过电子邮件验证",
-			"spanish": "Verifique con su correo electrónico",
-			"english": "Verify with your email",
-			"japanese": "メールで確認してください",
-			"korean": "이메일로 확인하십시오",
-			"german": "Überprüfen Sie mit Ihrer E -Mail"
-		},
-		"popup-continue-existing": {
-			"mandarin": "继续使用现有的{0}",
-			"spanish": "Continuar con {0} existente",
-			"english": "Continue with existing {0}",
-			"japanese": "既存の{0}を続行します",
-			"korean": "기존 {0} 계속",
-			"german": "Weiter mit vorhandenem {0}"
-		},
-		"register-title-additional-security": {
-			"mandarin": "出发前的最后一步",
-			"spanish": "Un último paso antes de irte",
-			"english": "One last step before you go",
-			"japanese": "行く前の最後の一歩",
-			"korean": "가기 전에 마지막 단계",
-			"german": "Ein letzter Schritt bevor du gehst"
-		},
-		"2fa-setup-step2-sub1": {
-			"mandarin": "使用当前浏览器设置",
-			"spanish": "Configurar usando el navegador actual",
-			"english": "Set up using current browser",
-			"japanese": "現在のブラウザを使用して設定",
-			"korean": "현재 브라우저를 사용하여 설정",
-			"german": "Mit aktuellem Browser einrichten"
-		},
-		"register-backup-phrase-desc1": {
-			"mandarin": "将向您发送一封包含备份短语的电子邮件。",
-			"spanish": "Se le enviará un correo electrónico con la frase de respaldo.",
-			"english": "An email will be sent to you containing the backup phrase.",
-			"japanese": "バックアップ フレーズを含むメールが送信されます。",
-			"korean": "백업 문구가 포함 된 이메일이 발송됩니다.",
-			"german": "Sie erhalten eine E-Mail mit der Backup-Phrase."
-		},
-		"2fa-setup-step3-hide-adv": {
-			"mandarin": "隐藏高级选项",
-			"spanish": "Ocultar opción avanzada",
-			"english": "Hide advanced option",
-			"japanese": "詳細オプションを非表示",
-			"korean": "고급 옵션 숨기기",
-			"german": "Erweiterte Option ausblenden"
-		},
-		"2fa-verify-success-subtitle": {
-			"mandarin": "登录",
-			"spanish": "iniciando sesión",
-			"english": "Logging you in",
-			"japanese": "ログインします",
-			"korean": "로그인",
-			"german": "Melden Sie sich an"
-		},
-		"2fa-setup-step1-desc22": {
-			"mandarin": "只需 3 个简单的步骤即可完成设置！",
-			"spanish": "¡Configúralo en 3 sencillos pasos!",
-			"english": "Set it up in 3 simple steps!",
-			"japanese": "3つの簡単なステップでセットアップしてください！",
-			"korean": "간단한 3단계로 설정하세요!",
-			"german": "Richten Sie es in 3 einfachen Schritten ein!"
-		},
-		"2fa-setup-step3-next3": {
-			"mandarin": "发送恢复短语",
-			"spanish": "Enviar frase de recuperación",
-			"english": "Send recovery phrase",
-			"japanese": "回復フレーズを送信する",
-			"korean": "복구 문구 보내기",
-			"german": "Wiederherstellungsphrase senden"
-		},
-		"register-backup-phrase-send": {
-			"mandarin": "发送恢复电子邮件",
-			"spanish": "Enviar correo de recuperación",
-			"english": "Send recovery email",
-			"japanese": "復旧メールを送信する",
-			"korean": "복구 이메일 보내기",
-			"german": "Wiederherstellungs-E-Mail senden"
-		},
-		"mpc-2fa-setup-step3-sub1": {
-			"mandarin": "提供电子邮件以接收恢复短语",
-			"spanish": "Proporcione un correo electrónico para recibir la frase de recuperación",
-			"english": "Provide an email to receive recovery factor",
-			"japanese": "回復フレーズを受け取るための電子メールを提供する",
-			"korean": "복구 문구를 받을 이메일 제공",
-			"german": "Geben Sie eine E-Mail an, um die Wiederherstellungsphrase zu erhalten"
-		},
-		"2fa-setup-step3-show-adv": {
-			"mandarin": "查看高级选项",
-			"spanish": "Ver opción avanzada",
-			"english": "View advanced option",
-			"japanese": "詳細オプションを表示",
-			"korean": "고급 옵션 보기",
-			"german": "Erweiterte Option anzeigen"
-		},
-		"2fa-verify-step1-rec-placeholder": {
-			"mandarin": "恢复短语",
-			"spanish": "Frase de recuperación",
-			"english": "Recovery phrase",
-			"japanese": "回復フレーズ",
-			"korean": "복구 문구",
-			"german": "Wiederherstellungsphrase"
-		},
-		"2fa-verify-step2-sub1": {
-			"mandarin": "验证成功",
-			"spanish": "Verificación exitosa",
-			"english": "Successful verification",
-			"japanese": "検証の成功",
-			"korean": "인증 성공",
-			"german": "Erfolgreiche Verifizierung"
-		},
-		"title": {
-			"mandarin": "一站式管理所有网络互动",
-			"spanish": "Administre todas sus interacciones web en un solo lugar",
-			"english": "Manage all your web interactions in one place",
-			"japanese": "すべてのWebインタラクションを1か所で管理します",
-			"korean": "모든 웹 상호 작용을 한 곳에서 관리",
-			"german": "Verwalten Sie alle Ihre Webinteraktionen an einem Ort"
-		},
-		"register-biometrics-desc": {
-			"mandarin": "使用面容 ID 或触控 ID 注册您的设备。 生物识别技术永远不会离开您的设备。",
-			"spanish": "Registre su dispositivo con Face ID o Touch ID. La biometría nunca abandona su dispositivo.",
-			"english": "Register your device with Face ID or Touch ID. Biometrics never leave your device.",
-			"japanese": "デバイスを Face ID または Touch ID で登録します。 生体認証がデバイスから離れることはありません。",
-			"korean": "Face ID 또는 Touch ID로 기기를 등록하세요. 생체 인식은 장치를 떠나지 않습니다.",
-			"german": "Registrieren Sie Ihr Gerät mit Face ID oder Touch ID. Biometrie verlässt Ihr Gerät nie."
-		},
-		"register-multiple-transports-desc": {
-			"english": "Register your device with biometrics or any web authentication methods.",
-			"german": "Registrieren Sie Ihr Gerät mit Biometrie oder Webauthentifizierungsmethoden.",
-			"mandarin": "用生物识别技术或任何Web身份验证方法注册您的设备。",
-			"korean": "생체 인식 또는 웹 인증 방법으로 장치를 등록하십시오.",
-			"japanese": "バイオメトリクスまたはWeb認証方法でデバイスを登録します。",
-			"spanish": "Registre su dispositivo con Biometrics o cualquier método de autenticación web."
-		},
-		"register-external-transports-desc": {
-			"english": "Register your device any web authentication methods.",
-			"german": "Registrieren Sie Ihr Gerät alle Webauthentifizierungsmethoden.",
-			"mandarin": "注册您的设备任何Web身份验证方法。",
-			"korean": "웹 인증 방법을 장치에 등록하십시오.",
-			"japanese": "Web認証方法をデバイスに登録してください。",
-			"spanish": "Registre su dispositivo cualquier método de autenticación web."
-		},
-		"mpc-2fa-setup-title3": {
-			"mandarin": "保存恢复短语",
-			"spanish": "Guardar frase de recuperación",
-			"english": "Save recovery factor",
-			"japanese": "回復フレーズを保存する",
-			"korean": "복구 문구 저장",
-			"german": "Wiederherstellungsphrase speichern"
-		},
-		"reconstruct-device-prev2": {
-			"mandarin": "Torus钱包的先前版本",
-			"spanish": "versión anterior de Torus Wallet",
-			"english": "previous version of the Torus Wallet",
-			"japanese": "トーラスウォレットの以前のバージョン",
-			"korean": "이전 버전의 토러스 지갑",
-			"german": "vorherige Version der Torus-Brieftasche"
-		},
-		"2fa-setup-step3-next4": {
-			"mandarin": "我已经保存了我的恢复短语",
-			"spanish": "He guardado mi frase de recuperación",
-			"english": "I have saved my recovery phrase",
-			"japanese": "回復フレーズを保存しました",
-			"korean": "복구 문구를 저장했습니다",
-			"german": "Ich habe meine Wiederherstellungsphrase gespeichert"
-		},
-		"2fa-setup-step3-download": {
-			"mandarin": "下载我的恢复短语",
-			"spanish": "Descarga mi frase de recuperación",
-			"english": "Download my recovery phrase",
-			"japanese": "私の回復フレーズをダウンロードする",
-			"korean": "내 복구 문구 다운로드",
-			"german": "Laden Sie meinen Wiederherstellungssatz herunter"
-		},
-		"reconstruct-biometrics-desc": {
-			"mandarin": "*仅适用于先前在以下设备上设置的Touch ID / Face ID：",
-			"spanish": "* Solo para Touch ID / Face ID configurado previamente en los siguientes dispositivos:",
-			"english": "* Only for Touch ID / Face ID previously set up on the following device(s):",
-			"japanese": "*以下のデバイスで以前に設定されたTouchID / Face IDの場合のみ：",
-			"korean": "* 다음 장치에서 이전에 설정 한 Touch ID / Face ID에만 해당됩니다.",
-			"german": "* Nur für Touch ID / Face ID, die zuvor auf den folgenden Geräten eingerichtet wurden:"
-		},
-		"reconstruct-multiple-transports-desc": {
-			"english": "Only for web authentication methods that was previously set up on the following device(s)",
-			"german": "Nur für Webauthentifizierungsmethoden, die zuvor auf den folgenden Geräten eingerichtet wurden (en)",
-			"mandarin": "仅对于以前在以下设备上设置的Web身份验证方法",
-			"korean": "다음 장치에서 이전에 설정된 웹 인증 방법에 대해서만",
-			"japanese": "以前に次のデバイスに設定されたWeb認証方法のみ",
-			"spanish": "Solo para métodos de autenticación web que se configuraron previamente en los siguientes dispositivos"
-		},
-		"register-password-confirm": {
-			"mandarin": "设定密码",
-			"spanish": "Configurar contraseña",
-			"english": "Set up password",
-			"japanese": "パスワードを設定する",
-			"korean": "비밀번호 설정",
-			"german": "Passwort einrichten"
-		},
-		"register-backup-phrase-title": {
-			"mandarin": "继续发送辅助邮箱",
-			"spanish": "Continuar con un correo de recuperación",
-			"english": "Continue with a recovery email",
-			"japanese": "復旧メールを続行します",
-			"korean": "복구 이메일로 계속",
-			"german": "Fahren Sie mit einer Wiederherstellungs-E-Mail fort"
-		},
-		"mpc-2fa-setup-step4-sub21": {
-			"mandarin": "粘贴恢复因子",
-			"spanish": "Pegar el factor de recuperación",
-			"english": "Paste the recovery factor",
-			"japanese": "回復係数を貼り付けます",
-			"korean": "회복 인자 붙여넣기",
-			"german": "Fügen Sie den Wiederherstellungsfaktor ein"
-		},
-		"2fa-verify-step1-sub1": {
-			"mandarin": "使用以下之一进行身份验证",
-			"spanish": "Autenticarse con uno de los siguientes",
-			"english": "Authenticate with one of the following",
-			"japanese": "次のいずれかで認証します",
-			"korean": "다음 중 하나로 인증",
-			"german": "Authentifizieren Sie sich mit einer der folgenden Optionen"
-		},
-		"2fa-verify-title1": {
-			"mandarin": "验证您的登录信息",
-			"spanish": "Verifique su inicio de sesión",
-			"english": "Verify your login",
-			"japanese": "ログインを確認する",
-			"korean": "로그인 확인",
-			"german": "Bestätigen Sie Ihre Anmeldung"
-		},
-		"migrate-desc22": {
-			"mandarin": "请在此新版本上验证您的身份",
-			"spanish": "por favor verifique su identidad en esta nueva versión",
-			"english": "kindly verify your identity on this new version",
-			"japanese": "この新しいバージョンであなたの身元を確認してください",
-			"korean": "이 새 버전에서 신원을 확인하십시오.",
-			"german": "Bitte überprüfen Sie Ihre Identität in dieser neuen Version"
-		},
-		"social-2fa-verify-account": {
-			"mandarin": "验证您的社交帐户",
-			"spanish": "Verifique con su cuenta social",
-			"english": "Verify with your social account",
-			"japanese": "ソーシャルアカウントで確認します",
-			"korean": "소셜 계정으로 확인하십시오",
-			"german": "Überprüfen Sie mit Ihrem sozialen Konto"
-		},
-		"register-subtitle-additional-security": {
-			"mandarin": "您的帐户安全很重要。 让我们支持它。",
-			"spanish": "La seguridad de su cuenta es importante. Hagamos una copia de seguridad.",
-			"english": "Your account security matters. Let’s back it up.",
-			"japanese": "アカウントのセキュリティが重要です。 後押ししましょう。",
-			"korean": "귀하의 계정 보안이 중요합니다. 백업합시다.",
-			"german": "Die Sicherheit Ihres Kontos ist wichtig. Lass es uns sichern."
-		},
-		"2fa-setup-step1-sub3": {
-			"mandarin": "为您的帐户添加额外的安全层并妥善保管您的资产。",
-			"spanish": "Agregue una capa adicional de seguridad a su cuenta y proteja sus activos.",
-			"english": "Add an extra layer of security to your account and safekeep your assets.",
-			"japanese": "アカウントにセキュリティの層を追加し、資産を保護します。",
-			"korean": "계정에 보안 계층을 추가하고 자산을 보호하십시오.",
-			"german": "Fügen Sie Ihrem Konto eine zusätzliche Sicherheitsebene hinzu und bewahren Sie Ihre Vermögenswerte sicher auf."
-		},
-		"social-2fa-subtitle-2": {
-			"mandarin": "如果您无法访问保存的浏览器，则可以通过社交帐户进行身份验证。",
-			"spanish": "En caso de que pierda acceso a su navegador guardado, puede autenticarse con su cuenta social.",
-			"english": "In case you lose access to your saved browser, you can authenticate with your Social account.",
-			"japanese": "保存されたブラウザへのアクセスを失う場合は、ソーシャルアカウントで認証できます。",
-			"korean": "저장된 브라우저에 대한 액세스 권한을 잃어버린 경우 소셜 계정으로 인증 할 수 있습니다.",
-			"german": "Falls Sie den Zugriff auf Ihren gespeicherten Browser verlieren, können Sie sich mit Ihrem sozialen Konto authentifizieren."
-		},
-		"popup-here": {
-			"mandarin": "这里",
-			"spanish": "aquí",
-			"english": "here",
-			"japanese": "ここに",
-			"korean": "여기",
-			"german": "Hier"
-		},
-		"verifier-email-desc": {
-			"mandarin": "继续发送电子邮件",
-			"spanish": "Continuar con el correo electrónico",
-			"english": "Continue with Email",
-			"japanese": "メールを続ける",
-			"korean": "이메일로 계속",
-			"german": "Fahren Sie mit E-Mail fort"
-		},
-		"returning-exist-use-another": {
-			"mandarin": "使用其他帐户",
-			"spanish": "Usa otra cuenta",
-			"english": "Use another account",
-			"japanese": "別のアカウントを使用する",
-			"korean": "다른 계정 사용",
-			"german": "Benutze einen anderen Account"
-		},
-		"popup-view-less": {
-			"mandarin": "查看较少的选项",
-			"spanish": "Ver menos opciones",
-			"english": "View less options",
-			"japanese": "少ないオプションを表示",
-			"korean": "옵션 간략히보기",
-			"german": "Weniger Optionen anzeigen"
-		},
-		"2fa-setup-title3": {
-			"mandarin": "保存恢复短语",
-			"spanish": "Guardar frase de recuperación",
-			"english": "Save recovery phrase",
-			"japanese": "回復フレーズを保存する",
-			"korean": "복구 문구 저장",
-			"german": "Wiederherstellungsphrase speichern"
-		},
-		"2fa-verify-step1-do-not-save": {
-			"mandarin": "不要保存此浏览器/设备。",
-			"spanish": "No guarde este navegador / dispositivo.",
-			"english": "Do not save this brower/device.",
-			"japanese": "このブラウザ/デバイスを保存しないでください。",
-			"korean": "이 브라우저/장치를 저장하지 마십시오.",
-			"german": "Speichern Sie diesen Browser/dieses Gerät nicht."
-		},
-		"2fa-setup-step3-sub22": {
-			"mandarin": "我知道如果我丢失了这个恢复短语，我将承担丢失帐户的风险。",
-			"spanish": "Sé que si pierdo esta frase de recuperación, correré el riesgo de perder mi cuenta.",
-			"english": "I know that if I lose this recovery phrase, I will bear the risk of losing my account.",
-			"japanese": "この回復フレーズを失った場合、アカウントを失うリスクを負うことを私は知っています。",
-			"korean": "이 복구 문구를 잃어버리면 계정을 잃을 위험을 감수해야 한다는 것을 알고 있습니다.",
-			"german": "Ich weiß, dass ich das Risiko trage, mein Konto zu verlieren, wenn ich diesen Wiederherstellungssatz verliere."
-		},
-		"returning-header-desc": {
-			"mandarin": "您的数字钱包通过",
-			"spanish": "Tu billetera digital a través de",
-			"english": "Your digital wallet via",
-			"japanese": "経由であなたのデジタルウォレット",
-			"korean": "디지털 지갑을 통해",
-			"german": "Ihre digitale Geldbörse über"
-		},
-		"2fa-setup-step4-next": {
-			"mandarin": "核实",
-			"spanish": "Verificar",
-			"english": "Verify",
-			"japanese": "確認",
-			"korean": "검증",
-			"german": "Verifizieren"
-		},
-		"reconstruct-title": {
-			"mandarin": "验证您的登录名",
-			"spanish": "Verifique su inicio de sesión",
-			"english": "Verify your login",
-			"japanese": "ログインを確認する",
-			"korean": "로그인 확인",
-			"german": "Überprüfen Sie Ihr Login"
-		},
-		"popup-subtitle": {
-			"mandarin": "选择您想继续的方式",
-			"spanish": "Seleccione cómo le gustaría continuar",
-			"english": "Select how you would like to continue",
-			"japanese": "続行する方法を選択してください",
-			"korean": "계속할 방법을 선택하십시오.",
-			"german": "Wählen Sie aus, wie Sie fortfahren möchten"
-		},
-		"2fa-verify-multi-subhead2": {
-			"mandarin": "登录请求将发送到您保存的浏览器",
-			"spanish": "Se enviará una solicitud de inicio de sesión a su navegador guardado",
-			"english": "A login request will be sent to your saved browser",
-			"japanese": "保存したブラウザにログインリクエストが送信されます",
-			"korean": "저장된 브라우저로 로그인 요청이 전송됩니다.",
-			"german": "Eine Anmeldeanfrage wird an Ihren gespeicherten Browser gesendet"
-		},
-		"returning-confirm-btn": {
-			"mandarin": "是的，继续生物识别",
-			"spanish": "Sí, continuar con la biometría",
-			"english": "Yes, continue with biometrics",
-			"japanese": "はい、生体認証を続行します",
-			"korean": "예, 생체 인식을 계속합니다.",
-			"german": "Ja, weiter mit Biometrie"
-		},
-		"register-subtitle": {
-			"mandarin": "选择以下之一",
-			"spanish": "Selecciona uno de los siguientes",
-			"english": "Select one of the following",
-			"japanese": "次のいずれかを選択してください",
-			"korean": "다음 중 하나를 선택하십시오.",
-			"german": "Wählen Sie eine der folgenden Optionen"
-		},
-		"reconstruct-subtitle": {
-			"mandarin": "验证以下内容之一以访问您的帐户",
-			"spanish": "Verifique con uno de los siguientes para acceder a su cuenta",
-			"english": "Verify with one of the following to access your account",
-			"japanese": "アカウントにアクセスするには、次のいずれかで確認してください",
-			"korean": "계정에 액세스하려면 다음 중 하나로 확인하세요.",
-			"german": "Überprüfen Sie mit einem der folgenden Punkte, um auf Ihr Konto zuzugreifen"
-		},
-		"register-title": {
-			"mandarin": "保护您的{0}帐户",
-			"spanish": "Asegurar su cuenta de {0}",
-			"english": "Securing your {0} account",
-			"japanese": "{0}アカウントを保護する",
-			"korean": "{0} 계정 보안",
-			"german": "Sichern Sie Ihr {0} Konto"
-		},
-		"register-title-try-webauth": {
-			"mandarin": "保护您的帐户",
-			"spanish": "Asegurar su cuenta",
-			"english": "Securing your account",
-			"japanese": "アカウントを保護する",
-			"korean": "계정 보안",
-			"german": "Sichern Sie Ihr Konto"
-		},
-		"reconstruct-device-prev3": {
-			"mandarin": "从下面存储的浏览器中验证您的身份。",
-			"spanish": "desde el navegador almacenado a continuación para verificar su identidad.",
-			"english": "from the stored browser below to verify your identity.",
-			"japanese": "以下の保存されているブラウザから本人確認を行ってください。",
-			"korean": "아래 저장된 브라우저에서 귀하의 신원을 확인하십시오.",
-			"german": "über den unten gespeicherten Browser, um Ihre Identität zu überprüfen."
-		},
-		"verifier-email-placeholder": {
-			"mandarin": "电子邮件",
-			"spanish": "Correo electrónico",
-			"english": "Email",
-			"japanese": "Eメール",
-			"korean": "이메일",
-			"german": "Email"
-		},
-		"social-2fa-warning-cta-1": {
-			"mandarin": "是的，我接受风险",
-			"spanish": "Sí, acepto el riesgo",
-			"english": "Yes, I accept the risk",
-			"japanese": "はい、私はリスクを受け入れます",
-			"korean": "예, 위험을 받아들입니다",
-			"german": "Ja, ich akzeptiere das Risiko"
-		},
-		"subtitle": {
-			"mandarin": "点击开始以继续",
-			"spanish": "Haga clic en comenzar para continuar",
-			"english": "Click Get Started to continue",
-			"japanese": "[開始]をクリックして続行します",
-			"korean": "계속하려면 시작하기를 클릭하세요.",
-			"german": "Klicken Sie auf Erste Schritte, um fortzufahren"
-		},
-		"2fa-verify-save-subhead": {
-			"mandarin": "您想将此设备保存为受信任的设备吗？",
-			"spanish": "¿Le gustaría guardar este dispositivo como dispositivo de confianza?",
-			"english": "Would you like to save this device as a trusted device?",
-			"japanese": "このデバイスを信頼できるデバイスとして保存しますか？",
-			"korean": "이 장치를 신뢰할 수 있는 장치로 저장하시겠습니까?",
-			"german": "Möchten Sie dieses Gerät als vertrauenswürdiges Gerät speichern?"
-		},
-		"2fa-setup-title5": {
-			"mandarin": "2FA 激活",
-			"spanish": "2FA activado",
-			"english": "2FA activated",
-			"japanese": "2FAがアクティブ化",
-			"korean": "2FA 활성화",
-			"german": "2FA aktiviert"
-		},
-		"mpc-2fa-setup-step3-sub2": {
-			"mandarin": "如果您无法访问保存的浏览器，您可以使用恢复短语进行身份验证。",
-			"spanish": "En caso de que pierda el acceso a su navegador guardado, puede autenticarse con su frase de recuperación.",
-			"english": "In case you lose access to your saved browser, you can authenticate with your recovery factor.",
-			"japanese": "保存したブラウザにアクセスできなくなった場合は、リカバリフレーズで認証できます。",
-			"korean": "저장된 브라우저에 액세스할 수 없는 경우 복구 문구로 인증할 수 있습니다.",
-			"german": "Falls Sie den Zugriff auf Ihren gespeicherten Browser verlieren, können Sie sich mit Ihrer Wiederherstellungsphrase authentifizieren."
-		},
-		"register-password-password": {
-			"mandarin": "输入密码",
-			"spanish": "Ingresa tu contraseña",
-			"english": "Enter your password",
-			"japanese": "パスワードを入力してください",
-			"korean": "비밀번호를 입력하세요",
-			"german": "Geben Sie Ihr Passwort ein"
-		},
-		"social-2fa-verify-heading": {
-			"mandarin": "社会恢复因素",
-			"spanish": "Factor de recuperación social",
-			"english": "Social Recovery factor",
-			"japanese": "社会的回復要因",
-			"korean": "사회 복구 요인",
-			"german": "Sozialer Genesungsfaktor"
-		},
-		"register-backup-phrase-additional-security-desc1": {
-			"mandarin": "将向您发送一封包含备份短语的电子邮件。",
-			"spanish": "Se le enviará un correo electrónico con la frase de respaldo.",
-			"english": "An email will be sent to you containing the backup phrase.",
-			"japanese": "バックアップ フレーズを含むメールが送信されます。",
-			"korean": "백업 문구가 포함 된 이메일이 발송됩니다.",
-			"german": "Sie erhalten eine E-Mail mit der Backup-Phrase."
-		},
-		"popup-manage": {
-			"mandarin": "管理帐户",
-			"spanish": "Administrar cuenta",
-			"english": "Manage account",
-			"japanese": "アカウントを管理する",
-			"korean": "계정 관리",
-			"german": "Konto verwalten"
-		},
-		"2fa-verify-try-other": {
-			"mandarin": "尝试其他方法",
-			"spanish": "Pruebe otros métodos",
-			"english": "Try other methods",
-			"japanese": "他の方法を試す",
-			"korean": "다른 방법 시도",
-			"german": "Probieren Sie andere Methoden aus"
-		},
-		"2fa-setup-title21": {
-			"mandarin": "第 1 步：保存您的设备",
-			"spanish": "Paso 1: Guarde su dispositivo",
-			"english": "Step 1: Save your device",
-			"japanese": "ステップ1：デバイスを保存する",
-			"korean": "1단계: 기기 저장",
-			"german": "Schritt 1: Speichern Sie Ihr Gerät"
-		},
-		"2fa-setup-step3-next2": {
-			"mandarin": "核实",
-			"spanish": "Verificar",
-			"english": "Verify",
-			"japanese": "確認",
-			"korean": "확인하다",
-			"german": "Verifizieren"
-		},
-		"migrate-list2": {
-			"mandarin": "由SSO和设备保护",
-			"spanish": "Asegurado por SSO y dispositivo",
-			"english": "Secured by SSO and device",
-			"japanese": "SSOとデバイスによって保護されています",
-			"korean": "SSO 및 장치로 보호",
-			"german": "Durch SSO und Gerät gesichert"
-		},
-		"2fa-verify-step1-verify": {
-			"mandarin": "核实",
-			"spanish": "Verificar",
-			"english": "Verify",
-			"japanese": "確認",
-			"korean": "검증",
-			"german": "Verifizieren"
-		}
-	}
+  "login": {
+    "2fa-verify-share-send": {
+      "mandarin": "发送请求",
+      "spanish": "Enviar petición",
+      "english": "Send request",
+      "japanese": "リクエストを送信",
+      "korean": "요청 보내기",
+      "german": "Anfrage senden",
+      "portuguese": "Enviar pedido"
+    },
+    "2fa-setup-step5-return-app": {
+      "mandarin": "返回申请",
+      "spanish": "Volver a la aplicación",
+      "english": "Return to application",
+      "japanese": "アプリケーションに戻る",
+      "korean": "애플리케이션으로 돌아가기",
+      "german": "Zurück zur Anwendung",
+      "portuguese": "Voltar ao aplicativo"
+    },
+    "2fa-setup-step3-sub21": {
+      "mandarin": "粘贴您发送到 {0} 的辅助短语",
+      "spanish": "Pegue su frase de recuperación enviada a {0}",
+      "english": "Paste your recovery phrase sent to {0}",
+      "japanese": "{0}に送信されたリカバリフレーズを貼り付けます",
+      "korean": "{0}(으)로 전송된 복구 문구를 붙여넣으세요.",
+      "german": "Fügen Sie Ihren Wiederherstellungssatz ein, der an {0} gesendet wurde",
+      "portuguese": "Cole sua frase de recuperação enviada para {0}"
+    },
+    "reconstruct-backup-phrase-desc-2": {
+      "mandarin": "确认已设置的备份集",
+      "spanish": "Compruebe el conjunto de copia de seguridad establecido",
+      "english": "Verify with your backup phrase that was setup on",
+      "japanese": "セットしたバックアップセットを確認する",
+      "korean": "설정된 백업 세트 확인",
+      "german": "Bestätigen Sie mit Ihrem Backup-Satz, der eingerichtet wurde",
+      "portuguese": "Verifique com sua frase de recuperação que foi configurada em"
+    },
+    "2fa-verify-share-subhead": {
+      "mandarin": "您需要以下其中一项才能登录",
+      "spanish": "Necesita uno de los siguientes para iniciar sesión",
+      "english": "You need one of the following to login",
+      "japanese": "ログインするには、次のいずれかが必要です",
+      "korean": "로그인하려면 다음 중 하나가 필요합니다.",
+      "german": "Sie benötigen eine der folgenden Möglichkeiten, um sich anzumelden",
+      "portuguese": "Você precisa de um dos seguintes para fazer login"
+    },
+    "reconstruct-biometrics-verify": {
+      "mandarin": "使用Touch ID / Face ID进行验证",
+      "spanish": "Verificar con Touch ID / Face ID",
+      "english": "Verify with Touch ID / Face ID",
+      "japanese": "Touch ID / FaceIDで確認する",
+      "korean": "Touch ID / Face ID로 확인",
+      "german": "Überprüfen Sie mit Touch ID / Face ID",
+      "portuguese": "Verificar com Touch ID / Face ID"
+    },
+    "reconstruct-multiple-transports-verify": {
+      "english": "Verify now",
+      "german": "Jetzt Prüfen",
+      "mandarin": "立即验证",
+      "korean": "지금 인증하십시오",
+      "japanese": "今すぐ確認してください",
+      "spanish": "Verifica ahora",
+      "portuguese": "Verifique agora"
+    },
+    "2fa-setup-step3-next": {
+      "mandarin": "继续",
+      "spanish": "Continuar",
+      "english": "Continue",
+      "japanese": "継続する",
+      "korean": "계속하다",
+      "german": "Weitermachen",
+      "portuguese": "Continuar"
+    },
+    "migrate-desc1": {
+      "mandarin": "最新版本的Torus Wallet由OpenLogin提供支持。",
+      "spanish": "La última versión de Torus Wallet funciona con OpenLogin.",
+      "english": "The latest version of Torus Wallet is powered by OpenLogin.",
+      "japanese": "Torus Walletの最新バージョンは、OpenLoginを利用しています。",
+      "korean": "최신 버전의 Torus Wallet은 OpenLogin에 의해 구동됩니다.",
+      "german": "Die neueste Version von Torus Wallet wird von OpenLogin unterstützt.",
+      "portuguese": "A versão mais recente do Torus Wallet é fornecida pelo OpenLogin."
+    },
+    "2fa-setup-title1": {
+      "mandarin": "保护您的帐户",
+      "spanish": "Asegure su cuenta",
+      "english": "Secure your account",
+      "japanese": "アカウントを保護する",
+      "korean": "계정 보안",
+      "german": "Sichern Sie Ihr Konto",
+      "portuguese": "Proteja sua conta"
+    },
+    "register-password-title": {
+      "mandarin": "设置帐号密码",
+      "spanish": "Configurar la contraseña de la cuenta",
+      "english": "Set up account password",
+      "japanese": "アカウントのパスワードを設定する",
+      "korean": "계정 비밀번호 설정",
+      "german": "Richten Sie das Kontokennwort ein",
+      "portuguese": "Configurar senha da conta"
+    },
+    "reconstruct-support": {
+      "mandarin": "联系支持",
+      "spanish": "Soporte de contacto",
+      "english": "Contact support",
+      "japanese": "サポート問い合わせ先",
+      "korean": "연락처 지원",
+      "german": "Kontaktieren Sie Support",
+      "portuguese": "Entre em contato com o suporte"
+    },
+    "returning-sign-in-header1": {
+      "mandarin": "使用其他帐户",
+      "spanish": "Usa otra cuenta",
+      "english": "Use another account",
+      "japanese": "別のアカウントを使用する",
+      "korean": "다른 계정 사용",
+      "german": "Benutze einen anderen Account",
+      "portuguese": "Usar outra conta"
+    },
+    "2fa-verify-multi-head": {
+      "mandarin": "允许从您保存的浏览器访问",
+      "spanish": "Permitir el acceso desde su navegador guardado",
+      "english": "Allow access from your saved browser",
+      "japanese": "保存したブラウザからのアクセスを許可する",
+      "korean": "저장된 브라우저에서 액세스 허용",
+      "german": "Erlauben Sie den Zugriff von Ihrem gespeicherten Browser",
+      "portuguese": "Permita o acesso do seu navegador salvo"
+    },
+    "social-2fa-subtitle-1": {
+      "mandarin": "用任何社会帐户登录将其设置为恢复因素",
+      "spanish": "Inicie sesión con cualquiera de la cuenta social para establecerla como factor de recuperación",
+      "english": "Login with any of the social account to set it as recovery factor",
+      "japanese": "ソーシャルアカウントのいずれかでログインして、回復要因として設定します",
+      "korean": "소셜 계정에 로그인하여 복구 계수로 설정",
+      "german": "Melden Sie sich mit einem der sozialen Konto an, um es als Wiederherstellungsfaktor festzulegen",
+      "portuguese": "Faça login com qualquer conta social para defini-la como fator de recuperação"
+    },
+    "social-2fa-warning-text": {
+      "mandarin": "您正在使用同一电子邮件进行帐户登录和社会因素。这是不安全的。您还想继续吗？",
+      "spanish": "Está utilizando el mismo correo electrónico para el inicio de sesión de la cuenta y el factor social. Esto es inseguro. ¿Todavía te gustaría continuar?",
+      "english": "You are using the same email for account login and social factor. This is insecure. Would you still like to proceed?",
+      "japanese": "アカウントログインとソーシャルファクターに同じメールを使用しています。これは不安です。まだ進みたいですか？",
+      "korean": "계정 로그인 및 소셜 요소에 동일한 이메일을 사용하고 있습니다. 이것은 안전하지 않습니다. 아직도 진행하고 싶습니까?",
+      "german": "Sie verwenden dieselbe E -Mail für Kontoanmeldung und sozialer Faktor. Das ist unsicher. Möchten Sie immer noch fortfahren?",
+      "portuguese": "Você está usando o mesmo e-mail para login da conta e fator social. Isso é inseguro. Você ainda gostaria de prosseguir?"
+    },
+    "2fa-setup-step3-download-phrase": {
+      "mandarin": "下载短语",
+      "spanish": "Descargar frase",
+      "english": "Download phrase",
+      "japanese": "フレーズをダウンロード",
+      "korean": "구문 다운로드",
+      "german": "Redewendung herunterladen",
+      "portuguese": "Baixar frase"
+    },
+    "2fa-setup-step1-sub2": {
+      "mandarin": "为您的帐户添加额外的安全层",
+      "spanish": "Agregue una capa adicional de seguridad a su cuenta",
+      "english": "Add an extra layer of security to your account",
+      "japanese": "アカウントにセキュリティの層を追加します",
+      "korean": "계정에 보안 계층 추가",
+      "german": "Fügen Sie Ihrem Konto eine zusätzliche Sicherheitsebene hinzu",
+      "portuguese": "Adicione uma camada extra de segurança à sua conta"
+    },
+    "2fa-verify-title2": {
+      "mandarin": "2FA 激活",
+      "spanish": "2FA activado",
+      "english": "2FA activated",
+      "japanese": "2FAがアクティブ化",
+      "korean": "2FA 활성화",
+      "german": "2FA aktiviert",
+      "portuguese": "2FA ativado"
+    },
+    "2fa-setup-step5-next": {
+      "mandarin": "完毕",
+      "spanish": "Hecho",
+      "english": "Done",
+      "japanese": "終わり",
+      "korean": "완료",
+      "german": "Fertig",
+      "portuguese": "Feito"
+    },
+    "reconstruct-fail": {
+      "mandarin": "无法找回帐户？",
+      "spanish": "¿No puede recuperar la cuenta?",
+      "english": "Unable to recover account?",
+      "japanese": "アカウントを回復できませんか？",
+      "korean": "계정을 복구 할 수 없습니까?",
+      "german": "Konto kann nicht wiederhergestellt werden?",
+      "portuguese": "Não é possível recuperar a conta?"
+    },
+    "2fa-setup-step2-sub2": {
+      "mandarin": "使用当前浏览器批准来自新设备/浏览器的访问。",
+      "spanish": "Utilice el navegador actual para aprobar el acceso desde nuevos dispositivos / navegadores.",
+      "english": "Use the current browser to approve access from new devices/browsers.",
+      "japanese": "現在のブラウザを使用して、新しいデバイス/ブラウザからのアクセスを承認します。",
+      "korean": "현재 브라우저를 사용하여 새 장치/브라우저에서 액세스를 승인합니다.",
+      "german": "Verwenden Sie den aktuellen Browser, um den Zugriff von neuen Geräten/Browsern zu genehmigen.",
+      "portuguese": "Use o navegador atual para aprovar o acesso de novos dispositivos/navegadores."
+    },
+    "reconstruct-device-desc1": {
+      "mandarin": "登录到",
+      "spanish": "Iniciar sesión en",
+      "english": "Login to",
+      "japanese": "ログインする",
+      "korean": "로그인",
+      "german": "Einloggen in",
+      "portuguese": "Logar em"
+    },
+    "migrate-title": {
+      "mandarin": "变得简单而安全",
+      "spanish": "hecho simple y seguro con",
+      "english": "made simple and secure with",
+      "japanese": "シンプルで安全に",
+      "korean": "간단하고 안전하게",
+      "german": "einfach und sicher gemacht mit",
+      "portuguese": "simples e seguro com"
+    },
+    "social-2fa-warn-text-2": {
+      "mandarin": "在登录页面上使用此社交因素签名将为您提供一个新帐户。",
+      "spanish": "Iniciar sesión con este factor social en la página de inicio de sesión le dará una nueva cuenta.",
+      "english": "Signing in with this Social factor at the login page will give you a new account.",
+      "japanese": "ログインページでこのソーシャルファクターにサインインすると、新しいアカウントが提供されます。",
+      "korean": "로그인 페이지 에서이 소셜 요소에 로그인하면 새 계정이 제공됩니다.",
+      "german": "Wenn Sie sich bei diesem sozialen Faktor auf der Anmeldeseite anmelden, erhalten Sie ein neues Konto.",
+      "portuguese": "Entrar com este fator social na página de login lhe dará uma nova conta."
+    },
+    "reconstruct-always-skip": {
+      "mandarin": "总是跳过",
+      "spanish": "Saltar siempre",
+      "english": "Always skip",
+      "japanese": "常にスキップする",
+      "korean": "항상 건너뛰기",
+      "german": "Immer überspringen",
+      "portuguese": "Sempre pular"
+    },
+    "2fa-setup-step1-desc21": {
+      "mandarin": "我们强烈建议为像您这样的活跃用户设置 2FA。",
+      "spanish": "Recomendamos encarecidamente una configuración 2FA para un usuario activo como usted.",
+      "english": "We highly recommend a 2FA set up for an active user like yourself.",
+      "japanese": "あなたのようなアクティブユーザーには2FAを設定することを強くお勧めします。",
+      "korean": "귀하와 같은 활성 사용자를 위해 2FA 설정을 적극 권장합니다.",
+      "german": "Wir empfehlen dringend ein 2FA-Setup für einen aktiven Benutzer wie Sie.",
+      "portuguese": "Recomendamos fortemente uma configuração 2FA para um usuário ativo como você."
+    },
+    "2fa-setup-step3-copy-phrase": {
+      "mandarin": "复制短语",
+      "spanish": "Copiar frase",
+      "english": "Copy phrase",
+      "japanese": "フレーズをコピーする",
+      "korean": "문구 복사",
+      "german": "Satz kopieren",
+      "portuguese": "Copiar frase"
+    },
+    "2fa-verify-recovery-placeholder": {
+      "mandarin": "恢复短语",
+      "spanish": "Frase de recuperación",
+      "english": "Recovery phrase",
+      "japanese": "回復フレーズ",
+      "korean": "복구 문구",
+      "german": "Wiederherstellungsphrase",
+      "portuguese": "Frase de recuperação"
+    },
+    "2fa-verify-share-resend": {
+      "mandarin": "重新发送请求",
+      "spanish": "Reenviar solicitud",
+      "english": "Resend request",
+      "japanese": "再送信リクエスト",
+      "korean": "재전송 요청",
+      "german": "Anfrage erneut senden",
+      "portuguese": "Reenviar solicitação"
+    },
+    "reconstruct-password-desc": {
+      "mandarin": "在此处输入您的帐户恢复密码",
+      "spanish": "Ingrese la contraseña de recuperación de su cuenta aquí",
+      "english": "Enter your account recovery password here",
+      "japanese": "ここにアカウント回復パスワードを入力してください",
+      "korean": "여기에 계정 복구 비밀번호를 입력하세요.",
+      "german": "Geben Sie hier Ihr Passwort für die Kontowiederherstellung ein",
+      "portuguese": "Digite sua senha de recuperação de conta aqui"
+    },
+    "2fa-setup-step3-cancel": {
+      "mandarin": "后退",
+      "spanish": "atrás",
+      "english": "Back",
+      "japanese": "戻る",
+      "korean": "뒤",
+      "german": "Zurück",
+      "portuguese": "Voltar"
+    },
+    "2fa-verify-step1-panel2": {
+      "mandarin": "恢复短语",
+      "spanish": "Frase de recuperación",
+      "english": "Recovery phrase",
+      "japanese": "回復フレーズ",
+      "korean": "복구 문구",
+      "german": "Wiederherstellungsphrase",
+      "portuguese": "Frase de recuperação"
+    },
+    "popup-title": {
+      "mandarin": "欢迎登机",
+      "spanish": "La bienvenida a bordo",
+      "english": "Welcome onboard",
+      "japanese": "ご乗車（搭乗）ありがとうございます",
+      "korean": "보드에 오신 것을 환영합니다",
+      "german": "Willkommen an Bord",
+      "portuguese": "Bem-vindo a bordo"
+    },
+    "2fa-setup-step5-sub2": {
+      "mandarin": "在 app.openlogin.com 上管理未来的帐户设置",
+      "spanish": "Administre la configuración de la cuenta futura en app.openlogin.com",
+      "english": "Manage future account settings on app.openlogin.com",
+      "japanese": "app.openlogin.comで将来のアカウント設定を管理します",
+      "korean": "app.openlogin.com에서 향후 계정 설정 관리",
+      "german": "Verwalten Sie zukünftige Kontoeinstellungen auf app.openlogin.com",
+      "portuguese": "Gerencie as configurações futuras da conta em app.openlogin.com"
+    },
+    "reconstruct-password-placeholder": {
+      "mandarin": "户口密码",
+      "spanish": "Contraseña de la cuenta",
+      "english": "Account password",
+      "japanese": "アカウントパスワード",
+      "korean": "계정 비밀번호",
+      "german": "Konto Passwort",
+      "portuguese": "Senha da conta"
+    },
+    "reconstruct-device-title": {
+      "mandarin": "设备",
+      "spanish": "Dispositivos",
+      "english": "Device(s)",
+      "japanese": "デバイス",
+      "korean": "장치",
+      "german": "Geräte",
+      "portuguese": "Dispositivo(s)"
+    },
+    "2fa-verify-recovery-title": {
+      "mandarin": "恢复代码",
+      "spanish": "Código de recuperación",
+      "english": "Recovery code",
+      "japanese": "リカバリコード",
+      "korean": "복구 코드",
+      "german": "Wiederherstellungscode",
+      "portuguese": "Código de recuperação"
+    },
+    "migrate-list1": {
+      "mandarin": "支持面部识别/触摸识别",
+      "spanish": "Soporta Face ID / Touch ID",
+      "english": "Supports Face ID / Touch ID",
+      "japanese": "Face ID / TouchIDをサポート",
+      "korean": "Face ID / Touch ID 지원",
+      "german": "Unterstützt Face ID / Touch ID",
+      "portuguese": "Suporta Face ID / Touch ID"
+    },
+    "register-biometrics-title": {
+      "mandarin": "继续使用Face ID或Touch ID",
+      "spanish": "Continuar con Face ID o Touch ID",
+      "english": "Continue with Face ID or Touch ID",
+      "japanese": "FaceIDまたはTouchIDに進む",
+      "korean": "Face ID 또는 Touch ID로 계속",
+      "german": "Fahren Sie mit Face ID oder Touch ID fort",
+      "portuguese": "Continue com Face ID ou Touch ID"
+    },
+    "register-multiple-transports-webauthn-title": {
+      "english": "Continue with Biometrics or any Web Authentication Methods",
+      "german": "Fahren Sie mit Biometrie oder Webauthentifizierungsmethoden fort",
+      "mandarin": "继续使用生物识别技术或任何Web身份验证方法",
+      "korean": "생체 인식 또는 웹 인증 방법을 계속하십시오",
+      "japanese": "生体認証またはWeb認証方法を継続します",
+      "spanish": "Continuar con biometría o cualquier método de autenticación web",
+      "portuguese": "Continue com a biometria ou qualquer método de autenticação da Web"
+    },
+    "register-external-transports-webauthn-title": {
+      "english": "Continue with any Web Authentication Methods",
+      "german": "Fahren Sie mit allen Webauthentifizierungsmethoden fort",
+      "mandarin": "继续使用任何Web身份验证方法",
+      "korean": "웹 인증 방법을 계속하십시오",
+      "japanese": "Web認証方法を続行します",
+      "spanish": "Continuar con cualquier método de autenticación web",
+      "portuguese": "Continue com qualquer método de autenticação da web"
+    },
+    "popup-view-more": {
+      "mandarin": "查看更多选项",
+      "spanish": "Ver más opciones",
+      "english": "View more options",
+      "japanese": "その他のオプションを表示",
+      "korean": "더 많은 옵션보기",
+      "german": "Weitere Optionen anzeigen",
+      "portuguese": "Ver mais opções"
+    },
+    "returning-confirm-title": {
+      "mandarin": "我们只是想确定一下。",
+      "spanish": "Solo queremos estar seguros.",
+      "english": "We just want to be sure.",
+      "japanese": "確認したいだけです。",
+      "korean": "우리는 확신하고 싶습니다.",
+      "german": "Wir wollen nur sicher sein.",
+      "portuguese": "Só queremos ter certeza."
+    },
+    "migrate-subtitle": {
+      "mandarin": "迁移您的tKey",
+      "spanish": "Migrar su tKey",
+      "english": "Migrating your tKey",
+      "japanese": "tKeyの移行",
+      "korean": "tKey 마이그레이션",
+      "german": "Migrieren Sie Ihren tKey",
+      "portuguese": "Migrando sua tKey"
+    },
+    "2fa-setup-step4-recovery": {
+      "mandarin": "恢复短语",
+      "spanish": "Frase de recuperación",
+      "english": "Recovery phrase",
+      "japanese": "回復フレーズ",
+      "korean": "복구 문구",
+      "german": "Wiederherstellungsphrase",
+      "portuguese": "Frase de recuperação"
+    },
+    "reconstruct-device-prev1": {
+      "mandarin": "登录到您的",
+      "spanish": "Inicie sesión en su",
+      "english": "Login to your",
+      "japanese": "あなたのログイン",
+      "korean": "귀하의",
+      "german": "Melden Sie sich bei Ihrem an",
+      "portuguese": "Entre no seu"
+    },
+    "register-backup-phrase-confirm-desc3": {
+      "mandarin": "重新输入辅助邮箱",
+      "spanish": "vuelve a ingresar el correo de recuperación",
+      "english": "re-enter recovery email",
+      "japanese": "リカバリメールを再入力してください",
+      "korean": "복구 이메일 다시 입력",
+      "german": "wiederherstellungs-E-Mail erneut eingeben",
+      "portuguese": "digite novamente o e-mail de recuperação"
+    },
+    "2fa-verify-step1-rec-label": {
+      "mandarin": "输入恢复短语",
+      "spanish": "Ingrese la frase de recuperación",
+      "english": "Enter recovery phrase",
+      "japanese": "回復フレーズを入力してください",
+      "korean": "복구 문구 입력",
+      "german": "Geben Sie den Wiederherstellungssatz ein",
+      "portuguese": "Digite a frase de recuperação"
+    },
+    "migrate-continue": {
+      "mandarin": "继续",
+      "spanish": "Continuar",
+      "english": "Continue",
+      "japanese": "継続する",
+      "korean": "계속하다",
+      "german": "Fortsetzen",
+      "portuguese": "Continuar"
+    },
+    "2fa-setup-step3-enter-email": {
+      "mandarin": "输入你的电子邮箱地址",
+      "spanish": "Ingrese su dirección de correo electrónico",
+      "english": "Enter your email address",
+      "japanese": "メールアドレスを入力してください",
+      "korean": "이메일 주소를 입력하세요",
+      "german": "Geben sie ihre E-Mailadresse ein",
+      "portuguese": "Insira o seu endereço de email"
+    },
+    "reconstruct-password-title": {
+      "mandarin": "找回密码",
+      "spanish": "Contraseña de recuperación",
+      "english": "Recovery password",
+      "japanese": "回復パスワード",
+      "korean": "복구 암호",
+      "german": "Passwort zum Zurücksetzen",
+      "portuguese": "Senha de recuperação"
+    },
+    "2fa-setup-step5-sub1": {
+      "mandarin": "您的 2FA 已激活！",
+      "spanish": "¡Su 2FA ha sido activado!",
+      "english": "Your 2FA has been activated!",
+      "japanese": "2FAがアクティブになりました！",
+      "korean": "2FA가 활성화되었습니다!",
+      "german": "Ihre 2FA wurde aktiviert!",
+      "portuguese": "Seu 2FA foi ativado!"
+    },
+    "2fa-setup-title32": {
+      "mandarin": "第 3 步：验证恢复短语",
+      "spanish": "Paso 3: Verificar la frase de recuperación",
+      "english": "Step 3: Verify Recovery Phrase",
+      "japanese": "ステップ3：リカバリフレーズを確認する",
+      "korean": "3단계: 복구 문구 확인",
+      "german": "Schritt 3: Überprüfen Sie die Wiederherstellungsphrase",
+      "portuguese": "Etapa 3: verificar a frase de recuperação"
+    },
+    "2fa-setup-step3-verified": {
+      "mandarin": "已验证",
+      "spanish": "Verificado",
+      "english": "Verified",
+      "japanese": "確認済み",
+      "korean": "확인됨",
+      "german": "Verifiziert",
+      "portuguese": "Verificado"
+    },
+    "register-backup-phrase-additional-security-desc2": {
+      "mandarin": "如果您丢失带有 Touch ID / Face ID 的设备，它可以帮助您恢复帐户。",
+      "spanish": "Le ayuda con la recuperación de la cuenta en caso de que pierda su dispositivo con Touch ID / Face ID.",
+      "english": "It helps you with account recovery in case you lose your device with Touch ID / Face ID.",
+      "japanese": "Touch ID / Face ID でデバイスを紛失した場合のアカウント回復に役立ちます。",
+      "korean": "Touch ID / Face ID로 기기를 분실 한 경우 계정 복구에 도움이됩니다.",
+      "german": "Es hilft Ihnen bei der Kontowiederherstellung, falls Sie Ihr Gerät mit Touch ID / Face ID verlieren.",
+      "portuguese": "Ele ajuda na recuperação da conta caso você perca seu dispositivo com Touch ID / Face ID."
+    },
+    "2fa-setup-title2": {
+      "mandarin": "设置 2FA",
+      "spanish": "Configurar 2FA",
+      "english": "Set up 2FA",
+      "japanese": "2FAを設定する",
+      "korean": "2FA 설정",
+      "german": "2FA einrichten",
+      "portuguese": "Configurar 2FA"
+    },
+    "2fa-verify-verify": {
+      "mandarin": "核实",
+      "spanish": "Verificar",
+      "english": "Verify",
+      "japanese": "確認",
+      "korean": "검증",
+      "german": "Verifizieren",
+      "portuguese": "Verificar"
+    },
+    "2fa-setup-step3-enter-recovery": {
+      "mandarin": "输入您的辅助短语",
+      "spanish": "Introduce tu frase de recuperación",
+      "english": "Enter your recovery phrase",
+      "japanese": "回復フレーズを入力してください",
+      "korean": "복구 문구를 입력하세요",
+      "german": "Geben Sie Ihren Wiederherstellungssatz ein",
+      "portuguese": "Digite sua frase de recuperação"
+    },
+    "social-2fa-heading": {
+      "mandarin": "设定社会恢复因素",
+      "spanish": "Establecer factor de recuperación social",
+      "english": "Set Social recovery factor",
+      "japanese": "社会的回復要因を設定します",
+      "korean": "사회 복구 요인을 설정하십시오",
+      "german": "Setzen Sie den sozialen Genesungsfaktor",
+      "portuguese": "Definir fator de recuperação social"
+    },
+    "mpc-2fa-verify-step1-rec-label": {
+      "mandarin": "输入恢复系数",
+      "spanish": "Ingrese el factor de recuperación",
+      "english": "Enter recovery factor",
+      "japanese": "回復係数を入力してください",
+      "korean": "회복 계수 입력",
+      "german": "Erholungsfaktor eingeben",
+      "portuguese": "Insira o fator de recuperação"
+    },
+    "reconstruct-device-desc": {
+      "mandarin": "从下面存储的浏览器登录到{0}以验证您的身份。",
+      "spanish": "Inicie sesión en {0} desde el navegador almacenado a continuación para verificar su identidad.",
+      "english": "Login to {0} from the stored browser below to verify your identity.",
+      "japanese": "以下の保存されているブラウザから{0}にログインして、本人確認を行ってください。",
+      "korean": "아래 저장된 브라우저에서 {0}에 로그인하여 신원을 확인하세요.",
+      "german": "Melden Sie sich über den unten gespeicherten Browser bei {0} an, um Ihre Identität zu überprüfen.",
+      "portuguese": "Faça login em {0} no navegador armazenado abaixo para verificar sua identidade."
+    },
+    "2fa-setup-step2-current-browser": {
+      "mandarin": "当前浏览器",
+      "spanish": "Navegador actual",
+      "english": "Current browser",
+      "japanese": "現在のブラウザ",
+      "korean": "현재 브라우저",
+      "german": "Aktueller Browser",
+      "portuguese": "Navegador atual"
+    },
+    "2fa-setup-step4-cancel": {
+      "mandarin": "后退",
+      "spanish": "atrás",
+      "english": "Back",
+      "japanese": "戻る",
+      "korean": "뒤",
+      "german": "Zurück",
+      "portuguese": "Voltar"
+    },
+    "social-2fa-view-less": {
+      "mandarin": "少查看",
+      "spanish": "Ver menos",
+      "english": "View less",
+      "japanese": "表示が少なくなります",
+      "korean": "덜보십시오",
+      "german": "Weniger anzeigen",
+      "portuguese": "Ver menos"
+    },
+    "2fa-verify-success-title": {
+      "mandarin": "2FA 验证",
+      "spanish": "2FA verificado",
+      "english": "2FA verified",
+      "japanese": "2FA検証済み",
+      "korean": "2FA 인증",
+      "german": "2FA verifiziert",
+      "portuguese": "2FA verificado"
+    },
+    "popup-terms": {
+      "mandarin": "使用条款",
+      "spanish": "Condiciones de uso",
+      "english": "Terms of use",
+      "japanese": "利用規約",
+      "korean": "이용 약관",
+      "german": "Nutzungsbedingungen",
+      "portuguese": "Termos de uso"
+    },
+    "migrate-list3": {
+      "mandarin": "受保护的用户数据和隐私",
+      "spanish": "Privacidad y datos de usuario protegidos",
+      "english": "Protected user Data and Privacy",
+      "japanese": "保護されたユーザーデータとプライバシー",
+      "korean": "보호 된 사용자 데이터 및 개인 정보",
+      "german": "Geschützte Benutzerdaten und Datenschutz",
+      "portuguese": "Dados e privacidade protegidos do usuário"
+    },
+    "popup-continue": {
+      "mandarin": "继续",
+      "spanish": "Continuar",
+      "english": "Continue",
+      "japanese": "継続する",
+      "korean": "계속하다",
+      "german": "Fortsetzen",
+      "portuguese": "Continuar"
+    },
+    "reconstruct-backup-phrase-title": {
+      "mandarin": "备用词组",
+      "spanish": "Frase de respaldo",
+      "english": "Backup phrase",
+      "japanese": "バックアップフレーズ",
+      "korean": "백업 문구",
+      "german": "Sicherungssatz",
+      "portuguese": "Frase de backup"
+    },
+    "2fa-verify-save-nosave": {
+      "mandarin": "下次吧",
+      "spanish": "Quizás la próxima vez",
+      "english": "Maybe next time",
+      "japanese": "また今度",
+      "korean": "아마 다음 번에",
+      "german": "Vielleicht nächstes Mal",
+      "portuguese": "Talvez na próxima vez"
+    },
+    "2fa-setup-step2-save-device": {
+      "mandarin": "保存当前设备",
+      "spanish": "Guardar dispositivo actual",
+      "english": "Save current device",
+      "japanese": "現在のデバイスを保存",
+      "korean": "현재 장치 저장",
+      "german": "Aktuelles Gerät speichern",
+      "portuguese": "Salvar dispositivo atual"
+    },
+    "2fa-setup-step4-sub22": {
+      "mandarin": "粘贴发送到您的电子邮件的恢复短语 {0}",
+      "spanish": "Pega la frase de recuperación enviada a tu correo electrónico {0}",
+      "english": "Paste the recovery phrase sent to your email {0}",
+      "japanese": "メールに送信されたリカバリフレーズを貼り付けます{0}",
+      "korean": "이메일로 전송된 복구 문구를 붙여넣으세요 {0}",
+      "german": "Fügen Sie den Wiederherstellungssatz ein, der an Ihre E-Mail-Adresse {0} gesendet wurde.",
+      "portuguese": "Cole a frase de recuperação enviada para seu e-mail {0}"
+    },
+    "returning-sign-in-header2": {
+      "mandarin": "您似乎尚未登录帐户",
+      "spanish": "Parece que aún no ha iniciado sesión en una cuenta",
+      "english": "It seems like you are not signed in to an account yet",
+      "japanese": "アカウントにまだサインインしていないようです",
+      "korean": "아직 계정에 로그인하지 않은 것 같습니다.",
+      "german": "Anscheinend bist du noch nicht bei einem Konto angemeldet",
+      "portuguese": "Parece que você ainda não está conectado a uma conta"
+    },
+    "register-backup-phrase-confirm-desc1": {
+      "mandarin": "我确认我已收到恢复电子邮件。",
+      "spanish": "Confirmo que he recibido el correo de recuperación.",
+      "english": "I confirm that I have received the recovery email.",
+      "japanese": "復旧メールを受信したことを確認しました。",
+      "korean": "我确认我已收到恢复电子邮件。",
+      "german": "Ich bestätige, dass ich die Wiederherstellungs-E-Mail erhalten habe.",
+      "portuguese": "Confirmo que recebi o e-mail de recuperação."
+    },
+    "2fa-verify-recovery-label": {
+      "mandarin": "输入恢复短语",
+      "spanish": "Ingrese la frase de recuperación",
+      "english": "Enter recovery phrase",
+      "japanese": "回復フレーズを入力してください",
+      "korean": "복구 문구 입력",
+      "german": "Geben Sie den Wiederherstellungssatz ein",
+      "portuguese": "Digite a frase de recuperação"
+    },
+    "constructYourKey": {
+      "mandarin": "构建您的密钥",
+      "spanish": "Construyendo tu clave en",
+      "english": "Constructing your key on",
+      "japanese": "キーを作成する",
+      "korean": "키 구성",
+      "german": "Bauen Sie Ihren Schlüssel auf",
+      "portuguese": "Construindo sua chave em"
+    },
+    "2fa-verify-save-head": {
+      "mandarin": "帐户已恢复",
+      "spanish": "Cuenta recuperada",
+      "english": "Account recovered",
+      "japanese": "アカウントが回復しました",
+      "korean": "계정 복구됨",
+      "german": "Konto wiederhergestellt",
+      "portuguese": "Conta recuperada"
+    },
+    "register-backup-phrase-desc": {
+      "mandarin": "包含备用短语的电子邮件将发送给您。如果您丢失了设备，它将帮助您进行帐户恢复。",
+      "spanish": "Se le enviará un correo electrónico con la frase de respaldo. Le ayuda con la recuperación de la cuenta en caso de que pierda su dispositivo.",
+      "english": "An email will be sent to you containing the backup phrase. It helps you with account recovery in case you lose your device.",
+      "japanese": "バックアップフレーズを記載したメールが送信されます。デバイスを紛失した場合のアカウントの復旧に役立ちます。",
+      "korean": "백업 문구가 포함 된 이메일이 전송됩니다.  기기 분실시 계정 복구에 도움이됩니다.",
+      "german": "Sie erhalten eine E-Mail mit der Sicherungsphrase. Sie hilft Ihnen bei der Wiederherstellung des Kontos, falls Sie Ihr Gerät verlieren.",
+      "portuguese": "Um e-mail será enviado para você contendo a frase de backup. Ele ajuda na recuperação da conta caso você perca seu dispositivo."
+    },
+    "2fa-setup-step3-note11": {
+      "mandarin": "笔记：",
+      "spanish": "Nota:",
+      "english": "Note:",
+      "japanese": "ノート：",
+      "korean": "메모:",
+      "german": "Notiz:",
+      "portuguese": "Observação:"
+    },
+    "verifier-webauth-desc": {
+      "mandarin": "继续使用WebAuthn",
+      "spanish": "Continuar con WebAuthn",
+      "english": "Continue with WebAuthn",
+      "japanese": "WebAuthnを続行します",
+      "korean": "WebAuthn으로 계속",
+      "german": "Fahren Sie mit WebAuthn fort",
+      "portuguese": "Continuar com WebAuthn"
+    },
+    "2fa-setup-step4-not-received": {
+      "mandarin": "没有收到吗？",
+      "spanish": "¿No lo recibiste?",
+      "english": "Did not receive it?",
+      "japanese": "受け取りませんでしたか？",
+      "korean": "받지 못하셨나요?",
+      "german": "Nicht erhalten?",
+      "portuguese": "Não recebeu?"
+    },
+    "reconstruct-biometrics-title": {
+      "mandarin": "支持面部识别/触摸识别的设备*",
+      "spanish": "Dispositivos habilitados con Face ID / Touch ID *",
+      "english": "Face ID / Touch ID enabled device(s) *",
+      "japanese": "Face ID / TouchID対応デバイス*",
+      "korean": "Face ID / Touch ID 지원 장치 *",
+      "german": "Face ID / Touch ID-fähige Geräte *",
+      "portuguese": "Dispositivo(s) habilitado(s) para Face ID / Touch ID*"
+    },
+    "reconstruct-multiple-transports-title": {
+      "english": "Web Authentication Enabled Device(s)",
+      "german": "Webauthentifizierung aktiviertes Geräte (en)",
+      "mandarin": "Web身份验证启用设备",
+      "korean": "웹 인증 활성화 장치",
+      "japanese": "Web認証有効化デバイス",
+      "spanish": "Dispositivo (s) de autenticación web",
+      "portuguese": "Dispositivo(s) habilitado(s) para utenticação da Web"
+    },
+    "returning-sign-in-desc": {
+      "mandarin": "继续执行以下操作之一以继续",
+      "spanish": "Continúe con uno de los siguientes para continuar",
+      "english": "Continue with one of the following to proceed",
+      "japanese": "次のいずれかを続行して続行します",
+      "korean": "계속하려면 다음 중 하나를 계속하십시오.",
+      "german": "Fahren Sie mit einem der folgenden Schritte fort, um fortzufahren",
+      "portuguese": "Continue com um dos seguintes"
+    },
+    "2fa-verify-step1-sub2": {
+      "mandarin": "您需要以下其中一项才能登录",
+      "spanish": "Necesita uno de los siguientes para iniciar sesión",
+      "english": "You need one of the following to login",
+      "japanese": "ログインするには、次のいずれかが必要です",
+      "korean": "로그인하려면 다음 중 하나가 필요합니다.",
+      "german": "Sie benötigen eine der folgenden Möglichkeiten, um sich anzumelden",
+      "portuguese": "Você precisa de um dos seguintes para fazer login"
+    },
+    "2fa-setup-step3-email": {
+      "mandarin": "电子邮件",
+      "spanish": "Correo electrónico",
+      "english": "Email",
+      "japanese": "Eメール",
+      "korean": "이메일",
+      "german": "Email",
+      "portuguese": "E-mail"
+    },
+    "2fa-setup-title4": {
+      "mandarin": "恢复验证",
+      "spanish": "Verificación de recuperación",
+      "english": "Recovery verification",
+      "japanese": "回復の検証",
+      "korean": "복구 확인",
+      "german": "Wiederherstellungsüberprüfung",
+      "portuguese": "Verificação de recuperação"
+    },
+    "2fa-setup-step4-resend": {
+      "mandarin": "重发",
+      "spanish": "Reenviar",
+      "english": "Resend",
+      "japanese": "再送",
+      "korean": "재전송",
+      "german": "Erneut senden",
+      "portuguese": "Reenviar"
+    },
+    "2fa-setup-step1-sub1": {
+      "mandarin": "启用 2 因素身份验证 (2FA)",
+      "spanish": "Habilitar la autenticación de 2 factores (2FA)",
+      "english": "Enable 2 Factor Authentication (2FA)",
+      "japanese": "2要素認証（2FA）を有効にする",
+      "korean": "2단계 인증(2FA) 활성화",
+      "german": "2-Faktor-Authentifizierung (2FA) aktivieren",
+      "portuguese": "Ativar autenticação de 2 fatores (2FA)"
+    },
+    "2fa-verify-multi-title": {
+      "mandarin": "{0} 台设备可用",
+      "spanish": "{0} dispositivos disponibles",
+      "english": "{0} devices available",
+      "japanese": "利用可能な{0}デバイス",
+      "korean": "사용 가능한 기기 {0}대",
+      "german": "{0} Geräte verfügbar",
+      "portuguese": "{0} dispositivos disponíveis"
+    },
+    "start": {
+      "mandarin": "开始使用",
+      "spanish": "Empezar",
+      "english": "Get Started",
+      "japanese": "はじめに",
+      "korean": "시작하다",
+      "german": "Loslegen",
+      "portuguese": "Começar"
+    },
+    "2fa-setup-step4-sub1": {
+      "mandarin": "验证您的恢复短语",
+      "spanish": "Verifica tu frase de recuperación",
+      "english": "Verify your recovery phrase",
+      "japanese": "回復フレーズを確認する",
+      "korean": "복구 문구 확인",
+      "german": "Bestätigen Sie Ihren Wiederherstellungssatz",
+      "portuguese": "Verifique sua frase de recuperação"
+    },
+    "popup-already": {
+      "mandarin": "已经有账户？",
+      "spanish": "¿Ya tienes una cuenta?",
+      "english": "Already have an account?",
+      "japanese": "すでにアカウントをお持ちですか？",
+      "korean": "이미 계정이 있습니까?",
+      "german": "Sie haben bereits ein Konto?",
+      "portuguese": "Já possui uma conta?"
+    },
+    "social-2fa-continue-text": {
+      "mandarin": "选择您喜欢如何继续",
+      "spanish": "Seleccione cómo le gusta continuar",
+      "english": "Select how you like to continue",
+      "japanese": "続行する方法を選択してください",
+      "korean": "계속하는 방법을 선택하십시오",
+      "german": "Wählen Sie, wie Sie fortfahren möchten",
+      "portuguese": "Selecione como você gostaria de continuar"
+    },
+    "social-2fa-view-more": {
+      "mandarin": "查看更多",
+      "spanish": "Ver más",
+      "english": "View more",
+      "japanese": "もっと見る",
+      "korean": "더보기",
+      "german": "Mehr sehen",
+      "portuguese": "Veja mais"
+    },
+    "2fa-setup-step3-confirm-phrase": {
+      "mandarin": "作为高级用户，我知道如果我丢失了此恢复短语，我将承担丢失帐户的风险。",
+      "spanish": "Como usuario avanzado, sé que si pierdo esta frase de recuperación, corro el riesgo de perder mi cuenta.",
+      "english": "As an advanced user, I know that if I lose this recovery phrase, I bear the risk of losing my account.",
+      "japanese": "上級ユーザーとして、この回復フレーズを失うと、アカウントを失うリスクがあることを私は知っています。",
+      "korean": "고급 사용자로서 나는 이 복구 문구를 잃어버리면 내 계정을 잃을 위험을 감수해야 한다는 것을 알고 있습니다.",
+      "german": "Als fortgeschrittener Benutzer weiß ich, dass ich das Risiko trage, mein Konto zu verlieren, wenn ich diesen Wiederherstellungssatz verliere.",
+      "portuguese": "Como usuário avançado, sei que, se perder esta frase de recuperação, corro o risco de perder minha conta."
+    },
+    "2fa-setup-step1-cancel": {
+      "mandarin": "下次吧",
+      "spanish": "Quizás la próxima vez",
+      "english": "Maybe next time",
+      "japanese": "また今度",
+      "korean": "아마 다음 번에",
+      "german": "Vielleicht nächstes Mal",
+      "portuguese": "Talvez na próxima vez"
+    },
+    "2fa-setup-step2-cancel": {
+      "mandarin": "后退",
+      "spanish": "atrás",
+      "english": "Back",
+      "japanese": "戻る",
+      "korean": "뒤",
+      "german": "Zurück",
+      "portuguese": "Voltar"
+    },
+    "popup-privacy": {
+      "mandarin": "隐私政策",
+      "spanish": "Política de privacidad",
+      "english": "Privacy policy",
+      "japanese": "個人情報保護方針",
+      "korean": "개인 정보 정책",
+      "german": "Datenschutz-Bestimmungen",
+      "portuguese": "Política de Privacidade"
+    },
+    "2fa-setup-step3-toggle1": {
+      "mandarin": "无需电子邮件即可保存我的恢复短语",
+      "spanish": "Guardar mi frase de recuperación sin correo electrónico",
+      "english": "Save my recovery phrase without email",
+      "japanese": "メールなしで回復フレーズを保存する",
+      "korean": "이메일 없이 내 복구 문구 저장",
+      "german": "Meine Wiederherstellungsphrase ohne E-Mail speichern",
+      "portuguese": "Salvar minha frase de recuperação sem e-mail"
+    },
+    "register-backup-phrase-confirm-desc2": {
+      "mandarin": "如果不，",
+      "spanish": "Que no,",
+      "english": "If not,",
+      "japanese": "そうでない場合は、",
+      "korean": "如果不，",
+      "german": "Wenn nicht,",
+      "portuguese": "Se não,"
+    },
+    "register-backup-phrase-desc2": {
+      "mandarin": "它可以帮助您在丢失设备时恢复帐户。",
+      "spanish": "Le ayuda con la recuperación de la cuenta en caso de que pierda su dispositivo.",
+      "english": "It helps you with account recovery in case you lose your device.",
+      "japanese": "デバイスを紛失した場合のアカウントの回復に役立ちます。",
+      "korean": "기기 분실시 계정 복구에 도움이됩니다.",
+      "german": "Es hilft Ihnen bei der Kontowiederherstellung, falls Sie Ihr Gerät verlieren.",
+      "portuguese": "Ele ajuda na recuperação da conta caso você perca seu dispositivo."
+    },
+    "mpc-2fa-setup-step4-sub1": {
+      "mandarin": "验证您的恢复系数",
+      "spanish": "Verifique su factor de recuperación",
+      "english": "Verify your recovery factor",
+      "japanese": "回復率を確認する",
+      "korean": "회복 계수 확인",
+      "german": "Überprüfen Sie Ihren Erholungsfaktor",
+      "portuguese": "Verifique seu fator de recuperação"
+    },
+    "register-continue": {
+      "mandarin": "继续",
+      "spanish": "Continuar",
+      "english": "Continue",
+      "japanese": "継続する",
+      "korean": "계속하다",
+      "german": "Fortsetzen",
+      "portuguese": "Continuar"
+    },
+    "social-2fa-warning-cta-2": {
+      "mandarin": "不，使用另一封电子邮件",
+      "spanish": "No, usa otro correo electrónico",
+      "english": "No, use another email",
+      "japanese": "いいえ、別のメールを使用してください",
+      "korean": "아니요, 다른 이메일을 사용하십시오",
+      "german": "Nein, verwenden Sie eine andere E -Mail",
+      "portuguese": "Não, use outro e-mail"
+    },
+    "reconstruct-always-skip-note": {
+      "mandarin": "通过选择“始终跳过”，您将不会收到再次登录 OpenLogin 帐户的提示。 如果您改变主意，您可以随时在“设置”中更改此首选项。",
+      "spanish": "Si selecciona 'Omitir siempre', no se le pedirá que vuelva a iniciar sesión en su cuenta de OpenLogin. Si cambia de opinión, puede cambiar esta preferencia en cualquier momento en 'Configuración'.",
+      "english": "By selecting 'Always skip', you will not be prompted to login to your OpenLogin account again. If you change your mind, you may change this preference anytime in 'Settings'.",
+      "japanese": "[常にスキップ]を選択すると、OpenLoginアカウントに再度ログインするように求められることはありません。 気が変わった場合は、「設定」でいつでもこの設定を変更できます。",
+      "korean": "'항상 건너뛰기'를 선택하면 OpenLogin 계정에 다시 로그인하라는 메시지가 표시되지 않습니다. 마음이 바뀌면 '설정'에서 언제든지 이 환경설정을 변경할 수 있습니다.",
+      "german": "Wenn Sie „Immer überspringen“ auswählen, werden Sie nicht aufgefordert, sich erneut bei Ihrem OpenLogin-Konto anzumelden. Wenn Sie Ihre Meinung ändern, können Sie diese Einstellung jederzeit in den \"Einstellungen\" ändern.",
+      "portuguese": "Ao selecionar 'Sempre pular', você não será solicitado a fazer login na sua conta OpenLogin novamente. Se mudar de ideia, você pode alterar essa preferência a qualquer momento em 'Configurações'."
+    },
+    "2fa-setup-step1-desc1": {
+      "mandarin": "每次登录需要 2 个身份验证因素",
+      "spanish": "Cada inicio de sesión requiere 2 factores para la autenticación",
+      "english": "Each login requires 2 factors for authentication",
+      "japanese": "各ログインには、認証のために2つの要素が必要です",
+      "korean": "각 로그인에는 인증을 위해 2가지 요소가 필요합니다.",
+      "german": "Jede Anmeldung erfordert 2 Faktoren zur Authentifizierung",
+      "portuguese": "Cada login requer 2 fatores para autenticação"
+    },
+    "mpc-2fa-setup-step4-sub22": {
+      "mandarin": "粘贴发送到您的电子邮件 {0} 的恢复因素",
+      "spanish": "Pegue el factor de recuperación enviado a su correo electrónico {0}",
+      "english": "Paste the recovery factor sent to your email {0}",
+      "japanese": "メール {0} に送信された回復係数を貼り付けます",
+      "korean": "이메일로 전송된 복구 요소를 붙여넣습니다. {0}",
+      "german": "Fügen Sie den an Ihre E-Mail gesendeten Wiederherstellungsfaktor ein {0}",
+      "portuguese": "Cole o fator de recuperação enviado para seu e-mail {0}"
+    },
+    "2fa-setup-step2-next": {
+      "mandarin": "继续",
+      "spanish": "Continuar",
+      "english": "Continue",
+      "japanese": "継続する",
+      "korean": "계속하다",
+      "german": "Weitermachen",
+      "portuguese": "Continuar"
+    },
+    "migrate-desc21": {
+      "mandarin": "享受Torus钱包的最新功能",
+      "spanish": "Para disfrutar de las últimas funciones de Torus Wallet",
+      "english": "To enjoy the latest features of the Torus Wallet",
+      "japanese": "トーラスウォレットの最新機能をお楽しみください",
+      "korean": "Torus Wallet의 최신 기능을 즐기려면",
+      "german": "Genießen Sie die neuesten Funktionen der Torus-Brieftasche",
+      "portuguese": "Para aproveitar os recursos mais recentes da Torus Wallet"
+    },
+    "mpc-2fa-verify-step1-panel2": {
+      "mandarin": "恢复系数",
+      "spanish": "Factor de recuperación",
+      "english": "Recovery factor",
+      "japanese": "回収率",
+      "korean": "회복 계수",
+      "german": "Erholungsfaktor",
+      "portuguese": "Fator de recuperação"
+    },
+    "social-2fa-warn-text-1": {
+      "mandarin": "这个社会因素仅充当备份共享，以恢复您的帐户链接到“ abcd@xyz.com”。",
+      "spanish": "Este factor social solo actúa como una participación de respaldo para recuperar su cuenta vinculada a \"abcd@xyz.com\".",
+      "english": "This Social factor only acts as a backup share to recover your account linked to “abcd@xyz.com”.",
+      "japanese": "このソーシャルファクターは、「abcd@xyz.com」にリンクされたアカウントを回復するためのバックアップ共有としてのみ機能します。",
+      "korean": "이 사회적 요소는 \"abcd@xyz.com\"에 링크 된 계정을 복구하기위한 백업 공유 역할을합니다.",
+      "german": "Dieser soziale Faktor fungiert nur als Sicherungsanteil, um Ihr mit „abcd@xyz.com“ verknüpfter Konto wiederherzustellen.",
+      "portuguese": "Este fator social atua apenas como um compartilhamento de backup para recuperar sua conta vinculada a “abcd@xyz.com”."
+    },
+    "mpc-2fa-setup-step3-download": {
+      "mandarin": "下载我的恢复因子",
+      "spanish": "Descargar mi factor de recuperación",
+      "english": "Download my recovery factor",
+      "japanese": "私のリカバリーファクターをダウンロードする",
+      "korean": "내 회복 인자 다운로드",
+      "german": "Laden Sie meinen Wiederherstellungsfaktor herunter",
+      "portuguese": "Baixar meu fator de recuperação"
+    },
+    "returning-exist-title": {
+      "mandarin": "欢迎回来，{0}",
+      "spanish": "Bienvenido de nuevo, {0}",
+      "english": "Welcome back, {0}",
+      "japanese": "おかえりなさい、{0}",
+      "korean": "다시 오신 것을 환영합니다. {0}",
+      "german": "Willkommen zurück, {0}",
+      "portuguese": "Bem-vindo de volta, {0}"
+    },
+    "returning-header-title": {
+      "mandarin": "登入",
+      "spanish": "Registrarse",
+      "english": "Sign in",
+      "japanese": "サインイン",
+      "korean": "로그인",
+      "german": "Einloggen",
+      "portuguese": "Entrar"
+    },
+    "2fa-verify-success-head": {
+      "mandarin": "成功的",
+      "spanish": "Exitoso",
+      "english": "Successful",
+      "japanese": "成功",
+      "korean": "성공적인",
+      "german": "Erfolgreich",
+      "portuguese": "Bem sucedido"
+    },
+    "2fa-setup-step3-next1": {
+      "mandarin": "完成设置",
+      "spanish": "Terminar de configurar",
+      "english": "Finish setting up",
+      "japanese": "セットアップを完了します",
+      "korean": "설정 완료",
+      "german": "Beenden Sie die Einrichtung",
+      "portuguese": "Concluir a configuração"
+    },
+    "reconstruct-device-desc2": {
+      "mandarin": "从以下任何设备中完成安全性验证。",
+      "spanish": "desde cualquiera de los siguientes dispositivos para completar la verificación de seguridad.",
+      "english": "from any of the following devices to complete the security verification.",
+      "japanese": "次のいずれかのデバイスからセキュリティ検証を完了します。",
+      "korean": "다음 장치 중 하나에서 보안 확인을 완료하십시오.",
+      "german": "von einem der folgenden Geräte, um die Sicherheitsüberprüfung abzuschließen.",
+      "portuguese": "de qualquer um dos seguintes dispositivos para concluir a verificação de segurança."
+    },
+    "reconstruct-backup-phrase-desc": {
+      "mandarin": "输入先前发送到您的辅助邮箱的备份短语。",
+      "spanish": "Ingrese la frase de respaldo enviada a su correo electrónico de recuperación anteriormente.",
+      "english": "Enter the backup phrase sent to your recovery email previously.",
+      "japanese": "以前にリカバリメールに送信されたバックアップフレーズを入力します。",
+      "korean": "이전에 복구 이메일로 전송 된 백업 문구를 입력하십시오.",
+      "german": "Geben Sie den Sicherungssatz ein, der zuvor an Ihre Wiederherstellungs-E-Mail gesendet wurde.",
+      "portuguese": "Digite a frase de backup enviada para seu e-mail de recuperação anteriormente."
+    },
+    "returning-continue": {
+      "mandarin": "继续{0}",
+      "spanish": "Continuar con {0}",
+      "english": "Continue with {0}",
+      "japanese": "{0}に進む",
+      "korean": "{0}로 계속",
+      "german": "Weiter mit {0}",
+      "portuguese": "Continuar com {0}"
+    },
+    "register-password-password-confirm": {
+      "mandarin": "重新输入密码",
+      "spanish": "reingresa tu contraseña",
+      "english": "Re-enter your password",
+      "japanese": "パスワードを再入力してください",
+      "korean": "비밀번호 재 입력",
+      "german": "Wiederhole die Eingabe deines Passwortes",
+      "portuguese": "Redigite sua senha"
+    },
+    "2fa-setup-step4-contact-support": {
+      "mandarin": "联系支持",
+      "spanish": "Soporte de contacto",
+      "english": "Contact Support",
+      "japanese": "サポート問い合わせ先",
+      "korean": "연락처 지원",
+      "german": "Kontaktieren Sie Support",
+      "portuguese": "Entre em contato com o suporte"
+    },
+    "reconstruct-backup-phrase-placeholder": {
+      "mandarin": "输入备用词组",
+      "spanish": "Ingrese la frase de respaldo",
+      "english": "Enter backup phrase",
+      "japanese": "バックアップフレーズを入力してください",
+      "korean": "백업 문구 입력",
+      "german": "Geben Sie die Sicherungsphrase ein",
+      "portuguese": "Digite a frase de backup"
+    },
+    "register-subtitle-try-webauth": {
+      "mandarin": "您要在此设备上启用Touch ID / Face ID吗？",
+      "spanish": "¿Le gustaría habilitar Touch ID / Face ID en este dispositivo?",
+      "english": "Would you like to enable Touch ID / Face ID on this device?",
+      "japanese": "このデバイスでTouchID / Face IDを有効にしますか？",
+      "korean": "이 장치에서 Touch ID / Face ID를 활성화 하시겠습니까?",
+      "german": "Möchten Sie die Touch ID / Face ID auf diesem Gerät aktivieren?",
+      "portuguese": "Gostaria de ativar o Touch ID / Face ID neste dispositivo?"
+    },
+    "2fa-setup-step3-note12": {
+      "mandarin": "您需要在下一个屏幕上确认此短语",
+      "spanish": "Deberá confirmar esta frase en la siguiente pantalla",
+      "english": "You will need to confirm this phrase on the next screen",
+      "japanese": "次の画面でこのフレーズを確認する必要があります",
+      "korean": "다음 화면에서 이 문구를 확인해야 합니다.",
+      "german": "Sie müssen diesen Satz auf dem nächsten Bildschirm bestätigen",
+      "portuguese": "Você precisará confirmar esta frase na próxima tela"
+    },
+    "2fa-setup-title31": {
+      "mandarin": "第 2 步：保存恢复短语",
+      "spanish": "Paso 2: Guarda la frase de recuperación",
+      "english": "Step 2: Save recovery phrase",
+      "japanese": "ステップ2：リカバリフレーズを保存する",
+      "korean": "2단계: 복구 문구 저장",
+      "german": "Schritt 2: Speichern Sie die Wiederherstellungsphrase",
+      "portuguese": "Etapa 2: salvar a frase de recuperação"
+    },
+    "2fa-verify-step1-go-app": {
+      "mandarin": "转到应用程序",
+      "spanish": "Ir a la aplicación",
+      "english": "Go to App",
+      "japanese": "アプリに行きます",
+      "korean": "앱으로 이동",
+      "german": "Gehe zu App",
+      "portuguese": "Vá para o aplicativo"
+    },
+    "2fa-setup-step3-sub2": {
+      "mandarin": "如果您无法访问保存的浏览器，您可以使用恢复短语进行身份验证。",
+      "spanish": "En caso de que pierda el acceso a su navegador guardado, puede autenticarse con su frase de recuperación.",
+      "english": "In case you lose access to your saved browser, you can authenticate with your recovery phrase.",
+      "japanese": "保存したブラウザにアクセスできなくなった場合は、リカバリフレーズで認証できます。",
+      "korean": "저장된 브라우저에 액세스할 수 없는 경우 복구 문구로 인증할 수 있습니다.",
+      "german": "Falls Sie den Zugriff auf Ihren gespeicherten Browser verlieren, können Sie sich mit Ihrer Wiederherstellungsphrase authentifizieren.",
+      "portuguese": "Caso perca o acesso ao seu navegador salvo, você pode autenticar com sua frase de recuperação."
+    },
+    "2fa-verify-save-save": {
+      "mandarin": "保存此设备",
+      "spanish": "Guardar este dispositivo",
+      "english": "Save this device",
+      "japanese": "このデバイスを保存します",
+      "korean": "이 기기 저장",
+      "german": "Speichern Sie dieses Gerät",
+      "portuguese": "Salvar este dispositivo"
+    },
+    "2fa-verify-share-head": {
+      "mandarin": "选择以下之一",
+      "spanish": "Selecciona uno de los siguientes",
+      "english": "Select one of the following",
+      "japanese": "次のいずれかを選択してください",
+      "korean": "다음 중 하나를 선택하십시오.",
+      "german": "Wählen Sie eine der folgenden Optionen",
+      "portuguese": "Selecione um dos seguintes"
+    },
+    "mpc-2fa-setup-step4-recovery": {
+      "mandarin": "恢复系数",
+      "spanish": "Factor de recuperación",
+      "english": "Recovery factor",
+      "japanese": "回収率",
+      "korean": "회복 계수",
+      "german": "Erholungsfaktor",
+      "portuguese": "Fator de recuperação"
+    },
+    "2fa-verify-reference-id": {
+      "mandarin": "参考编号",
+      "spanish": "Identificación de referencia",
+      "english": "Reference ID",
+      "japanese": "参照ID",
+      "korean": "참조 ID",
+      "german": "Referenz ID",
+      "portuguese": "Identificador de referência"
+    },
+    "2fa-setup-step4-sub21": {
+      "mandarin": "粘贴恢复短语",
+      "spanish": "Pega la frase de recuperación",
+      "english": "Paste the recovery phrase",
+      "japanese": "回復フレーズを貼り付けます",
+      "korean": "복구 문구 붙여넣기",
+      "german": "Fügen Sie den Wiederherstellungssatz ein",
+      "portuguese": "Cole a frase de recuperação"
+    },
+    "2fa-verify-recovery-note": {
+      "mandarin": "如果您无法验证上述任何一项，则无法登录您的帐户。",
+      "spanish": "Si no puede verificar ninguno de los anteriores, no puede iniciar sesión en su cuenta.",
+      "english": "If you are unable to verify any of the above, you are unable to login to your account.",
+      "japanese": "上記のいずれかを確認できない場合は、アカウントにログインできません。",
+      "korean": "위의 항목 중 하나라도 확인할 수 없으면 계정에 로그인할 수 없습니다.",
+      "german": "Wenn Sie keinen der oben genannten Punkte bestätigen können, können Sie sich nicht bei Ihrem Konto anmelden.",
+      "portuguese": "Se você não conseguir verificar nenhum dos itens acima, não poderá fazer login na sua conta."
+    },
+    "register-backup-phrase-placeholder": {
+      "mandarin": "输入辅助邮箱",
+      "spanish": "Ingresa el correo de recuperación",
+      "english": "Enter recovery email",
+      "japanese": "復旧メールを入力してください",
+      "korean": "복구 이메일 입력",
+      "german": "Geben Sie die Wiederherstellungs-E-Mail ein",
+      "portuguese": "Digite o e-mail de recuperação"
+    },
+    "2fa-setup-step3-sub1": {
+      "mandarin": "提供电子邮件以接收恢复短语",
+      "spanish": "Proporcione un correo electrónico para recibir la frase de recuperación",
+      "english": "Provide an email to receive recovery phrase",
+      "japanese": "回復フレーズを受け取るための電子メールを提供する",
+      "korean": "복구 문구를 받을 이메일 제공",
+      "german": "Geben Sie eine E-Mail an, um die Wiederherstellungsphrase zu erhalten",
+      "portuguese": "Forneça um e-mail para receber a frase de recuperação"
+    },
+    "register-skip": {
+      "mandarin": "立即跳过",
+      "spanish": "Saltar por ahora",
+      "english": "Skip for Now",
+      "japanese": "今はスキップ",
+      "korean": "일단은 스킵",
+      "german": "Für jetzt überspringen",
+      "portuguese": "Pular por agora"
+    },
+    "returning-confirm-desc": {
+      "mandarin": "继续通过生物识别登录？",
+      "spanish": "¿Continuar con el inicio de sesión mediante datos biométricos?",
+      "english": "Continue your sign in via biometrics?",
+      "japanese": "生体認証を介してサインインを続行しますか？",
+      "korean": "생체 인식을 통해 계속 로그인 하시겠습니까?",
+      "german": "Mit der Anmeldung über Biometrie fortfahren?",
+      "portuguese": "Continuar seu login via biometria?"
+    },
+    "register-biometrics-enable": {
+      "mandarin": "启用触摸ID /面部ID",
+      "spanish": "Habilitar Touch ID / Face ID",
+      "english": "Enable Touch ID / Face ID",
+      "japanese": "Touch ID / FaceIDを有効にする",
+      "korean": "Touch ID / Face ID 활성화",
+      "german": "Aktivieren Sie Touch ID / Face ID",
+      "portuguese": "Ativar Touch ID / Face ID"
+    },
+    "register-multiple-transports-cta": {
+      "english": "Set it up",
+      "german": "Es einrichten",
+      "mandarin": "设置它",
+      "korean": "설정하십시오",
+      "japanese": "準備する",
+      "spanish": "Prepararlo",
+      "portuguese": "Configurá-lo"
+    },
+    "reconstruct-backup-phrase-desc-3": {
+      "mandarin": "并发送到电子邮件：",
+      "spanish": "y enviado al correo electrónico:",
+      "english": "and sent to email: ",
+      "japanese": "そして電子メールに送られる：",
+      "korean": "이메일로 전송:",
+      "german": "und an E-Mail gesendet:",
+      "portuguese": "e enviado para o e-mail:"
+    },
+    "2fa-verify-share-browser": {
+      "mandarin": "浏览器",
+      "spanish": "Navegador",
+      "english": "Browser",
+      "japanese": "ブラウザ",
+      "korean": "브라우저",
+      "german": "Browser",
+      "portuguese": "Navegador"
+    },
+    "2fa-setup-step4-check-time": {
+      "mandarin": "没有收到吗？ 反感。 再次签入{0}",
+      "spanish": "¿No lo recibiste? Resentirse de. Vuelve a comprobar en {0}",
+      "english": "Did not receive it? Resent. Check again in {0}",
+      "japanese": "受け取りませんでしたか？ 憤る。 {0}でもう一度確認してください",
+      "korean": "받지 못하셨나요? 화내다. {0}에서 다시 확인",
+      "german": "Nicht erhalten? Übelnehmen. Erneut einchecken in {0}",
+      "portuguese": "Não recebeu? Reenviar. Verifique novamente em {0}"
+    },
+    "2fa-verify-multi-subhead": {
+      "mandarin": "登录到以下已保存的浏览器以批准访问",
+      "spanish": "Inicie sesión en el siguiente navegador guardado para aprobar el acceso",
+      "english": "Login to the following saved browser to approve access",
+      "japanese": "次の保存されたブラウザにログインして、アクセスを承認します",
+      "korean": "액세스를 승인하려면 다음 저장된 브라우저에 로그인하십시오.",
+      "german": "Melden Sie sich beim folgenden gespeicherten Browser an, um den Zugriff zu genehmigen",
+      "portuguese": "Faça login no seguinte navegador salvo para aprovar o acesso"
+    },
+    "2fa-setup-title12": {
+      "mandarin": "设置 2 因素身份验证",
+      "spanish": "Configurar autenticación de 2 factores",
+      "english": "Set up 2 Factor Authentication",
+      "japanese": "2要素認証を設定する",
+      "korean": "2단계 인증 설정",
+      "german": "2-Faktor-Authentifizierung einrichten",
+      "portuguese": "Configure a autenticação de 2 fatores"
+    },
+    "verifier-google-desc": {
+      "mandarin": "继续使用Google",
+      "spanish": "Continuar con Google",
+      "english": "Continue with Google",
+      "japanese": "Googleで続行",
+      "korean": "Google로 계속",
+      "german": "Fahren Sie mit Google fort",
+      "portuguese": "Continuar com o Google"
+    },
+    "2fa-setup-step3-manual-save": {
+      "mandarin": "手动保存您的短语",
+      "spanish": "Guarde manualmente su frase",
+      "english": "Manually save your phrase",
+      "japanese": "フレーズを手動で保存する",
+      "korean": "수동으로 문구 저장",
+      "german": "Speichern Sie Ihren Satz manuell",
+      "portuguese": "Salve manualmente sua frase"
+    },
+    "2fa-setup-step3-toggle2": {
+      "mandarin": "通过电子邮件向我发送恢复短语",
+      "spanish": "Envíame mi frase de recuperación por correo electrónico",
+      "english": "Email me my recovery phrase",
+      "japanese": "私の回復フレーズを私にメールしてください",
+      "korean": "내 복구 문구를 이메일로 보내주세요",
+      "german": "Senden Sie mir meinen Wiederherstellungssatz per E-Mail",
+      "portuguese": "Envie-me um e-mail com minha frase de recuperação"
+    },
+    "2fa-setup-step1-next": {
+      "mandarin": "设置 2FA",
+      "spanish": "Configurar 2FA",
+      "english": "Set up 2FA",
+      "japanese": "2FAを設定する",
+      "korean": "2FA 설정",
+      "german": "2FA einrichten",
+      "portuguese": "Configurar 2FA"
+    },
+    "2fa-setup-step2-confirm-note": {
+      "mandarin": "我了解清除浏览器历史记录和 cookie 将删除我浏览器上的这个因素。",
+      "spanish": "Entiendo que borrar el historial del navegador y las cookies eliminará este factor en mi navegador.",
+      "english": "I understand that clearing browser history and cookies will delete this factor on my browser.",
+      "japanese": "ブラウザの履歴とCookieをクリアすると、ブラウザのこの要素が削除されることを理解しています。",
+      "korean": "브라우저 기록 및 쿠키를 지우면 내 브라우저에서 이 요소가 삭제된다는 것을 이해합니다.",
+      "german": "Mir ist bewusst, dass das Löschen des Browserverlaufs und der Cookies diesen Faktor in meinem Browser löscht.",
+      "portuguese": "Entendo que limpar o histórico e os cookies do navegador excluirá esse fator do meu navegador."
+    },
+    "2fa-verify-step1-panel1": {
+      "mandarin": "保存的浏览器/设备",
+      "spanish": "Navegadores / dispositivos guardados",
+      "english": "Saved browser(s) / devices",
+      "japanese": "保存されたブラウザ/デバイス",
+      "korean": "저장된 브라우저/기기",
+      "german": "Gespeicherte(r) Browser/Geräte",
+      "portuguese": "Navegadores/dispositivos salvos"
+    },
+    "mpc-2fa-verify-step1-rec-placeholder": {
+      "mandarin": "恢复系数",
+      "spanish": "Factor de recuperación",
+      "english": "Recovery factor",
+      "japanese": "回収率",
+      "korean": "회복 계수",
+      "german": "Erholungsfaktor",
+      "portuguese": "Fator de recuperação"
+    },
+    "social-2fa-verify-email": {
+      "mandarin": "通过电子邮件验证",
+      "spanish": "Verifique con su correo electrónico",
+      "english": "Verify with your email",
+      "japanese": "メールで確認してください",
+      "korean": "이메일로 확인하십시오",
+      "german": "Überprüfen Sie mit Ihrer E -Mail",
+      "portuguese": "Verifique com seu e-mail"
+    },
+    "popup-continue-existing": {
+      "mandarin": "继续使用现有的{0}",
+      "spanish": "Continuar con {0} existente",
+      "english": "Continue with existing {0}",
+      "japanese": "既存の{0}を続行します",
+      "korean": "기존 {0} 계속",
+      "german": "Weiter mit vorhandenem {0}",
+      "portuguese": "Continuar com {0} existente"
+    },
+    "register-title-additional-security": {
+      "mandarin": "出发前的最后一步",
+      "spanish": "Un último paso antes de irte",
+      "english": "One last step before you go",
+      "japanese": "行く前の最後の一歩",
+      "korean": "가기 전에 마지막 단계",
+      "german": "Ein letzter Schritt bevor du gehst",
+      "portuguese": "Um último passo antes de ir"
+    },
+    "2fa-setup-step2-sub1": {
+      "mandarin": "使用当前浏览器设置",
+      "spanish": "Configurar usando el navegador actual",
+      "english": "Set up using current browser",
+      "japanese": "現在のブラウザを使用して設定",
+      "korean": "현재 브라우저를 사용하여 설정",
+      "german": "Mit aktuellem Browser einrichten",
+      "portuguese": "Configurar usando o navegador atual"
+    },
+    "register-backup-phrase-desc1": {
+      "mandarin": "将向您发送一封包含备份短语的电子邮件。",
+      "spanish": "Se le enviará un correo electrónico con la frase de respaldo.",
+      "english": "An email will be sent to you containing the backup phrase.",
+      "japanese": "バックアップ フレーズを含むメールが送信されます。",
+      "korean": "백업 문구가 포함 된 이메일이 발송됩니다.",
+      "german": "Sie erhalten eine E-Mail mit der Backup-Phrase.",
+      "portuguese": "Um e-mail será enviado para você contendo a frase de backup."
+    },
+    "2fa-setup-step3-hide-adv": {
+      "mandarin": "隐藏高级选项",
+      "spanish": "Ocultar opción avanzada",
+      "english": "Hide advanced option",
+      "japanese": "詳細オプションを非表示",
+      "korean": "고급 옵션 숨기기",
+      "german": "Erweiterte Option ausblenden",
+      "portuguese": "Ocultar opção avançada"
+    },
+    "2fa-verify-success-subtitle": {
+      "mandarin": "登录",
+      "spanish": "iniciando sesión",
+      "english": "Logging you in",
+      "japanese": "ログインします",
+      "korean": "로그인",
+      "german": "Melden Sie sich an",
+      "portuguese": "Conectando você"
+    },
+    "2fa-setup-step1-desc22": {
+      "mandarin": "只需 3 个简单的步骤即可完成设置！",
+      "spanish": "¡Configúralo en 3 sencillos pasos!",
+      "english": "Set it up in 3 simple steps!",
+      "japanese": "3つの簡単なステップでセットアップしてください！",
+      "korean": "간단한 3단계로 설정하세요!",
+      "german": "Richten Sie es in 3 einfachen Schritten ein!",
+      "portuguese": "Configure em 3 passos simples!"
+    },
+    "2fa-setup-step3-next3": {
+      "mandarin": "发送恢复短语",
+      "spanish": "Enviar frase de recuperación",
+      "english": "Send recovery phrase",
+      "japanese": "回復フレーズを送信する",
+      "korean": "복구 문구 보내기",
+      "german": "Wiederherstellungsphrase senden",
+      "portuguese": "Enviar frase de recuperação"
+    },
+    "register-backup-phrase-send": {
+      "mandarin": "发送恢复电子邮件",
+      "spanish": "Enviar correo de recuperación",
+      "english": "Send recovery email",
+      "japanese": "復旧メールを送信する",
+      "korean": "복구 이메일 보내기",
+      "german": "Wiederherstellungs-E-Mail senden",
+      "portuguese": "Enviar e-mail de recuperação"
+    },
+    "mpc-2fa-setup-step3-sub1": {
+      "mandarin": "提供电子邮件以接收恢复短语",
+      "spanish": "Proporcione un correo electrónico para recibir la frase de recuperación",
+      "english": "Provide an email to receive recovery factor",
+      "japanese": "回復フレーズを受け取るための電子メールを提供する",
+      "korean": "복구 문구를 받을 이메일 제공",
+      "german": "Geben Sie eine E-Mail an, um die Wiederherstellungsphrase zu erhalten",
+      "portuguese": "Forneça um e-mail para receber o fator de recuperação"
+    },
+    "2fa-setup-step3-show-adv": {
+      "mandarin": "查看高级选项",
+      "spanish": "Ver opción avanzada",
+      "english": "View advanced option",
+      "japanese": "詳細オプションを表示",
+      "korean": "고급 옵션 보기",
+      "german": "Erweiterte Option anzeigen",
+      "portuguese": "Ver opção avançada"
+    },
+    "2fa-verify-step1-rec-placeholder": {
+      "mandarin": "恢复短语",
+      "spanish": "Frase de recuperación",
+      "english": "Recovery phrase",
+      "japanese": "回復フレーズ",
+      "korean": "복구 문구",
+      "german": "Wiederherstellungsphrase",
+      "portuguese": "Frase de recuperação"
+    },
+    "2fa-verify-step2-sub1": {
+      "mandarin": "验证成功",
+      "spanish": "Verificación exitosa",
+      "english": "Successful verification",
+      "japanese": "検証の成功",
+      "korean": "인증 성공",
+      "german": "Erfolgreiche Verifizierung",
+      "portuguese": "Verificação bem-sucedida"
+    },
+    "title": {
+      "mandarin": "一站式管理所有网络互动",
+      "spanish": "Administre todas sus interacciones web en un solo lugar",
+      "english": "Manage all your web interactions in one place",
+      "japanese": "すべてのWebインタラクションを1か所で管理します",
+      "korean": "모든 웹 상호 작용을 한 곳에서 관리",
+      "german": "Verwalten Sie alle Ihre Webinteraktionen an einem Ort",
+      "portuguese": "Gerencie todas as suas interações na web em um só lugar"
+    },
+    "register-biometrics-desc": {
+      "mandarin": "使用面容 ID 或触控 ID 注册您的设备。 生物识别技术永远不会离开您的设备。",
+      "spanish": "Registre su dispositivo con Face ID o Touch ID. La biometría nunca abandona su dispositivo.",
+      "english": "Register your device with Face ID or Touch ID. Biometrics never leave your device.",
+      "japanese": "デバイスを Face ID または Touch ID で登録します。 生体認証がデバイスから離れることはありません。",
+      "korean": "Face ID 또는 Touch ID로 기기를 등록하세요. 생체 인식은 장치를 떠나지 않습니다.",
+      "german": "Registrieren Sie Ihr Gerät mit Face ID oder Touch ID. Biometrie verlässt Ihr Gerät nie.",
+      "portuguese": "Registre seu dispositivo com Face ID ou Touch ID. A biometria nunca sai do seu dispositivo."
+    },
+    "register-multiple-transports-desc": {
+      "english": "Register your device with biometrics or any web authentication methods.",
+      "german": "Registrieren Sie Ihr Gerät mit Biometrie oder Webauthentifizierungsmethoden.",
+      "mandarin": "用生物识别技术或任何Web身份验证方法注册您的设备。",
+      "korean": "생체 인식 또는 웹 인증 방법으로 장치를 등록하십시오.",
+      "japanese": "バイオメトリクスまたはWeb認証方法でデバイスを登録します。",
+      "spanish": "Registre su dispositivo con Biometrics o cualquier método de autenticación web.",
+      "portuguese": "Registre seu dispositivo com biometria ou qualquer método de autenticação da web."
+    },
+    "register-external-transports-desc": {
+      "english": "Register your device any web authentication methods.",
+      "german": "Registrieren Sie Ihr Gerät alle Webauthentifizierungsmethoden.",
+      "mandarin": "注册您的设备任何Web身份验证方法。",
+      "korean": "웹 인증 방법을 장치에 등록하십시오.",
+      "japanese": "Web認証方法をデバイスに登録してください。",
+      "spanish": "Registre su dispositivo cualquier método de autenticación web.",
+      "portuguese": "Registre seu dispositivo em qualquer método de autenticação da web."
+    },
+    "mpc-2fa-setup-title3": {
+      "mandarin": "保存恢复短语",
+      "spanish": "Guardar frase de recuperación",
+      "english": "Save recovery factor",
+      "japanese": "回復フレーズを保存する",
+      "korean": "복구 문구 저장",
+      "german": "Wiederherstellungsphrase speichern",
+      "portuguese": "Salvar fator de recuperação"
+    },
+    "reconstruct-device-prev2": {
+      "mandarin": "Torus钱包的先前版本",
+      "spanish": "versión anterior de Torus Wallet",
+      "english": "previous version of the Torus Wallet",
+      "japanese": "トーラスウォレットの以前のバージョン",
+      "korean": "이전 버전의 토러스 지갑",
+      "german": "vorherige Version der Torus-Brieftasche",
+      "portuguese": "versão anterior da Torus Wallet"
+    },
+    "2fa-setup-step3-next4": {
+      "mandarin": "我已经保存了我的恢复短语",
+      "spanish": "He guardado mi frase de recuperación",
+      "english": "I have saved my recovery phrase",
+      "japanese": "回復フレーズを保存しました",
+      "korean": "복구 문구를 저장했습니다",
+      "german": "Ich habe meine Wiederherstellungsphrase gespeichert",
+      "portuguese": "Salvei minha frase de recuperação"
+    },
+    "2fa-setup-step3-download": {
+      "mandarin": "下载我的恢复短语",
+      "spanish": "Descarga mi frase de recuperación",
+      "english": "Download my recovery phrase",
+      "japanese": "私の回復フレーズをダウンロードする",
+      "korean": "내 복구 문구 다운로드",
+      "german": "Laden Sie meinen Wiederherstellungssatz herunter",
+      "portuguese": "Baixar minha frase de recuperação"
+    },
+    "reconstruct-biometrics-desc": {
+      "mandarin": "*仅适用于先前在以下设备上设置的Touch ID / Face ID：",
+      "spanish": "* Solo para Touch ID / Face ID configurado previamente en los siguientes dispositivos:",
+      "english": "* Only for Touch ID / Face ID previously set up on the following device(s):",
+      "japanese": "*以下のデバイスで以前に設定されたTouchID / Face IDの場合のみ：",
+      "korean": "* 다음 장치에서 이전에 설정 한 Touch ID / Face ID에만 해당됩니다.",
+      "german": "* Nur für Touch ID / Face ID, die zuvor auf den folgenden Geräten eingerichtet wurden:",
+      "portuguese": "* Apenas para Touch ID / Face ID previamente configurado no(s) seguinte(s) dispositivo(s):"
+    },
+    "reconstruct-multiple-transports-desc": {
+      "english": "Only for web authentication methods that was previously set up on the following device(s)",
+      "german": "Nur für Webauthentifizierungsmethoden, die zuvor auf den folgenden Geräten eingerichtet wurden (en)",
+      "mandarin": "仅对于以前在以下设备上设置的Web身份验证方法",
+      "korean": "다음 장치에서 이전에 설정된 웹 인증 방법에 대해서만",
+      "japanese": "以前に次のデバイスに設定されたWeb認証方法のみ",
+      "spanish": "Solo para métodos de autenticación web que se configuraron previamente en los siguientes dispositivos",
+      "portuguese": "Apenas para métodos de autenticação da web que foram configurados anteriormente no(s) seguinte(s) dispositivo(s)"
+    },
+    "register-password-confirm": {
+      "mandarin": "设定密码",
+      "spanish": "Configurar contraseña",
+      "english": "Set up password",
+      "japanese": "パスワードを設定する",
+      "korean": "비밀번호 설정",
+      "german": "Passwort einrichten",
+      "portuguese": "Configurar senha"
+    },
+    "register-backup-phrase-title": {
+      "mandarin": "继续发送辅助邮箱",
+      "spanish": "Continuar con un correo de recuperación",
+      "english": "Continue with a recovery email",
+      "japanese": "復旧メールを続行します",
+      "korean": "복구 이메일로 계속",
+      "german": "Fahren Sie mit einer Wiederherstellungs-E-Mail fort",
+      "portuguese": "Continuar com um e-mail de recuperação"
+    },
+    "mpc-2fa-setup-step4-sub21": {
+      "mandarin": "粘贴恢复因子",
+      "spanish": "Pegar el factor de recuperación",
+      "english": "Paste the recovery factor",
+      "japanese": "回復係数を貼り付けます",
+      "korean": "회복 인자 붙여넣기",
+      "german": "Fügen Sie den Wiederherstellungsfaktor ein",
+      "portuguese": "Cole o fator de recuperação"
+    },
+    "2fa-verify-step1-sub1": {
+      "mandarin": "使用以下之一进行身份验证",
+      "spanish": "Autenticarse con uno de los siguientes",
+      "english": "Authenticate with one of the following",
+      "japanese": "次のいずれかで認証します",
+      "korean": "다음 중 하나로 인증",
+      "german": "Authentifizieren Sie sich mit einer der folgenden Optionen",
+      "portuguese": "Autenticar com um dos seguintes"
+    },
+    "2fa-verify-title1": {
+      "mandarin": "验证您的登录信息",
+      "spanish": "Verifique su inicio de sesión",
+      "english": "Verify your login",
+      "japanese": "ログインを確認する",
+      "korean": "로그인 확인",
+      "german": "Bestätigen Sie Ihre Anmeldung",
+      "portuguese": "Verifique seu login"
+    },
+    "migrate-desc22": {
+      "mandarin": "请在此新版本上验证您的身份",
+      "spanish": "por favor verifique su identidad en esta nueva versión",
+      "english": "kindly verify your identity on this new version",
+      "japanese": "この新しいバージョンであなたの身元を確認してください",
+      "korean": "이 새 버전에서 신원을 확인하십시오.",
+      "german": "Bitte überprüfen Sie Ihre Identität in dieser neuen Version",
+      "portuguese": "gentilmente verifique sua identidade nesta nova versão"
+    },
+    "social-2fa-verify-account": {
+      "mandarin": "验证您的社交帐户",
+      "spanish": "Verifique con su cuenta social",
+      "english": "Verify with your social account",
+      "japanese": "ソーシャルアカウントで確認します",
+      "korean": "소셜 계정으로 확인하십시오",
+      "german": "Überprüfen Sie mit Ihrem sozialen Konto",
+      "portuguese": "Verifique com sua conta social"
+    },
+    "register-subtitle-additional-security": {
+      "mandarin": "您的帐户安全很重要。 让我们支持它。",
+      "spanish": "La seguridad de su cuenta es importante. Hagamos una copia de seguridad.",
+      "english": "Your account security matters. Let’s back it up.",
+      "japanese": "アカウントのセキュリティが重要です。 後押ししましょう。",
+      "korean": "귀하의 계정 보안이 중요합니다. 백업합시다.",
+      "german": "Die Sicherheit Ihres Kontos ist wichtig. Lass es uns sichern.",
+      "portuguese": "A segurança da sua conta é importante. Vamos fazer backup."
+    },
+    "2fa-setup-step1-sub3": {
+      "mandarin": "为您的帐户添加额外的安全层并妥善保管您的资产。",
+      "spanish": "Agregue una capa adicional de seguridad a su cuenta y proteja sus activos.",
+      "english": "Add an extra layer of security to your account and safekeep your assets.",
+      "japanese": "アカウントにセキュリティの層を追加し、資産を保護します。",
+      "korean": "계정에 보안 계층을 추가하고 자산을 보호하십시오.",
+      "german": "Fügen Sie Ihrem Konto eine zusätzliche Sicherheitsebene hinzu und bewahren Sie Ihre Vermögenswerte sicher auf.",
+      "portuguese": "Adicione uma camada extra de segurança à sua conta e proteja seus ativos."
+    },
+    "social-2fa-subtitle-2": {
+      "mandarin": "如果您无法访问保存的浏览器，则可以通过社交帐户进行身份验证。",
+      "spanish": "En caso de que pierda acceso a su navegador guardado, puede autenticarse con su cuenta social.",
+      "english": "In case you lose access to your saved browser, you can authenticate with your Social account.",
+      "japanese": "保存されたブラウザへのアクセスを失う場合は、ソーシャルアカウントで認証できます。",
+      "korean": "저장된 브라우저에 대한 액세스 권한을 잃어버린 경우 소셜 계정으로 인증 할 수 있습니다.",
+      "german": "Falls Sie den Zugriff auf Ihren gespeicherten Browser verlieren, können Sie sich mit Ihrem sozialen Konto authentifizieren.",
+      "portuguese": "Caso perca o acesso ao seu navegador salvo, você pode se autenticar com sua conta Social."
+    },
+    "popup-here": {
+      "mandarin": "这里",
+      "spanish": "aquí",
+      "english": "here",
+      "japanese": "ここに",
+      "korean": "여기",
+      "german": "Hier",
+      "portuguese": "aqui"
+    },
+    "verifier-email-desc": {
+      "mandarin": "继续发送电子邮件",
+      "spanish": "Continuar con el correo electrónico",
+      "english": "Continue with Email",
+      "japanese": "メールを続ける",
+      "korean": "이메일로 계속",
+      "german": "Fahren Sie mit E-Mail fort",
+      "portuguese": "Continuar com e-mail"
+    },
+    "returning-exist-use-another": {
+      "mandarin": "使用其他帐户",
+      "spanish": "Usa otra cuenta",
+      "english": "Use another account",
+      "japanese": "別のアカウントを使用する",
+      "korean": "다른 계정 사용",
+      "german": "Benutze einen anderen Account",
+      "portuguese": "Usar outra conta"
+    },
+    "popup-view-less": {
+      "mandarin": "查看较少的选项",
+      "spanish": "Ver menos opciones",
+      "english": "View less options",
+      "japanese": "少ないオプションを表示",
+      "korean": "옵션 간략히보기",
+      "german": "Weniger Optionen anzeigen",
+      "portuguese": "Ver menos opções"
+    },
+    "2fa-setup-title3": {
+      "mandarin": "保存恢复短语",
+      "spanish": "Guardar frase de recuperación",
+      "english": "Save recovery phrase",
+      "japanese": "回復フレーズを保存する",
+      "korean": "복구 문구 저장",
+      "german": "Wiederherstellungsphrase speichern",
+      "portuguese": "Salvar frase de recuperação"
+    },
+    "2fa-verify-step1-do-not-save": {
+      "mandarin": "不要保存此浏览器/设备。",
+      "spanish": "No guarde este navegador / dispositivo.",
+      "english": "Do not save this brower/device.",
+      "japanese": "このブラウザ/デバイスを保存しないでください。",
+      "korean": "이 브라우저/장치를 저장하지 마십시오.",
+      "german": "Speichern Sie diesen Browser/dieses Gerät nicht.",
+      "portuguese": "Não salve este navegador/dispositivo."
+    },
+    "2fa-setup-step3-sub22": {
+      "mandarin": "我知道如果我丢失了这个恢复短语，我将承担丢失帐户的风险。",
+      "spanish": "Sé que si pierdo esta frase de recuperación, correré el riesgo de perder mi cuenta.",
+      "english": "I know that if I lose this recovery phrase, I will bear the risk of losing my account.",
+      "japanese": "この回復フレーズを失った場合、アカウントを失うリスクを負うことを私は知っています。",
+      "korean": "이 복구 문구를 잃어버리면 계정을 잃을 위험을 감수해야 한다는 것을 알고 있습니다.",
+      "german": "Ich weiß, dass ich das Risiko trage, mein Konto zu verlieren, wenn ich diesen Wiederherstellungssatz verliere.",
+      "portuguese": "Sei que se eu perder esta frase de recuperação, correrei o risco de perder minha conta."
+    },
+    "returning-header-desc": {
+      "mandarin": "您的数字钱包通过",
+      "spanish": "Tu billetera digital a través de",
+      "english": "Your digital wallet via",
+      "japanese": "経由であなたのデジタルウォレット",
+      "korean": "디지털 지갑을 통해",
+      "german": "Ihre digitale Geldbörse über",
+      "portuguese": "Sua carteira digital via"
+    },
+    "2fa-setup-step4-next": {
+      "mandarin": "核实",
+      "spanish": "Verificar",
+      "english": "Verify",
+      "japanese": "確認",
+      "korean": "검증",
+      "german": "Verifizieren",
+      "portuguese": "Verificar"
+    },
+    "reconstruct-title": {
+      "mandarin": "验证您的登录名",
+      "spanish": "Verifique su inicio de sesión",
+      "english": "Verify your login",
+      "japanese": "ログインを確認する",
+      "korean": "로그인 확인",
+      "german": "Überprüfen Sie Ihr Login",
+      "portuguese": "Verifique seu login"
+    },
+    "popup-subtitle": {
+      "mandarin": "选择您想继续的方式",
+      "spanish": "Seleccione cómo le gustaría continuar",
+      "english": "Select how you would like to continue",
+      "japanese": "続行する方法を選択してください",
+      "korean": "계속할 방법을 선택하십시오.",
+      "german": "Wählen Sie aus, wie Sie fortfahren möchten",
+      "portuguese": "Selecione como você gostaria de continuar"
+    },
+    "2fa-verify-multi-subhead2": {
+      "mandarin": "登录请求将发送到您保存的浏览器",
+      "spanish": "Se enviará una solicitud de inicio de sesión a su navegador guardado",
+      "english": "A login request will be sent to your saved browser",
+      "japanese": "保存したブラウザにログインリクエストが送信されます",
+      "korean": "저장된 브라우저로 로그인 요청이 전송됩니다.",
+      "german": "Eine Anmeldeanfrage wird an Ihren gespeicherten Browser gesendet",
+      "portuguese": "Uma solicitação de login será enviada para o seu navegador salvo"
+    },
+    "returning-confirm-btn": {
+      "mandarin": "是的，继续生物识别",
+      "spanish": "Sí, continuar con la biometría",
+      "english": "Yes, continue with biometrics",
+      "japanese": "はい、生体認証を続行します",
+      "korean": "예, 생체 인식을 계속합니다.",
+      "german": "Ja, weiter mit Biometrie",
+      "portuguese": "Sim, continuar com a biometria"
+    },
+    "register-subtitle": {
+      "mandarin": "选择以下之一",
+      "spanish": "Selecciona uno de los siguientes",
+      "english": "Select one of the following",
+      "japanese": "次のいずれかを選択してください",
+      "korean": "다음 중 하나를 선택하십시오.",
+      "german": "Wählen Sie eine der folgenden Optionen",
+      "portuguese": "Selecione um dos seguintes"
+    },
+    "reconstruct-subtitle": {
+      "mandarin": "验证以下内容之一以访问您的帐户",
+      "spanish": "Verifique con uno de los siguientes para acceder a su cuenta",
+      "english": "Verify with one of the following to access your account",
+      "japanese": "アカウントにアクセスするには、次のいずれかで確認してください",
+      "korean": "계정에 액세스하려면 다음 중 하나로 확인하세요.",
+      "german": "Überprüfen Sie mit einem der folgenden Punkte, um auf Ihr Konto zuzugreifen",
+      "portuguese": "Verifique com um dos seguintes para acessar sua conta"
+    },
+    "register-title": {
+      "mandarin": "保护您的{0}帐户",
+      "spanish": "Asegurar su cuenta de {0}",
+      "english": "Securing your {0} account",
+      "japanese": "{0}アカウントを保護する",
+      "korean": "{0} 계정 보안",
+      "german": "Sichern Sie Ihr {0} Konto",
+      "portuguese": "Protegendo sua conta {0}"
+    },
+    "register-title-try-webauth": {
+      "mandarin": "保护您的帐户",
+      "spanish": "Asegurar su cuenta",
+      "english": "Securing your account",
+      "japanese": "アカウントを保護する",
+      "korean": "계정 보안",
+      "german": "Sichern Sie Ihr Konto",
+      "portuguese": "Protegendo sua conta"
+    },
+    "reconstruct-device-prev3": {
+      "mandarin": "从下面存储的浏览器中验证您的身份。",
+      "spanish": "desde el navegador almacenado a continuación para verificar su identidad.",
+      "english": "from the stored browser below to verify your identity.",
+      "japanese": "以下の保存されているブラウザから本人確認を行ってください。",
+      "korean": "아래 저장된 브라우저에서 귀하의 신원을 확인하십시오.",
+      "german": "über den unten gespeicherten Browser, um Ihre Identität zu überprüfen.",
+      "portuguese": "do navegador armazenado abaixo para verificar sua identidade."
+    },
+    "verifier-email-placeholder": {
+      "mandarin": "电子邮件",
+      "spanish": "Correo electrónico",
+      "english": "Email",
+      "japanese": "Eメール",
+      "korean": "이메일",
+      "german": "Email",
+      "portuguese": "E-mail"
+    },
+    "social-2fa-warning-cta-1": {
+      "mandarin": "是的，我接受风险",
+      "spanish": "Sí, acepto el riesgo",
+      "english": "Yes, I accept the risk",
+      "japanese": "はい、私はリスクを受け入れます",
+      "korean": "예, 위험을 받아들입니다",
+      "german": "Ja, ich akzeptiere das Risiko",
+      "portuguese": "Sim, eu aceito o risco"
+    },
+    "subtitle": {
+      "mandarin": "点击开始以继续",
+      "spanish": "Haga clic en comenzar para continuar",
+      "english": "Click Get Started to continue",
+      "japanese": "[開始]をクリックして続行します",
+      "korean": "계속하려면 시작하기를 클릭하세요.",
+      "german": "Klicken Sie auf Erste Schritte, um fortzufahren",
+      "portuguese": "Clique em Começar para continuar"
+    },
+    "2fa-verify-save-subhead": {
+      "mandarin": "您想将此设备保存为受信任的设备吗？",
+      "spanish": "¿Le gustaría guardar este dispositivo como dispositivo de confianza?",
+      "english": "Would you like to save this device as a trusted device?",
+      "japanese": "このデバイスを信頼できるデバイスとして保存しますか？",
+      "korean": "이 장치를 신뢰할 수 있는 장치로 저장하시겠습니까?",
+      "german": "Möchten Sie dieses Gerät als vertrauenswürdiges Gerät speichern?",
+      "portuguese": "Deseja salvar este dispositivo como um dispositivo confiável?"
+    },
+    "2fa-setup-title5": {
+      "mandarin": "2FA 激活",
+      "spanish": "2FA activado",
+      "english": "2FA activated",
+      "japanese": "2FAがアクティブ化",
+      "korean": "2FA 활성화",
+      "german": "2FA aktiviert",
+      "portuguese": "2FA ativado"
+    },
+    "mpc-2fa-setup-step3-sub2": {
+      "mandarin": "如果您无法访问保存的浏览器，您可以使用恢复短语进行身份验证。",
+      "spanish": "En caso de que pierda el acceso a su navegador guardado, puede autenticarse con su frase de recuperación.",
+      "english": "In case you lose access to your saved browser, you can authenticate with your recovery factor.",
+      "japanese": "保存したブラウザにアクセスできなくなった場合は、リカバリフレーズで認証できます。",
+      "korean": "저장된 브라우저에 액세스할 수 없는 경우 복구 문구로 인증할 수 있습니다.",
+      "german": "Falls Sie den Zugriff auf Ihren gespeicherten Browser verlieren, können Sie sich mit Ihrer Wiederherstellungsphrase authentifizieren.",
+      "portuguese": "Caso perca o acesso ao seu navegador salvo, você pode autenticar com seu fator de recuperação."
+    },
+    "register-password-password": {
+      "mandarin": "输入密码",
+      "spanish": "Ingresa tu contraseña",
+      "english": "Enter your password",
+      "japanese": "パスワードを入力してください",
+      "korean": "비밀번호를 입력하세요",
+      "german": "Geben Sie Ihr Passwort ein",
+      "portuguese": "Coloque sua senha"
+    },
+    "social-2fa-verify-heading": {
+      "mandarin": "社会恢复因素",
+      "spanish": "Factor de recuperación social",
+      "english": "Social Recovery factor",
+      "japanese": "社会的回復要因",
+      "korean": "사회 복구 요인",
+      "german": "Sozialer Genesungsfaktor",
+      "portuguese": "Fator de Recuperação Social"
+    },
+    "register-backup-phrase-additional-security-desc1": {
+      "mandarin": "将向您发送一封包含备份短语的电子邮件。",
+      "spanish": "Se le enviará un correo electrónico con la frase de respaldo.",
+      "english": "An email will be sent to you containing the backup phrase.",
+      "japanese": "バックアップ フレーズを含むメールが送信されます。",
+      "korean": "백업 문구가 포함 된 이메일이 발송됩니다.",
+      "german": "Sie erhalten eine E-Mail mit der Backup-Phrase.",
+      "portuguese": "Um e-mail será enviado para você contendo a frase de backup."
+    },
+    "popup-manage": {
+      "mandarin": "管理帐户",
+      "spanish": "Administrar cuenta",
+      "english": "Manage account",
+      "japanese": "アカウントを管理する",
+      "korean": "계정 관리",
+      "german": "Konto verwalten",
+      "portuguese": "Gerenciar conta"
+    },
+    "2fa-verify-try-other": {
+      "mandarin": "尝试其他方法",
+      "spanish": "Pruebe otros métodos",
+      "english": "Try other methods",
+      "japanese": "他の方法を試す",
+      "korean": "다른 방법 시도",
+      "german": "Probieren Sie andere Methoden aus",
+      "portuguese": "Tente outros métodos"
+    },
+    "2fa-setup-title21": {
+      "mandarin": "第 1 步：保存您的设备",
+      "spanish": "Paso 1: Guarde su dispositivo",
+      "english": "Step 1: Save your device",
+      "japanese": "ステップ1：デバイスを保存する",
+      "korean": "1단계: 기기 저장",
+      "german": "Schritt 1: Speichern Sie Ihr Gerät",
+      "portuguese": "Etapa 1: salve seu dispositivo"
+    },
+    "2fa-setup-step3-next2": {
+      "mandarin": "核实",
+      "spanish": "Verificar",
+      "english": "Verify",
+      "japanese": "確認",
+      "korean": "확인하다",
+      "german": "Verifizieren",
+      "portuguese": "Verificar"
+    },
+    "migrate-list2": {
+      "mandarin": "由SSO和设备保护",
+      "spanish": "Asegurado por SSO y dispositivo",
+      "english": "Secured by SSO and device",
+      "japanese": "SSOとデバイスによって保護されています",
+      "korean": "SSO 및 장치로 보호",
+      "german": "Durch SSO und Gerät gesichert",
+      "portuguese": "Protegido por SSO e dispositivo"
+    },
+    "2fa-verify-step1-verify": {
+      "mandarin": "核实",
+      "spanish": "Verificar",
+      "english": "Verify",
+      "japanese": "確認",
+      "korean": "검증",
+      "german": "Verifizieren",
+      "portuguese": "Verificar"
+    }
+  }
 }

--- a/Openlogin-locale/locales-login.json
+++ b/Openlogin-locale/locales-login.json
@@ -1,1700 +1,1912 @@
 {
-	"login": {
-		"2fa-verify-share-send": {
-			"mandarin": "发送请求",
-			"spanish": "Enviar petición",
-			"english": "Send request",
-			"japanese": "リクエストを送信",
-			"korean": "요청 보내기",
-			"german": "Anfrage senden"
-		},
-		"2fa-setup-step5-return-app": {
-			"mandarin": "返回申请",
-			"spanish": "Volver a la aplicación",
-			"english": "Return to application",
-			"japanese": "アプリケーションに戻る",
-			"korean": "애플리케이션으로 돌아가기",
-			"german": "Zurück zur Anwendung"
-		},
-		"2fa-setup-step3-sub21": {
-			"mandarin": "粘贴您发送到 {0} 的辅助短语",
-			"spanish": "Pegue su frase de recuperación enviada a {0}",
-			"english": "Paste your recovery phrase sent to {0}",
-			"japanese": "{0}に送信されたリカバリフレーズを貼り付けます",
-			"korean": "{0}(으)로 전송된 복구 문구를 붙여넣으세요.",
-			"german": "Fügen Sie Ihren Wiederherstellungssatz ein, der an {0} gesendet wurde"
-		},
-		"reconstruct-backup-phrase-desc-2": {
-			"mandarin": "确认已设置的备份集",
-			"spanish": "Compruebe el conjunto de copia de seguridad establecido",
-			"english": "Verify with your backup phrase that was setup on",
-			"japanese": "セットしたバックアップセットを確認する",
-			"korean": "설정된 백업 세트 확인",
-			"german": "Bestätigen Sie mit Ihrem Backup-Satz, der eingerichtet wurde"
-		},
-		"2fa-verify-share-subhead": {
-			"mandarin": "您需要以下其中一项才能登录",
-			"spanish": "Necesita uno de los siguientes para iniciar sesión",
-			"english": "You need one of the following to login",
-			"japanese": "ログインするには、次のいずれかが必要です",
-			"korean": "로그인하려면 다음 중 하나가 필요합니다.",
-			"german": "Sie benötigen eine der folgenden Möglichkeiten, um sich anzumelden"
-		},
-		"reconstruct-biometrics-verify": {
-			"mandarin": "使用Touch ID / Face ID进行验证",
-			"spanish": "Verificar con Touch ID / Face ID",
-			"english": "Verify with Touch ID / Face ID",
-			"japanese": "Touch ID / FaceIDで確認する",
-			"korean": "Touch ID / Face ID로 확인",
-			"german": "Überprüfen Sie mit Touch ID / Face ID"
-		},
-		"2fa-setup-step3-next": {
-			"mandarin": "继续",
-			"spanish": "Continuar",
-			"english": "Continue",
-			"japanese": "継続する",
-			"korean": "계속하다",
-			"german": "Weitermachen"
-		},
-		"migrate-desc1": {
-			"mandarin": "最新版本的Torus Wallet由OpenLogin提供支持。",
-			"spanish": "La última versión de Torus Wallet funciona con OpenLogin.",
-			"english": "The latest version of Torus Wallet is powered by OpenLogin.",
-			"japanese": "Torus Walletの最新バージョンは、OpenLoginを利用しています。",
-			"korean": "최신 버전의 Torus Wallet은 OpenLogin에 의해 구동됩니다.",
-			"german": "Die neueste Version von Torus Wallet wird von OpenLogin unterstützt."
-		},
-		"2fa-setup-title1": {
-			"mandarin": "保护您的帐户",
-			"spanish": "Asegure su cuenta",
-			"english": "Secure your account",
-			"japanese": "アカウントを保護する",
-			"korean": "계정 보안",
-			"german": "Sichern Sie Ihr Konto"
-		},
-		"register-password-title": {
-			"mandarin": "设置帐号密码",
-			"spanish": "Configurar la contraseña de la cuenta",
-			"english": "Set up account password",
-			"japanese": "アカウントのパスワードを設定する",
-			"korean": "계정 비밀번호 설정",
-			"german": "Richten Sie das Kontokennwort ein"
-		},
-		"reconstruct-support": {
-			"mandarin": "联系支持",
-			"spanish": "Soporte de contacto",
-			"english": "Contact support",
-			"japanese": "サポート問い合わせ先",
-			"korean": "연락처 지원",
-			"german": "Kontaktieren Sie Support"
-		},
-		"returning-sign-in-header1": {
-			"mandarin": "使用其他帐户",
-			"spanish": "Usa otra cuenta",
-			"english": "Use another account",
-			"japanese": "別のアカウントを使用する",
-			"korean": "다른 계정 사용",
-			"german": "Benutze einen anderen Account"
-		},
-		"2fa-verify-multi-head": {
-			"mandarin": "允许从您保存的浏览器访问",
-			"spanish": "Permitir el acceso desde su navegador guardado",
-			"english": "Allow access from your saved browser",
-			"japanese": "保存したブラウザからのアクセスを許可する",
-			"korean": "저장된 브라우저에서 액세스 허용",
-			"german": "Erlauben Sie den Zugriff von Ihrem gespeicherten Browser"
-		},
-		"social-2fa-subtitle-1": {
-			"mandarin": "用任何社会帐户登录将其设置为恢复因素",
-			"spanish": "Inicie sesión con cualquiera de la cuenta social para establecerla como factor de recuperación",
-			"english": "Login with any of the social account to set it as recovery factor",
-			"japanese": "ソーシャルアカウントのいずれかでログインして、回復要因として設定します",
-			"korean": "소셜 계정에 로그인하여 복구 계수로 설정",
-			"german": "Melden Sie sich mit einem der sozialen Konto an, um es als Wiederherstellungsfaktor festzulegen"
-		},
-		"social-2fa-warning-text": {
-			"mandarin": "您正在使用同一电子邮件进行帐户登录和社会因素。这是不安全的。您还想继续吗？",
-			"spanish": "Está utilizando el mismo correo electrónico para el inicio de sesión de la cuenta y el factor social. Esto es inseguro. ¿Todavía te gustaría continuar?",
-			"english": "You are using the same email for account login and social factor. This is insecure. Would you still like to proceed?",
-			"japanese": "アカウントログインとソーシャルファクターに同じメールを使用しています。これは不安です。まだ進みたいですか？",
-			"korean": "계정 로그인 및 소셜 요소에 동일한 이메일을 사용하고 있습니다. 이것은 안전하지 않습니다. 아직도 진행하고 싶습니까?",
-			"german": "Sie verwenden dieselbe E -Mail für Kontoanmeldung und sozialer Faktor. Das ist unsicher. Möchten Sie immer noch fortfahren?"
-		},
-		"2fa-setup-step3-download-phrase": {
-			"mandarin": "下载短语",
-			"spanish": "Descargar frase",
-			"english": "Download phrase",
-			"japanese": "フレーズをダウンロード",
-			"korean": "구문 다운로드",
-			"german": "Redewendung herunterladen"
-		},
-		"2fa-setup-step1-sub2": {
-			"mandarin": "为您的帐户添加额外的安全层",
-			"spanish": "Agregue una capa adicional de seguridad a su cuenta",
-			"english": "Add an extra layer of security to your account",
-			"japanese": "アカウントにセキュリティの層を追加します",
-			"korean": "계정에 보안 계층 추가",
-			"german": "Fügen Sie Ihrem Konto eine zusätzliche Sicherheitsebene hinzu"
-		},
-		"2fa-verify-title2": {
-			"mandarin": "2FA 激活",
-			"spanish": "2FA activado",
-			"english": "2FA activated",
-			"japanese": "2FAがアクティブ化",
-			"korean": "2FA 활성화",
-			"german": "2FA aktiviert"
-		},
-		"2fa-setup-step5-next": {
-			"mandarin": "完毕",
-			"spanish": "Hecho",
-			"english": "Done",
-			"japanese": "終わり",
-			"korean": "완료",
-			"german": "Fertig"
-		},
-		"reconstruct-fail": {
-			"mandarin": "无法找回帐户？",
-			"spanish": "¿No puede recuperar la cuenta?",
-			"english": "Unable to recover account?",
-			"japanese": "アカウントを回復できませんか？",
-			"korean": "계정을 복구 할 수 없습니까?",
-			"german": "Konto kann nicht wiederhergestellt werden?"
-		},
-		"2fa-setup-step2-sub2": {
-			"mandarin": "使用当前浏览器批准来自新设备/浏览器的访问。",
-			"spanish": "Utilice el navegador actual para aprobar el acceso desde nuevos dispositivos / navegadores.",
-			"english": "Use the current browser to approve access from new devices/browsers.",
-			"japanese": "現在のブラウザを使用して、新しいデバイス/ブラウザからのアクセスを承認します。",
-			"korean": "현재 브라우저를 사용하여 새 장치/브라우저에서 액세스를 승인합니다.",
-			"german": "Verwenden Sie den aktuellen Browser, um den Zugriff von neuen Geräten/Browsern zu genehmigen."
-		},
-		"reconstruct-device-desc1": {
-			"mandarin": "登录到",
-			"spanish": "Iniciar sesión en",
-			"english": "Login to",
-			"japanese": "ログインする",
-			"korean": "로그인",
-			"german": "Einloggen in"
-		},
-		"migrate-title": {
-			"mandarin": "变得简单而安全",
-			"spanish": "hecho simple y seguro con",
-			"english": "made simple and secure with",
-			"japanese": "シンプルで安全に",
-			"korean": "간단하고 안전하게",
-			"german": "einfach und sicher gemacht mit"
-		},
-		"social-2fa-warn-text-2": {
-			"mandarin": "在登录页面上使用此社交因素签名将为您提供一个新帐户。",
-			"spanish": "Iniciar sesión con este factor social en la página de inicio de sesión le dará una nueva cuenta.",
-			"english": "Signing in with this Social factor at the login page will give you a new account.",
-			"japanese": "ログインページでこのソーシャルファクターにサインインすると、新しいアカウントが提供されます。",
-			"korean": "로그인 페이지 에서이 소셜 요소에 로그인하면 새 계정이 제공됩니다.",
-			"german": "Wenn Sie sich bei diesem sozialen Faktor auf der Anmeldeseite anmelden, erhalten Sie ein neues Konto."
-		},
-		"reconstruct-always-skip": {
-			"mandarin": "总是跳过",
-			"spanish": "Saltar siempre",
-			"english": "Always skip",
-			"japanese": "常にスキップする",
-			"korean": "항상 건너뛰기",
-			"german": "Immer überspringen"
-		},
-		"2fa-setup-step1-desc21": {
-			"mandarin": "我们强烈建议为像您这样的活跃用户设置 2FA。",
-			"spanish": "Recomendamos encarecidamente una configuración 2FA para un usuario activo como usted.",
-			"english": "We highly recommend a 2FA set up for an active user like yourself.",
-			"japanese": "あなたのようなアクティブユーザーには2FAを設定することを強くお勧めします。",
-			"korean": "귀하와 같은 활성 사용자를 위해 2FA 설정을 적극 권장합니다.",
-			"german": "Wir empfehlen dringend ein 2FA-Setup für einen aktiven Benutzer wie Sie."
-		},
-		"2fa-setup-step3-copy-phrase": {
-			"mandarin": "复制短语",
-			"spanish": "Copiar frase",
-			"english": "Copy phrase",
-			"japanese": "フレーズをコピーする",
-			"korean": "문구 복사",
-			"german": "Satz kopieren"
-		},
-		"2fa-verify-recovery-placeholder": {
-			"mandarin": "恢复短语",
-			"spanish": "Frase de recuperación",
-			"english": "Recovery phrase",
-			"japanese": "回復フレーズ",
-			"korean": "복구 문구",
-			"german": "Wiederherstellungsphrase"
-		},
-		"2fa-verify-share-resend": {
-			"mandarin": "重新发送请求",
-			"spanish": "Reenviar solicitud",
-			"english": "Resend request",
-			"japanese": "再送信リクエスト",
-			"korean": "재전송 요청",
-			"german": "Anfrage erneut senden"
-		},
-		"reconstruct-password-desc": {
-			"mandarin": "在此处输入您的帐户恢复密码",
-			"spanish": "Ingrese la contraseña de recuperación de su cuenta aquí",
-			"english": "Enter your account recovery password here",
-			"japanese": "ここにアカウント回復パスワードを入力してください",
-			"korean": "여기에 계정 복구 비밀번호를 입력하세요.",
-			"german": "Geben Sie hier Ihr Passwort für die Kontowiederherstellung ein"
-		},
-		"2fa-setup-step3-cancel": {
-			"mandarin": "后退",
-			"spanish": "atrás",
-			"english": "Back",
-			"japanese": "戻る",
-			"korean": "뒤",
-			"german": "Zurück"
-		},
-		"2fa-verify-step1-panel2": {
-			"mandarin": "恢复短语",
-			"spanish": "Frase de recuperación",
-			"english": "Recovery phrase",
-			"japanese": "回復フレーズ",
-			"korean": "복구 문구",
-			"german": "Wiederherstellungsphrase"
-		},
-		"popup-title": {
-			"mandarin": "欢迎登机",
-			"spanish": "La bienvenida a bordo",
-			"english": "Welcome onboard",
-			"japanese": "ご乗車（搭乗）ありがとうございます",
-			"korean": "보드에 오신 것을 환영합니다",
-			"german": "Willkommen an Bord"
-		},
-		"2fa-setup-step5-sub2": {
-			"mandarin": "在 app.openlogin.com 上管理未来的帐户设置",
-			"spanish": "Administre la configuración de la cuenta futura en app.openlogin.com",
-			"english": "Manage future account settings on app.openlogin.com",
-			"japanese": "app.openlogin.comで将来のアカウント設定を管理します",
-			"korean": "app.openlogin.com에서 향후 계정 설정 관리",
-			"german": "Verwalten Sie zukünftige Kontoeinstellungen auf app.openlogin.com"
-		},
-		"reconstruct-password-placeholder": {
-			"mandarin": "户口密码",
-			"spanish": "Contraseña de la cuenta",
-			"english": "Account password",
-			"japanese": "アカウントパスワード",
-			"korean": "계정 비밀번호",
-			"german": "Konto Passwort"
-		},
-		"reconstruct-device-title": {
-			"mandarin": "设备",
-			"spanish": "Dispositivos",
-			"english": "Device(s)",
-			"japanese": "デバイス",
-			"korean": "장치",
-			"german": "Geräte"
-		},
-		"2fa-verify-recovery-title": {
-			"mandarin": "恢复代码",
-			"spanish": "Código de recuperación",
-			"english": "Recovery code",
-			"japanese": "リカバリコード",
-			"korean": "복구 코드",
-			"german": "Wiederherstellungscode"
-		},
-		"migrate-list1": {
-			"mandarin": "支持面部识别/触摸识别",
-			"spanish": "Soporta Face ID / Touch ID",
-			"english": "Supports Face ID / Touch ID",
-			"japanese": "Face ID / TouchIDをサポート",
-			"korean": "Face ID / Touch ID 지원",
-			"german": "Unterstützt Face ID / Touch ID"
-		},
-		"register-biometrics-title": {
-			"mandarin": "继续使用Face ID或Touch ID",
-			"spanish": "Continuar con Face ID o Touch ID",
-			"english": "Continue with Face ID or Touch ID",
-			"japanese": "FaceIDまたはTouchIDに進む",
-			"korean": "Face ID 또는 Touch ID로 계속",
-			"german": "Fahren Sie mit Face ID oder Touch ID fort"
-		},
-		"popup-view-more": {
-			"mandarin": "查看更多选项",
-			"spanish": "Ver más opciones",
-			"english": "View more options",
-			"japanese": "その他のオプションを表示",
-			"korean": "더 많은 옵션보기",
-			"german": "Weitere Optionen anzeigen"
-		},
-		"returning-confirm-title": {
-			"mandarin": "我们只是想确定一下。",
-			"spanish": "Solo queremos estar seguros.",
-			"english": "We just want to be sure.",
-			"japanese": "確認したいだけです。",
-			"korean": "우리는 확신하고 싶습니다.",
-			"german": "Wir wollen nur sicher sein."
-		},
-		"migrate-subtitle": {
-			"mandarin": "迁移您的tKey",
-			"spanish": "Migrar su tKey",
-			"english": "Migrating your tKey",
-			"japanese": "tKeyの移行",
-			"korean": "tKey 마이그레이션",
-			"german": "Migrieren Sie Ihren tKey"
-		},
-		"2fa-setup-step4-recovery": {
-			"mandarin": "恢复短语",
-			"spanish": "Frase de recuperación",
-			"english": "Recovery phrase",
-			"japanese": "回復フレーズ",
-			"korean": "복구 문구",
-			"german": "Wiederherstellungsphrase"
-		},
-		"reconstruct-device-prev1": {
-			"mandarin": "登录到您的",
-			"spanish": "Inicie sesión en su",
-			"english": "Login to your",
-			"japanese": "あなたのログイン",
-			"korean": "귀하의",
-			"german": "Melden Sie sich bei Ihrem an"
-		},
-		"register-backup-phrase-confirm-desc3": {
-			"mandarin": "重新输入辅助邮箱",
-			"spanish": "vuelve a ingresar el correo de recuperación",
-			"english": "re-enter recovery email",
-			"japanese": "リカバリメールを再入力してください",
-			"korean": "복구 이메일 다시 입력",
-			"german": "wiederherstellungs-E-Mail erneut eingeben"
-		},
-		"2fa-verify-step1-rec-label": {
-			"mandarin": "输入恢复短语",
-			"spanish": "Ingrese la frase de recuperación",
-			"english": "Enter recovery phrase",
-			"japanese": "回復フレーズを入力してください",
-			"korean": "복구 문구 입력",
-			"german": "Geben Sie den Wiederherstellungssatz ein"
-		},
-		"migrate-continue": {
-			"mandarin": "继续",
-			"spanish": "Continuar",
-			"english": "Continue",
-			"japanese": "継続する",
-			"korean": "계속하다",
-			"german": "Fortsetzen"
-		},
-		"2fa-setup-step3-enter-email": {
-			"mandarin": "输入你的电子邮箱地址",
-			"spanish": "Ingrese su dirección de correo electrónico",
-			"english": "Enter your email address",
-			"japanese": "メールアドレスを入力してください",
-			"korean": "이메일 주소를 입력하세요",
-			"german": "Geben sie ihre E-Mailadresse ein"
-		},
-		"reconstruct-password-title": {
-			"mandarin": "找回密码",
-			"spanish": "Contraseña de recuperación",
-			"english": "Recovery password",
-			"japanese": "回復パスワード",
-			"korean": "복구 암호",
-			"german": "Passwort zum Zurücksetzen"
-		},
-		"2fa-setup-step5-sub1": {
-			"mandarin": "您的 2FA 已激活！",
-			"spanish": "¡Su 2FA ha sido activado!",
-			"english": "Your 2FA has been activated!",
-			"japanese": "2FAがアクティブになりました！",
-			"korean": "2FA가 활성화되었습니다!",
-			"german": "Ihre 2FA wurde aktiviert!"
-		},
-		"2fa-setup-title32": {
-			"mandarin": "第 3 步：验证恢复短语",
-			"spanish": "Paso 3: Verificar la frase de recuperación",
-			"english": "Step 3: Verify Recovery Phrase",
-			"japanese": "ステップ3：リカバリフレーズを確認する",
-			"korean": "3단계: 복구 문구 확인",
-			"german": "Schritt 3: Überprüfen Sie die Wiederherstellungsphrase"
-		},
-		"2fa-setup-step3-verified": {
-			"mandarin": "已验证",
-			"spanish": "Verificado",
-			"english": "Verified",
-			"japanese": "確認済み",
-			"korean": "확인됨",
-			"german": "Verifiziert"
-		},
-		"register-backup-phrase-additional-security-desc2": {
-			"mandarin": "如果您丢失带有 Touch ID / Face ID 的设备，它可以帮助您恢复帐户。",
-			"spanish": "Le ayuda con la recuperación de la cuenta en caso de que pierda su dispositivo con Touch ID / Face ID.",
-			"english": "It helps you with account recovery in case you lose your device with Touch ID / Face ID.",
-			"japanese": "Touch ID / Face ID でデバイスを紛失した場合のアカウント回復に役立ちます。",
-			"korean": "Touch ID / Face ID로 기기를 분실 한 경우 계정 복구에 도움이됩니다.",
-			"german": "Es hilft Ihnen bei der Kontowiederherstellung, falls Sie Ihr Gerät mit Touch ID / Face ID verlieren."
-		},
-		"2fa-setup-title2": {
-			"mandarin": "设置 2FA",
-			"spanish": "Configurar 2FA",
-			"english": "Set up 2FA",
-			"japanese": "2FAを設定する",
-			"korean": "2FA 설정",
-			"german": "2FA einrichten"
-		},
-		"2fa-verify-verify": {
-			"mandarin": "核实",
-			"spanish": "Verificar",
-			"english": "Verify",
-			"japanese": "確認",
-			"korean": "검증",
-			"german": "Verifizieren"
-		},
-		"2fa-setup-step3-enter-recovery": {
-			"mandarin": "输入您的辅助短语",
-			"spanish": "Introduce tu frase de recuperación",
-			"english": "Enter your recovery phrase",
-			"japanese": "回復フレーズを入力してください",
-			"korean": "복구 문구를 입력하세요",
-			"german": "Geben Sie Ihren Wiederherstellungssatz ein"
-		},
-		"social-2fa-heading": {
-			"mandarin": "设定社会恢复因素",
-			"spanish": "Establecer factor de recuperación social",
-			"english": "Set Social recovery factor",
-			"japanese": "社会的回復要因を設定します",
-			"korean": "사회 복구 요인을 설정하십시오",
-			"german": "Setzen Sie den sozialen Genesungsfaktor"
-		},
-		"mpc-2fa-verify-step1-rec-label": {
-			"mandarin": "输入恢复系数",
-			"spanish": "Ingrese el factor de recuperación",
-			"english": "Enter recovery factor",
-			"japanese": "回復係数を入力してください",
-			"korean": "회복 계수 입력",
-			"german": "Erholungsfaktor eingeben"
-		},
-		"reconstruct-device-desc": {
-			"mandarin": "从下面存储的浏览器登录到{0}以验证您的身份。",
-			"spanish": "Inicie sesión en {0} desde el navegador almacenado a continuación para verificar su identidad.",
-			"english": "Login to {0} from the stored browser below to verify your identity.",
-			"japanese": "以下の保存されているブラウザから{0}にログインして、本人確認を行ってください。",
-			"korean": "아래 저장된 브라우저에서 {0}에 로그인하여 신원을 확인하세요.",
-			"german": "Melden Sie sich über den unten gespeicherten Browser bei {0} an, um Ihre Identität zu überprüfen."
-		},
-		"2fa-setup-step2-current-browser": {
-			"mandarin": "当前浏览器",
-			"spanish": "Navegador actual",
-			"english": "Current browser",
-			"japanese": "現在のブラウザ",
-			"korean": "현재 브라우저",
-			"german": "Aktueller Browser"
-		},
-		"2fa-setup-step4-cancel": {
-			"mandarin": "后退",
-			"spanish": "atrás",
-			"english": "Back",
-			"japanese": "戻る",
-			"korean": "뒤",
-			"german": "Zurück"
-		},
-		"social-2fa-view-less": {
-			"mandarin": "少查看",
-			"spanish": "Ver menos",
-			"english": "View less",
-			"japanese": "表示が少なくなります",
-			"korean": "덜보십시오",
-			"german": "Weniger anzeigen"
-		},
-		"2fa-verify-success-title": {
-			"mandarin": "2FA 验证",
-			"spanish": "2FA verificado",
-			"english": "2FA verified",
-			"japanese": "2FA検証済み",
-			"korean": "2FA 인증",
-			"german": "2FA verifiziert"
-		},
-		"popup-terms": {
-			"mandarin": "使用条款",
-			"spanish": "Condiciones de uso",
-			"english": "Terms of use",
-			"japanese": "利用規約",
-			"korean": "이용 약관",
-			"german": "Nutzungsbedingungen"
-		},
-		"migrate-list3": {
-			"mandarin": "受保护的用户数据和隐私",
-			"spanish": "Privacidad y datos de usuario protegidos",
-			"english": "Protected user Data and Privacy",
-			"japanese": "保護されたユーザーデータとプライバシー",
-			"korean": "보호 된 사용자 데이터 및 개인 정보",
-			"german": "Geschützte Benutzerdaten und Datenschutz"
-		},
-		"popup-continue": {
-			"mandarin": "继续",
-			"spanish": "Continuar",
-			"english": "Continue",
-			"japanese": "継続する",
-			"korean": "계속하다",
-			"german": "Fortsetzen"
-		},
-		"reconstruct-backup-phrase-title": {
-			"mandarin": "备用词组",
-			"spanish": "Frase de respaldo",
-			"english": "Backup phrase",
-			"japanese": "バックアップフレーズ",
-			"korean": "백업 문구",
-			"german": "Sicherungssatz"
-		},
-		"2fa-verify-save-nosave": {
-			"mandarin": "下次吧",
-			"spanish": "Quizás la próxima vez",
-			"english": "Maybe next time",
-			"japanese": "また今度",
-			"korean": "아마 다음 번에",
-			"german": "Vielleicht nächstes Mal"
-		},
-		"2fa-setup-step2-save-device": {
-			"mandarin": "保存当前设备",
-			"spanish": "Guardar dispositivo actual",
-			"english": "Save current device",
-			"japanese": "現在のデバイスを保存",
-			"korean": "현재 장치 저장",
-			"german": "Aktuelles Gerät speichern"
-		},
-		"2fa-setup-step4-sub22": {
-			"mandarin": "粘贴发送到您的电子邮件的恢复短语 {0}",
-			"spanish": "Pega la frase de recuperación enviada a tu correo electrónico {0}",
-			"english": "Paste the recovery phrase sent to your email {0}",
-			"japanese": "メールに送信されたリカバリフレーズを貼り付けます{0}",
-			"korean": "이메일로 전송된 복구 문구를 붙여넣으세요 {0}",
-			"german": "Fügen Sie den Wiederherstellungssatz ein, der an Ihre E-Mail-Adresse {0} gesendet wurde."
-		},
-		"returning-sign-in-header2": {
-			"mandarin": "您似乎尚未登录帐户",
-			"spanish": "Parece que aún no ha iniciado sesión en una cuenta",
-			"english": "It seems like you are not signed in to an account yet",
-			"japanese": "アカウントにまだサインインしていないようです",
-			"korean": "아직 계정에 로그인하지 않은 것 같습니다.",
-			"german": "Anscheinend bist du noch nicht bei einem Konto angemeldet"
-		},
-		"register-backup-phrase-confirm-desc1": {
-			"mandarin": "我确认我已收到恢复电子邮件。",
-			"spanish": "Confirmo que he recibido el correo de recuperación.",
-			"english": "I confirm that I have received the recovery email.",
-			"japanese": "復旧メールを受信したことを確認しました。",
-			"korean": "我确认我已收到恢复电子邮件。",
-			"german": "Ich bestätige, dass ich die Wiederherstellungs-E-Mail erhalten habe."
-		},
-		"2fa-verify-recovery-label": {
-			"mandarin": "输入恢复短语",
-			"spanish": "Ingrese la frase de recuperación",
-			"english": "Enter recovery phrase",
-			"japanese": "回復フレーズを入力してください",
-			"korean": "복구 문구 입력",
-			"german": "Geben Sie den Wiederherstellungssatz ein"
-		},
-		"constructYourKey": {
-			"mandarin": "构建您的密钥",
-			"spanish": "Construyendo tu clave en",
-			"english": "Constructing your key on",
-			"japanese": "キーを作成する",
-			"korean": "키 구성",
-			"german": "Bauen Sie Ihren Schlüssel auf"
-		},
-		"2fa-verify-save-head": {
-			"mandarin": "帐户已恢复",
-			"spanish": "Cuenta recuperada",
-			"english": "Account recovered",
-			"japanese": "アカウントが回復しました",
-			"korean": "계정 복구됨",
-			"german": "Konto wiederhergestellt"
-		},
-		"register-backup-phrase-desc": {
-			"mandarin": "包含备用短语的电子邮件将发送给您。如果您丢失了设备，它将帮助您进行帐户恢复。",
-			"spanish": "Se le enviará un correo electrónico con la frase de respaldo. Le ayuda con la recuperación de la cuenta en caso de que pierda su dispositivo.",
-			"english": "An email will be sent to you containing the backup phrase. It helps you with account recovery in case you lose your device.",
-			"japanese": "バックアップフレーズを記載したメールが送信されます。デバイスを紛失した場合のアカウントの復旧に役立ちます。",
-			"korean": "백업 문구가 포함 된 이메일이 전송됩니다.  기기 분실시 계정 복구에 도움이됩니다.",
-			"german": "Sie erhalten eine E-Mail mit der Sicherungsphrase. Sie hilft Ihnen bei der Wiederherstellung des Kontos, falls Sie Ihr Gerät verlieren."
-		},
-		"2fa-setup-step3-note11": {
-			"mandarin": "笔记：",
-			"spanish": "Nota:",
-			"english": "Note:",
-			"japanese": "ノート：",
-			"korean": "메모:",
-			"german": "Notiz:"
-		},
-		"verifier-webauth-desc": {
-			"mandarin": "继续使用WebAuthn",
-			"spanish": "Continuar con WebAuthn",
-			"english": "Continue with WebAuthn",
-			"japanese": "WebAuthnを続行します",
-			"korean": "WebAuthn으로 계속",
-			"german": "Fahren Sie mit WebAuthn fort"
-		},
-		"2fa-setup-step4-not-received": {
-			"mandarin": "没有收到吗？",
-			"spanish": "¿No lo recibiste?",
-			"english": "Did not receive it?",
-			"japanese": "受け取りませんでしたか？",
-			"korean": "받지 못하셨나요?",
-			"german": "Nicht erhalten?"
-		},
-		"reconstruct-biometrics-title": {
-			"mandarin": "支持面部识别/触摸识别的设备*",
-			"spanish": "Dispositivos habilitados con Face ID / Touch ID *",
-			"english": "Face ID / Touch ID enabled device(s) *",
-			"japanese": "Face ID / TouchID対応デバイス*",
-			"korean": "Face ID / Touch ID 지원 장치 *",
-			"german": "Face ID / Touch ID-fähige Geräte *"
-		},
-		"returning-sign-in-desc": {
-			"mandarin": "继续执行以下操作之一以继续",
-			"spanish": "Continúe con uno de los siguientes para continuar",
-			"english": "Continue with one of the following to proceed",
-			"japanese": "次のいずれかを続行して続行します",
-			"korean": "계속하려면 다음 중 하나를 계속하십시오.",
-			"german": "Fahren Sie mit einem der folgenden Schritte fort, um fortzufahren"
-		},
-		"2fa-verify-step1-sub2": {
-			"mandarin": "您需要以下其中一项才能登录",
-			"spanish": "Necesita uno de los siguientes para iniciar sesión",
-			"english": "You need one of the following to login",
-			"japanese": "ログインするには、次のいずれかが必要です",
-			"korean": "로그인하려면 다음 중 하나가 필요합니다.",
-			"german": "Sie benötigen eine der folgenden Möglichkeiten, um sich anzumelden"
-		},
-		"2fa-setup-step3-email": {
-			"mandarin": "电子邮件",
-			"spanish": "Correo electrónico",
-			"english": "Email",
-			"japanese": "Eメール",
-			"korean": "이메일",
-			"german": "Email"
-		},
-		"2fa-setup-title4": {
-			"mandarin": "恢复验证",
-			"spanish": "Verificación de recuperación",
-			"english": "Recovery verification",
-			"japanese": "回復の検証",
-			"korean": "복구 확인",
-			"german": "Wiederherstellungsüberprüfung"
-		},
-		"2fa-setup-step4-resend": {
-			"mandarin": "重发",
-			"spanish": "Reenviar",
-			"english": "Resend",
-			"japanese": "再送",
-			"korean": "재전송",
-			"german": "Erneut senden"
-		},
-		"2fa-setup-step1-sub1": {
-			"mandarin": "启用 2 因素身份验证 (2FA)",
-			"spanish": "Habilitar la autenticación de 2 factores (2FA)",
-			"english": "Enable 2 Factor Authentication (2FA)",
-			"japanese": "2要素認証（2FA）を有効にする",
-			"korean": "2단계 인증(2FA) 활성화",
-			"german": "2-Faktor-Authentifizierung (2FA) aktivieren"
-		},
-		"2fa-verify-multi-title": {
-			"mandarin": "{0} 台设备可用",
-			"spanish": "{0} dispositivos disponibles",
-			"english": "{0} devices available",
-			"japanese": "利用可能な{0}デバイス",
-			"korean": "사용 가능한 기기 {0}대",
-			"german": "{0} Geräte verfügbar"
-		},
-		"start": {
-			"mandarin": "开始使用",
-			"spanish": "Empezar",
-			"english": "Get Started",
-			"japanese": "はじめに",
-			"korean": "시작하다",
-			"german": "Loslegen"
-		},
-		"2fa-setup-step4-sub1": {
-			"mandarin": "验证您的恢复短语",
-			"spanish": "Verifica tu frase de recuperación",
-			"english": "Verify your recovery phrase",
-			"japanese": "回復フレーズを確認する",
-			"korean": "복구 문구 확인",
-			"german": "Bestätigen Sie Ihren Wiederherstellungssatz"
-		},
-		"popup-already": {
-			"mandarin": "已经有账户？",
-			"spanish": "¿Ya tienes una cuenta?",
-			"english": "Already have an account?",
-			"japanese": "すでにアカウントをお持ちですか？",
-			"korean": "이미 계정이 있습니까?",
-			"german": "Sie haben bereits ein Konto?"
-		},
-		"social-2fa-continue-text": {
-			"mandarin": "选择您喜欢如何继续",
-			"spanish": "Seleccione cómo le gusta continuar",
-			"english": "Select how you like to continue",
-			"japanese": "続行する方法を選択してください",
-			"korean": "계속하는 방법을 선택하십시오",
-			"german": "Wählen Sie, wie Sie fortfahren möchten"
-		},
-		"social-2fa-view-more": {
-			"mandarin": "查看更多",
-			"spanish": "Ver más",
-			"english": "View more",
-			"japanese": "もっと見る",
-			"korean": "더보기",
-			"german": "Mehr sehen"
-		},
-		"2fa-setup-step3-confirm-phrase": {
-			"mandarin": "作为高级用户，我知道如果我丢失了此恢复短语，我将承担丢失帐户的风险。",
-			"spanish": "Como usuario avanzado, sé que si pierdo esta frase de recuperación, corro el riesgo de perder mi cuenta.",
-			"english": "As an advanced user, I know that if I lose this recovery phrase, I bear the risk of losing my account.",
-			"japanese": "上級ユーザーとして、この回復フレーズを失うと、アカウントを失うリスクがあることを私は知っています。",
-			"korean": "고급 사용자로서 나는 이 복구 문구를 잃어버리면 내 계정을 잃을 위험을 감수해야 한다는 것을 알고 있습니다.",
-			"german": "Als fortgeschrittener Benutzer weiß ich, dass ich das Risiko trage, mein Konto zu verlieren, wenn ich diesen Wiederherstellungssatz verliere."
-		},
-		"2fa-setup-step1-cancel": {
-			"mandarin": "下次吧",
-			"spanish": "Quizás la próxima vez",
-			"english": "Maybe next time",
-			"japanese": "また今度",
-			"korean": "아마 다음 번에",
-			"german": "Vielleicht nächstes Mal"
-		},
-		"2fa-setup-step2-cancel": {
-			"mandarin": "后退",
-			"spanish": "atrás",
-			"english": "Back",
-			"japanese": "戻る",
-			"korean": "뒤",
-			"german": "Zurück"
-		},
-		"popup-privacy": {
-			"mandarin": "隐私政策",
-			"spanish": "Política de privacidad",
-			"english": "Privacy policy",
-			"japanese": "個人情報保護方針",
-			"korean": "개인 정보 정책",
-			"german": "Datenschutz-Bestimmungen"
-		},
-		"2fa-setup-step3-toggle1": {
-			"mandarin": "无需电子邮件即可保存我的恢复短语",
-			"spanish": "Guardar mi frase de recuperación sin correo electrónico",
-			"english": "Save my recovery phrase without email",
-			"japanese": "メールなしで回復フレーズを保存する",
-			"korean": "이메일 없이 내 복구 문구 저장",
-			"german": "Meine Wiederherstellungsphrase ohne E-Mail speichern"
-		},
-		"register-backup-phrase-confirm-desc2": {
-			"mandarin": "如果不，",
-			"spanish": "Que no,",
-			"english": "If not,",
-			"japanese": "そうでない場合は、",
-			"korean": "如果不，",
-			"german": "Wenn nicht,"
-		},
-		"register-backup-phrase-desc2": {
-			"mandarin": "它可以帮助您在丢失设备时恢复帐户。",
-			"spanish": "Le ayuda con la recuperación de la cuenta en caso de que pierda su dispositivo.",
-			"english": "It helps you with account recovery in case you lose your device.",
-			"japanese": "デバイスを紛失した場合のアカウントの回復に役立ちます。",
-			"korean": "기기 분실시 계정 복구에 도움이됩니다.",
-			"german": "Es hilft Ihnen bei der Kontowiederherstellung, falls Sie Ihr Gerät verlieren."
-		},
-		"mpc-2fa-setup-step4-sub1": {
-			"mandarin": "验证您的恢复系数",
-			"spanish": "Verifique su factor de recuperación",
-			"english": "Verify your recovery factor",
-			"japanese": "回復率を確認する",
-			"korean": "회복 계수 확인",
-			"german": "Überprüfen Sie Ihren Erholungsfaktor"
-		},
-		"register-continue": {
-			"mandarin": "继续",
-			"spanish": "Continuar",
-			"english": "Continue",
-			"japanese": "継続する",
-			"korean": "계속하다",
-			"german": "Fortsetzen"
-		},
-		"social-2fa-warning-cta-2": {
-			"mandarin": "不，使用另一封电子邮件",
-			"spanish": "No, usa otro correo electrónico",
-			"english": "No, use another email",
-			"japanese": "いいえ、別のメールを使用してください",
-			"korean": "아니요, 다른 이메일을 사용하십시오",
-			"german": "Nein, verwenden Sie eine andere E -Mail"
-		},
-		"reconstruct-always-skip-note": {
-			"mandarin": "通过选择“始终跳过”，您将不会收到再次登录 OpenLogin 帐户的提示。 如果您改变主意，您可以随时在“设置”中更改此首选项。",
-			"spanish": "Si selecciona 'Omitir siempre', no se le pedirá que vuelva a iniciar sesión en su cuenta de OpenLogin. Si cambia de opinión, puede cambiar esta preferencia en cualquier momento en 'Configuración'.",
-			"english": "By selecting 'Always skip', you will not be prompted to login to your OpenLogin account again. If you change your mind, you may change this preference anytime in 'Settings'.",
-			"japanese": "[常にスキップ]を選択すると、OpenLoginアカウントに再度ログインするように求められることはありません。 気が変わった場合は、「設定」でいつでもこの設定を変更できます。",
-			"korean": "'항상 건너뛰기'를 선택하면 OpenLogin 계정에 다시 로그인하라는 메시지가 표시되지 않습니다. 마음이 바뀌면 '설정'에서 언제든지 이 환경설정을 변경할 수 있습니다.",
-			"german": "Wenn Sie „Immer überspringen“ auswählen, werden Sie nicht aufgefordert, sich erneut bei Ihrem OpenLogin-Konto anzumelden. Wenn Sie Ihre Meinung ändern, können Sie diese Einstellung jederzeit in den \"Einstellungen\" ändern."
-		},
-		"2fa-setup-step1-desc1": {
-			"mandarin": "每次登录需要 2 个身份验证因素",
-			"spanish": "Cada inicio de sesión requiere 2 factores para la autenticación",
-			"english": "Each login requires 2 factors for authentication",
-			"japanese": "各ログインには、認証のために2つの要素が必要です",
-			"korean": "각 로그인에는 인증을 위해 2가지 요소가 필요합니다.",
-			"german": "Jede Anmeldung erfordert 2 Faktoren zur Authentifizierung"
-		},
-		"mpc-2fa-setup-step4-sub22": {
-			"mandarin": "粘贴发送到您的电子邮件 {0} 的恢复因素",
-			"spanish": "Pegue el factor de recuperación enviado a su correo electrónico {0}",
-			"english": "Paste the recovery factor sent to your email {0}",
-			"japanese": "メール {0} に送信された回復係数を貼り付けます",
-			"korean": "이메일로 전송된 복구 요소를 붙여넣습니다. {0}",
-			"german": "Fügen Sie den an Ihre E-Mail gesendeten Wiederherstellungsfaktor ein {0}"
-		},
-		"2fa-setup-step2-next": {
-			"mandarin": "继续",
-			"spanish": "Continuar",
-			"english": "Continue",
-			"japanese": "継続する",
-			"korean": "계속하다",
-			"german": "Weitermachen"
-		},
-		"migrate-desc21": {
-			"mandarin": "享受Torus钱包的最新功能",
-			"spanish": "Para disfrutar de las últimas funciones de Torus Wallet",
-			"english": "To enjoy the latest features of the Torus Wallet",
-			"japanese": "トーラスウォレットの最新機能をお楽しみください",
-			"korean": "Torus Wallet의 최신 기능을 즐기려면",
-			"german": "Genießen Sie die neuesten Funktionen der Torus-Brieftasche"
-		},
-		"mpc-2fa-verify-step1-panel2": {
-			"mandarin": "恢复系数",
-			"spanish": "Factor de recuperación",
-			"english": "Recovery factor",
-			"japanese": "回収率",
-			"korean": "회복 계수",
-			"german": "Erholungsfaktor"
-		},
-		"social-2fa-warn-text-1": {
-			"mandarin": "这个社会因素仅充当备份共享，以恢复您的帐户链接到“ abcd@xyz.com”。",
-			"spanish": "Este factor social solo actúa como una participación de respaldo para recuperar su cuenta vinculada a \"abcd@xyz.com\".",
-			"english": "This Social factor only acts as a backup share to recover your account linked to “abcd@xyz.com”.",
-			"japanese": "このソーシャルファクターは、「abcd@xyz.com」にリンクされたアカウントを回復するためのバックアップ共有としてのみ機能します。",
-			"korean": "이 사회적 요소는 \"abcd@xyz.com\"에 링크 된 계정을 복구하기위한 백업 공유 역할을합니다.",
-			"german": "Dieser soziale Faktor fungiert nur als Sicherungsanteil, um Ihr mit „abcd@xyz.com“ verknüpfter Konto wiederherzustellen."
-		},
-		"mpc-2fa-setup-step3-download": {
-			"mandarin": "下载我的恢复因子",
-			"spanish": "Descargar mi factor de recuperación",
-			"english": "Download my recovery factor",
-			"japanese": "私のリカバリーファクターをダウンロードする",
-			"korean": "내 회복 인자 다운로드",
-			"german": "Laden Sie meinen Wiederherstellungsfaktor herunter"
-		},
-		"returning-exist-title": {
-			"mandarin": "欢迎回来，{0}",
-			"spanish": "Bienvenido de nuevo, {0}",
-			"english": "Welcome back, {0}",
-			"japanese": "おかえりなさい、{0}",
-			"korean": "다시 오신 것을 환영합니다. {0}",
-			"german": "Willkommen zurück, {0}"
-		},
-		"returning-header-title": {
-			"mandarin": "登入",
-			"spanish": "Registrarse",
-			"english": "Sign in",
-			"japanese": "サインイン",
-			"korean": "로그인",
-			"german": "Einloggen"
-		},
-		"2fa-verify-success-head": {
-			"mandarin": "成功的",
-			"spanish": "Exitoso",
-			"english": "Successful",
-			"japanese": "成功",
-			"korean": "성공적인",
-			"german": "Erfolgreich"
-		},
-		"2fa-setup-step3-next1": {
-			"mandarin": "完成设置",
-			"spanish": "Terminar de configurar",
-			"english": "Finish setting up",
-			"japanese": "セットアップを完了します",
-			"korean": "설정 완료",
-			"german": "Beenden Sie die Einrichtung"
-		},
-		"reconstruct-device-desc2": {
-			"mandarin": "从以下任何设备中完成安全性验证。",
-			"spanish": "desde cualquiera de los siguientes dispositivos para completar la verificación de seguridad.",
-			"english": "from any of the following devices to complete the security verification.",
-			"japanese": "次のいずれかのデバイスからセキュリティ検証を完了します。",
-			"korean": "다음 장치 중 하나에서 보안 확인을 완료하십시오.",
-			"german": "von einem der folgenden Geräte, um die Sicherheitsüberprüfung abzuschließen."
-		},
-		"reconstruct-backup-phrase-desc": {
-			"mandarin": "输入先前发送到您的辅助邮箱的备份短语。",
-			"spanish": "Ingrese la frase de respaldo enviada a su correo electrónico de recuperación anteriormente.",
-			"english": "Enter the backup phrase sent to your recovery email previously.",
-			"japanese": "以前にリカバリメールに送信されたバックアップフレーズを入力します。",
-			"korean": "이전에 복구 이메일로 전송 된 백업 문구를 입력하십시오.",
-			"german": "Geben Sie den Sicherungssatz ein, der zuvor an Ihre Wiederherstellungs-E-Mail gesendet wurde."
-		},
-		"returning-continue": {
-			"mandarin": "继续{0}",
-			"spanish": "Continuar con {0}",
-			"english": "Continue with {0}",
-			"japanese": "{0}に進む",
-			"korean": "{0}로 계속",
-			"german": "Weiter mit {0}"
-		},
-		"register-password-password-confirm": {
-			"mandarin": "重新输入密码",
-			"spanish": "reingresa tu contraseña",
-			"english": "Re-enter your password",
-			"japanese": "パスワードを再入力してください",
-			"korean": "비밀번호 재 입력",
-			"german": "Wiederhole die Eingabe deines Passwortes"
-		},
-		"2fa-setup-step4-contact-support": {
-			"mandarin": "联系支持",
-			"spanish": "Soporte de contacto",
-			"english": "Contact Support",
-			"japanese": "サポート問い合わせ先",
-			"korean": "연락처 지원",
-			"german": "Kontaktieren Sie Support"
-		},
-		"reconstruct-backup-phrase-placeholder": {
-			"mandarin": "输入备用词组",
-			"spanish": "Ingrese la frase de respaldo",
-			"english": "Enter backup phrase",
-			"japanese": "バックアップフレーズを入力してください",
-			"korean": "백업 문구 입력",
-			"german": "Geben Sie die Sicherungsphrase ein"
-		},
-		"register-subtitle-try-webauth": {
-			"mandarin": "您要在此设备上启用Touch ID / Face ID吗？",
-			"spanish": "¿Le gustaría habilitar Touch ID / Face ID en este dispositivo?",
-			"english": "Would you like to enable Touch ID / Face ID on this device?",
-			"japanese": "このデバイスでTouchID / Face IDを有効にしますか？",
-			"korean": "이 장치에서 Touch ID / Face ID를 활성화 하시겠습니까?",
-			"german": "Möchten Sie die Touch ID / Face ID auf diesem Gerät aktivieren?"
-		},
-		"2fa-setup-step3-note12": {
-			"mandarin": "您需要在下一个屏幕上确认此短语",
-			"spanish": "Deberá confirmar esta frase en la siguiente pantalla",
-			"english": "You will need to confirm this phrase on the next screen",
-			"japanese": "次の画面でこのフレーズを確認する必要があります",
-			"korean": "다음 화면에서 이 문구를 확인해야 합니다.",
-			"german": "Sie müssen diesen Satz auf dem nächsten Bildschirm bestätigen"
-		},
-		"2fa-setup-title31": {
-			"mandarin": "第 2 步：保存恢复短语",
-			"spanish": "Paso 2: Guarda la frase de recuperación",
-			"english": "Step 2: Save recovery phrase",
-			"japanese": "ステップ2：リカバリフレーズを保存する",
-			"korean": "2단계: 복구 문구 저장",
-			"german": "Schritt 2: Speichern Sie die Wiederherstellungsphrase"
-		},
-		"2fa-verify-step1-go-app": {
-			"mandarin": "转到应用程序",
-			"spanish": "Ir a la aplicación",
-			"english": "Go to App",
-			"japanese": "アプリに行きます",
-			"korean": "앱으로 이동",
-			"german": "Gehe zu App"
-		},
-		"2fa-setup-step3-sub2": {
-			"mandarin": "如果您无法访问保存的浏览器，您可以使用恢复短语进行身份验证。",
-			"spanish": "En caso de que pierda el acceso a su navegador guardado, puede autenticarse con su frase de recuperación.",
-			"english": "In case you lose access to your saved browser, you can authenticate with your recovery phrase.",
-			"japanese": "保存したブラウザにアクセスできなくなった場合は、リカバリフレーズで認証できます。",
-			"korean": "저장된 브라우저에 액세스할 수 없는 경우 복구 문구로 인증할 수 있습니다.",
-			"german": "Falls Sie den Zugriff auf Ihren gespeicherten Browser verlieren, können Sie sich mit Ihrer Wiederherstellungsphrase authentifizieren."
-		},
-		"2fa-verify-save-save": {
-			"mandarin": "保存此设备",
-			"spanish": "Guardar este dispositivo",
-			"english": "Save this device",
-			"japanese": "このデバイスを保存します",
-			"korean": "이 기기 저장",
-			"german": "Speichern Sie dieses Gerät"
-		},
-		"2fa-verify-share-head": {
-			"mandarin": "选择以下之一",
-			"spanish": "Selecciona uno de los siguientes",
-			"english": "Select one of the following",
-			"japanese": "次のいずれかを選択してください",
-			"korean": "다음 중 하나를 선택하십시오.",
-			"german": "Wählen Sie eine der folgenden Optionen"
-		},
-		"mpc-2fa-setup-step4-recovery": {
-			"mandarin": "恢复系数",
-			"spanish": "Factor de recuperación",
-			"english": "Recovery factor",
-			"japanese": "回収率",
-			"korean": "회복 계수",
-			"german": "Erholungsfaktor"
-		},
-		"2fa-verify-reference-id": {
-			"mandarin": "参考编号",
-			"spanish": "Identificación de referencia",
-			"english": "Reference ID",
-			"japanese": "参照ID",
-			"korean": "참조 ID",
-			"german": "Referenz ID"
-		},
-		"2fa-setup-step4-sub21": {
-			"mandarin": "粘贴恢复短语",
-			"spanish": "Pega la frase de recuperación",
-			"english": "Paste the recovery phrase",
-			"japanese": "回復フレーズを貼り付けます",
-			"korean": "복구 문구 붙여넣기",
-			"german": "Fügen Sie den Wiederherstellungssatz ein"
-		},
-		"2fa-verify-recovery-note": {
-			"mandarin": "如果您无法验证上述任何一项，则无法登录您的帐户。",
-			"spanish": "Si no puede verificar ninguno de los anteriores, no puede iniciar sesión en su cuenta.",
-			"english": "If you are unable to verify any of the above, you are unable to login to your account.",
-			"japanese": "上記のいずれかを確認できない場合は、アカウントにログインできません。",
-			"korean": "위의 항목 중 하나라도 확인할 수 없으면 계정에 로그인할 수 없습니다.",
-			"german": "Wenn Sie keinen der oben genannten Punkte bestätigen können, können Sie sich nicht bei Ihrem Konto anmelden."
-		},
-		"register-backup-phrase-placeholder": {
-			"mandarin": "输入辅助邮箱",
-			"spanish": "Ingresa el correo de recuperación",
-			"english": "Enter recovery email",
-			"japanese": "復旧メールを入力してください",
-			"korean": "복구 이메일 입력",
-			"german": "Geben Sie die Wiederherstellungs-E-Mail ein"
-		},
-		"2fa-setup-step3-sub1": {
-			"mandarin": "提供电子邮件以接收恢复短语",
-			"spanish": "Proporcione un correo electrónico para recibir la frase de recuperación",
-			"english": "Provide an email to receive recovery phrase",
-			"japanese": "回復フレーズを受け取るための電子メールを提供する",
-			"korean": "복구 문구를 받을 이메일 제공",
-			"german": "Geben Sie eine E-Mail an, um die Wiederherstellungsphrase zu erhalten"
-		},
-		"register-skip": {
-			"mandarin": "立即跳过",
-			"spanish": "Saltar por ahora",
-			"english": "Skip for Now",
-			"japanese": "今はスキップ",
-			"korean": "일단은 스킵",
-			"german": "Für jetzt überspringen"
-		},
-		"returning-confirm-desc": {
-			"mandarin": "继续通过生物识别登录？",
-			"spanish": "¿Continuar con el inicio de sesión mediante datos biométricos?",
-			"english": "Continue your sign in via biometrics?",
-			"japanese": "生体認証を介してサインインを続行しますか？",
-			"korean": "생체 인식을 통해 계속 로그인 하시겠습니까?",
-			"german": "Mit der Anmeldung über Biometrie fortfahren?"
-		},
-		"register-biometrics-enable": {
-			"mandarin": "启用触摸ID /面部ID",
-			"spanish": "Habilitar Touch ID / Face ID",
-			"english": "Enable Touch ID / Face ID",
-			"japanese": "Touch ID / FaceIDを有効にする",
-			"korean": "Touch ID / Face ID 활성화",
-			"german": "Aktivieren Sie Touch ID / Face ID"
-		},
-		"reconstruct-backup-phrase-desc-3": {
-			"mandarin": "并发送到电子邮件：",
-			"spanish": "y enviado al correo electrónico:",
-			"english": "and sent to email: ",
-			"japanese": "そして電子メールに送られる：",
-			"korean": "이메일로 전송:",
-			"german": "und an E-Mail gesendet:"
-		},
-		"2fa-verify-share-browser": {
-			"mandarin": "浏览器",
-			"spanish": "Navegador",
-			"english": "Browser",
-			"japanese": "ブラウザ",
-			"korean": "브라우저",
-			"german": "Browser"
-		},
-		"2fa-setup-step4-check-time": {
-			"mandarin": "没有收到吗？ 反感。 再次签入{0}",
-			"spanish": "¿No lo recibiste? Resentirse de. Vuelve a comprobar en {0}",
-			"english": "Did not receive it? Resent. Check again in {0}",
-			"japanese": "受け取りませんでしたか？ 憤る。 {0}でもう一度確認してください",
-			"korean": "받지 못하셨나요? 화내다. {0}에서 다시 확인",
-			"german": "Nicht erhalten? Übelnehmen. Erneut einchecken in {0}"
-		},
-		"2fa-verify-multi-subhead": {
-			"mandarin": "登录到以下已保存的浏览器以批准访问",
-			"spanish": "Inicie sesión en el siguiente navegador guardado para aprobar el acceso",
-			"english": "Login to the following saved browser to approve access",
-			"japanese": "次の保存されたブラウザにログインして、アクセスを承認します",
-			"korean": "액세스를 승인하려면 다음 저장된 브라우저에 로그인하십시오.",
-			"german": "Melden Sie sich beim folgenden gespeicherten Browser an, um den Zugriff zu genehmigen"
-		},
-		"2fa-setup-title12": {
-			"mandarin": "设置 2 因素身份验证",
-			"spanish": "Configurar autenticación de 2 factores",
-			"english": "Set up 2 Factor Authentication",
-			"japanese": "2要素認証を設定する",
-			"korean": "2단계 인증 설정",
-			"german": "2-Faktor-Authentifizierung einrichten"
-		},
-		"verifier-google-desc": {
-			"mandarin": "继续使用Google",
-			"spanish": "Continuar con Google",
-			"english": "Continue with Google",
-			"japanese": "Googleで続行",
-			"korean": "Google로 계속",
-			"german": "Fahren Sie mit Google fort"
-		},
-		"2fa-setup-step3-manual-save": {
-			"mandarin": "手动保存您的短语",
-			"spanish": "Guarde manualmente su frase",
-			"english": "Manually save your phrase",
-			"japanese": "フレーズを手動で保存する",
-			"korean": "수동으로 문구 저장",
-			"german": "Speichern Sie Ihren Satz manuell"
-		},
-		"2fa-setup-step3-toggle2": {
-			"mandarin": "通过电子邮件向我发送恢复短语",
-			"spanish": "Envíame mi frase de recuperación por correo electrónico",
-			"english": "Email me my recovery phrase",
-			"japanese": "私の回復フレーズを私にメールしてください",
-			"korean": "내 복구 문구를 이메일로 보내주세요",
-			"german": "Senden Sie mir meinen Wiederherstellungssatz per E-Mail"
-		},
-		"2fa-setup-step1-next": {
-			"mandarin": "设置 2FA",
-			"spanish": "Configurar 2FA",
-			"english": "Set up 2FA",
-			"japanese": "2FAを設定する",
-			"korean": "2FA 설정",
-			"german": "2FA einrichten"
-		},
-		"2fa-setup-step2-confirm-note": {
-			"mandarin": "我了解清除浏览器历史记录和 cookie 将删除我浏览器上的这个因素。",
-			"spanish": "Entiendo que borrar el historial del navegador y las cookies eliminará este factor en mi navegador.",
-			"english": "I understand that clearing browser history and cookies will delete this factor on my browser.",
-			"japanese": "ブラウザの履歴とCookieをクリアすると、ブラウザのこの要素が削除されることを理解しています。",
-			"korean": "브라우저 기록 및 쿠키를 지우면 내 브라우저에서 이 요소가 삭제된다는 것을 이해합니다.",
-			"german": "Mir ist bewusst, dass das Löschen des Browserverlaufs und der Cookies diesen Faktor in meinem Browser löscht."
-		},
-		"2fa-verify-step1-panel1": {
-			"mandarin": "保存的浏览器/设备",
-			"spanish": "Navegadores / dispositivos guardados",
-			"english": "Saved browser(s) / devices",
-			"japanese": "保存されたブラウザ/デバイス",
-			"korean": "저장된 브라우저/기기",
-			"german": "Gespeicherte(r) Browser/Geräte"
-		},
-		"mpc-2fa-verify-step1-rec-placeholder": {
-			"mandarin": "恢复系数",
-			"spanish": "Factor de recuperación",
-			"english": "Recovery factor",
-			"japanese": "回収率",
-			"korean": "회복 계수",
-			"german": "Erholungsfaktor"
-		},
-		"social-2fa-verify-email": {
-			"mandarin": "通过电子邮件验证",
-			"spanish": "Verifique con su correo electrónico",
-			"english": "Verify with your email",
-			"japanese": "メールで確認してください",
-			"korean": "이메일로 확인하십시오",
-			"german": "Überprüfen Sie mit Ihrer E -Mail"
-		},
-		"popup-continue-existing": {
-			"mandarin": "继续使用现有的{0}",
-			"spanish": "Continuar con {0} existente",
-			"english": "Continue with existing {0}",
-			"japanese": "既存の{0}を続行します",
-			"korean": "기존 {0} 계속",
-			"german": "Weiter mit vorhandenem {0}"
-		},
-		"register-title-additional-security": {
-			"mandarin": "出发前的最后一步",
-			"spanish": "Un último paso antes de irte",
-			"english": "One last step before you go",
-			"japanese": "行く前の最後の一歩",
-			"korean": "가기 전에 마지막 단계",
-			"german": "Ein letzter Schritt bevor du gehst"
-		},
-		"2fa-setup-step2-sub1": {
-			"mandarin": "使用当前浏览器设置",
-			"spanish": "Configurar usando el navegador actual",
-			"english": "Set up using current browser",
-			"japanese": "現在のブラウザを使用して設定",
-			"korean": "현재 브라우저를 사용하여 설정",
-			"german": "Mit aktuellem Browser einrichten"
-		},
-		"register-backup-phrase-desc1": {
-			"mandarin": "将向您发送一封包含备份短语的电子邮件。",
-			"spanish": "Se le enviará un correo electrónico con la frase de respaldo.",
-			"english": "An email will be sent to you containing the backup phrase.",
-			"japanese": "バックアップ フレーズを含むメールが送信されます。",
-			"korean": "백업 문구가 포함 된 이메일이 발송됩니다.",
-			"german": "Sie erhalten eine E-Mail mit der Backup-Phrase."
-		},
-		"2fa-setup-step3-hide-adv": {
-			"mandarin": "隐藏高级选项",
-			"spanish": "Ocultar opción avanzada",
-			"english": "Hide advanced option",
-			"japanese": "詳細オプションを非表示",
-			"korean": "고급 옵션 숨기기",
-			"german": "Erweiterte Option ausblenden"
-		},
-		"2fa-verify-success-subtitle": {
-			"mandarin": "登录",
-			"spanish": "iniciando sesión",
-			"english": "Logging you in",
-			"japanese": "ログインします",
-			"korean": "로그인",
-			"german": "Melden Sie sich an"
-		},
-		"2fa-setup-step1-desc22": {
-			"mandarin": "只需 3 个简单的步骤即可完成设置！",
-			"spanish": "¡Configúralo en 3 sencillos pasos!",
-			"english": "Set it up in 3 simple steps!",
-			"japanese": "3つの簡単なステップでセットアップしてください！",
-			"korean": "간단한 3단계로 설정하세요!",
-			"german": "Richten Sie es in 3 einfachen Schritten ein!"
-		},
-		"2fa-setup-step3-next3": {
-			"mandarin": "发送恢复短语",
-			"spanish": "Enviar frase de recuperación",
-			"english": "Send recovery phrase",
-			"japanese": "回復フレーズを送信する",
-			"korean": "복구 문구 보내기",
-			"german": "Wiederherstellungsphrase senden"
-		},
-		"register-backup-phrase-send": {
-			"mandarin": "发送恢复电子邮件",
-			"spanish": "Enviar correo de recuperación",
-			"english": "Send recovery email",
-			"japanese": "復旧メールを送信する",
-			"korean": "복구 이메일 보내기",
-			"german": "Wiederherstellungs-E-Mail senden"
-		},
-		"mpc-2fa-setup-step3-sub1": {
-			"mandarin": "提供电子邮件以接收恢复短语",
-			"spanish": "Proporcione un correo electrónico para recibir la frase de recuperación",
-			"english": "Provide an email to receive recovery factor",
-			"japanese": "回復フレーズを受け取るための電子メールを提供する",
-			"korean": "복구 문구를 받을 이메일 제공",
-			"german": "Geben Sie eine E-Mail an, um die Wiederherstellungsphrase zu erhalten"
-		},
-		"2fa-setup-step3-show-adv": {
-			"mandarin": "查看高级选项",
-			"spanish": "Ver opción avanzada",
-			"english": "View advanced option",
-			"japanese": "詳細オプションを表示",
-			"korean": "고급 옵션 보기",
-			"german": "Erweiterte Option anzeigen"
-		},
-		"2fa-verify-step1-rec-placeholder": {
-			"mandarin": "恢复短语",
-			"spanish": "Frase de recuperación",
-			"english": "Recovery phrase",
-			"japanese": "回復フレーズ",
-			"korean": "복구 문구",
-			"german": "Wiederherstellungsphrase"
-		},
-		"2fa-verify-step2-sub1": {
-			"mandarin": "验证成功",
-			"spanish": "Verificación exitosa",
-			"english": "Successful verification",
-			"japanese": "検証の成功",
-			"korean": "인증 성공",
-			"german": "Erfolgreiche Verifizierung"
-		},
-		"title": {
-			"mandarin": "一站式管理所有网络互动",
-			"spanish": "Administre todas sus interacciones web en un solo lugar",
-			"english": "Manage all your web interactions in one place",
-			"japanese": "すべてのWebインタラクションを1か所で管理します",
-			"korean": "모든 웹 상호 작용을 한 곳에서 관리",
-			"german": "Verwalten Sie alle Ihre Webinteraktionen an einem Ort"
-		},
-		"register-biometrics-desc": {
-			"mandarin": "使用面容 ID 或触控 ID 注册您的设备。 生物识别技术永远不会离开您的设备。",
-			"spanish": "Registre su dispositivo con Face ID o Touch ID. La biometría nunca abandona su dispositivo.",
-			"english": "Register your device with Face ID or Touch ID. Biometrics never leave your device.",
-			"japanese": "デバイスを Face ID または Touch ID で登録します。 生体認証がデバイスから離れることはありません。",
-			"korean": "Face ID 또는 Touch ID로 기기를 등록하세요. 생체 인식은 장치를 떠나지 않습니다.",
-			"german": "Registrieren Sie Ihr Gerät mit Face ID oder Touch ID. Biometrie verlässt Ihr Gerät nie."
-		},
-		"mpc-2fa-setup-title3": {
-			"mandarin": "保存恢复短语",
-			"spanish": "Guardar frase de recuperación",
-			"english": "Save recovery factor",
-			"japanese": "回復フレーズを保存する",
-			"korean": "복구 문구 저장",
-			"german": "Wiederherstellungsphrase speichern"
-		},
-		"reconstruct-device-prev2": {
-			"mandarin": "Torus钱包的先前版本",
-			"spanish": "versión anterior de Torus Wallet",
-			"english": "previous version of the Torus Wallet",
-			"japanese": "トーラスウォレットの以前のバージョン",
-			"korean": "이전 버전의 토러스 지갑",
-			"german": "vorherige Version der Torus-Brieftasche"
-		},
-		"2fa-setup-step3-next4": {
-			"mandarin": "我已经保存了我的恢复短语",
-			"spanish": "He guardado mi frase de recuperación",
-			"english": "I have saved my recovery phrase",
-			"japanese": "回復フレーズを保存しました",
-			"korean": "복구 문구를 저장했습니다",
-			"german": "Ich habe meine Wiederherstellungsphrase gespeichert"
-		},
-		"2fa-setup-step3-download": {
-			"mandarin": "下载我的恢复短语",
-			"spanish": "Descarga mi frase de recuperación",
-			"english": "Download my recovery phrase",
-			"japanese": "私の回復フレーズをダウンロードする",
-			"korean": "내 복구 문구 다운로드",
-			"german": "Laden Sie meinen Wiederherstellungssatz herunter"
-		},
-		"reconstruct-biometrics-desc": {
-			"mandarin": "*仅适用于先前在以下设备上设置的Touch ID / Face ID：",
-			"spanish": "* Solo para Touch ID / Face ID configurado previamente en los siguientes dispositivos:",
-			"english": "* Only for Touch ID / Face ID previously set up on the following device(s):",
-			"japanese": "*以下のデバイスで以前に設定されたTouchID / Face IDの場合のみ：",
-			"korean": "* 다음 장치에서 이전에 설정 한 Touch ID / Face ID에만 해당됩니다.",
-			"german": "* Nur für Touch ID / Face ID, die zuvor auf den folgenden Geräten eingerichtet wurden:"
-		},
-		"register-password-confirm": {
-			"mandarin": "设定密码",
-			"spanish": "Configurar contraseña",
-			"english": "Set up password",
-			"japanese": "パスワードを設定する",
-			"korean": "비밀번호 설정",
-			"german": "Passwort einrichten"
-		},
-		"register-backup-phrase-title": {
-			"mandarin": "继续发送辅助邮箱",
-			"spanish": "Continuar con un correo de recuperación",
-			"english": "Continue with a recovery email",
-			"japanese": "復旧メールを続行します",
-			"korean": "복구 이메일로 계속",
-			"german": "Fahren Sie mit einer Wiederherstellungs-E-Mail fort"
-		},
-		"mpc-2fa-setup-step4-sub21": {
-			"mandarin": "粘贴恢复因子",
-			"spanish": "Pegar el factor de recuperación",
-			"english": "Paste the recovery factor",
-			"japanese": "回復係数を貼り付けます",
-			"korean": "회복 인자 붙여넣기",
-			"german": "Fügen Sie den Wiederherstellungsfaktor ein"
-		},
-		"2fa-verify-step1-sub1": {
-			"mandarin": "使用以下之一进行身份验证",
-			"spanish": "Autenticarse con uno de los siguientes",
-			"english": "Authenticate with one of the following",
-			"japanese": "次のいずれかで認証します",
-			"korean": "다음 중 하나로 인증",
-			"german": "Authentifizieren Sie sich mit einer der folgenden Optionen"
-		},
-		"2fa-verify-title1": {
-			"mandarin": "验证您的登录信息",
-			"spanish": "Verifique su inicio de sesión",
-			"english": "Verify your login",
-			"japanese": "ログインを確認する",
-			"korean": "로그인 확인",
-			"german": "Bestätigen Sie Ihre Anmeldung"
-		},
-		"migrate-desc22": {
-			"mandarin": "请在此新版本上验证您的身份",
-			"spanish": "por favor verifique su identidad en esta nueva versión",
-			"english": "kindly verify your identity on this new version",
-			"japanese": "この新しいバージョンであなたの身元を確認してください",
-			"korean": "이 새 버전에서 신원을 확인하십시오.",
-			"german": "Bitte überprüfen Sie Ihre Identität in dieser neuen Version"
-		},
-		"social-2fa-verify-account": {
-			"mandarin": "验证您的社交帐户",
-			"spanish": "Verifique con su cuenta social",
-			"english": "Verify with your social account",
-			"japanese": "ソーシャルアカウントで確認します",
-			"korean": "소셜 계정으로 확인하십시오",
-			"german": "Überprüfen Sie mit Ihrem sozialen Konto"
-		},
-		"register-subtitle-additional-security": {
-			"mandarin": "您的帐户安全很重要。 让我们支持它。",
-			"spanish": "La seguridad de su cuenta es importante. Hagamos una copia de seguridad.",
-			"english": "Your account security matters. Let’s back it up.",
-			"japanese": "アカウントのセキュリティが重要です。 後押ししましょう。",
-			"korean": "귀하의 계정 보안이 중요합니다. 백업합시다.",
-			"german": "Die Sicherheit Ihres Kontos ist wichtig. Lass es uns sichern."
-		},
-		"2fa-setup-step1-sub3": {
-			"mandarin": "为您的帐户添加额外的安全层并妥善保管您的资产。",
-			"spanish": "Agregue una capa adicional de seguridad a su cuenta y proteja sus activos.",
-			"english": "Add an extra layer of security to your account and safekeep your assets.",
-			"japanese": "アカウントにセキュリティの層を追加し、資産を保護します。",
-			"korean": "계정에 보안 계층을 추가하고 자산을 보호하십시오.",
-			"german": "Fügen Sie Ihrem Konto eine zusätzliche Sicherheitsebene hinzu und bewahren Sie Ihre Vermögenswerte sicher auf."
-		},
-		"social-2fa-subtitle-2": {
-			"mandarin": "如果您无法访问保存的浏览器，则可以通过社交帐户进行身份验证。",
-			"spanish": "En caso de que pierda acceso a su navegador guardado, puede autenticarse con su cuenta social.",
-			"english": "In case you lose access to your saved browser, you can authenticate with your Social account.",
-			"japanese": "保存されたブラウザへのアクセスを失う場合は、ソーシャルアカウントで認証できます。",
-			"korean": "저장된 브라우저에 대한 액세스 권한을 잃어버린 경우 소셜 계정으로 인증 할 수 있습니다.",
-			"german": "Falls Sie den Zugriff auf Ihren gespeicherten Browser verlieren, können Sie sich mit Ihrem sozialen Konto authentifizieren."
-		},
-		"popup-here": {
-			"mandarin": "这里",
-			"spanish": "aquí",
-			"english": "here",
-			"japanese": "ここに",
-			"korean": "여기",
-			"german": "Hier"
-		},
-		"verifier-email-desc": {
-			"mandarin": "继续发送电子邮件",
-			"spanish": "Continuar con el correo electrónico",
-			"english": "Continue with Email",
-			"japanese": "メールを続ける",
-			"korean": "이메일로 계속",
-			"german": "Fahren Sie mit E-Mail fort"
-		},
-		"returning-exist-use-another": {
-			"mandarin": "使用其他帐户",
-			"spanish": "Usa otra cuenta",
-			"english": "Use another account",
-			"japanese": "別のアカウントを使用する",
-			"korean": "다른 계정 사용",
-			"german": "Benutze einen anderen Account"
-		},
-		"popup-view-less": {
-			"mandarin": "查看较少的选项",
-			"spanish": "Ver menos opciones",
-			"english": "View less options",
-			"japanese": "少ないオプションを表示",
-			"korean": "옵션 간략히보기",
-			"german": "Weniger Optionen anzeigen"
-		},
-		"2fa-setup-title3": {
-			"mandarin": "保存恢复短语",
-			"spanish": "Guardar frase de recuperación",
-			"english": "Save recovery phrase",
-			"japanese": "回復フレーズを保存する",
-			"korean": "복구 문구 저장",
-			"german": "Wiederherstellungsphrase speichern"
-		},
-		"2fa-verify-step1-do-not-save": {
-			"mandarin": "不要保存此浏览器/设备。",
-			"spanish": "No guarde este navegador / dispositivo.",
-			"english": "Do not save this brower/device.",
-			"japanese": "このブラウザ/デバイスを保存しないでください。",
-			"korean": "이 브라우저/장치를 저장하지 마십시오.",
-			"german": "Speichern Sie diesen Browser/dieses Gerät nicht."
-		},
-		"2fa-setup-step3-sub22": {
-			"mandarin": "我知道如果我丢失了这个恢复短语，我将承担丢失帐户的风险。",
-			"spanish": "Sé que si pierdo esta frase de recuperación, correré el riesgo de perder mi cuenta.",
-			"english": "I know that if I lose this recovery phrase, I will bear the risk of losing my account.",
-			"japanese": "この回復フレーズを失った場合、アカウントを失うリスクを負うことを私は知っています。",
-			"korean": "이 복구 문구를 잃어버리면 계정을 잃을 위험을 감수해야 한다는 것을 알고 있습니다.",
-			"german": "Ich weiß, dass ich das Risiko trage, mein Konto zu verlieren, wenn ich diesen Wiederherstellungssatz verliere."
-		},
-		"returning-header-desc": {
-			"mandarin": "您的数字钱包通过",
-			"spanish": "Tu billetera digital a través de",
-			"english": "Your digital wallet via",
-			"japanese": "経由であなたのデジタルウォレット",
-			"korean": "디지털 지갑을 통해",
-			"german": "Ihre digitale Geldbörse über"
-		},
-		"2fa-setup-step4-next": {
-			"mandarin": "核实",
-			"spanish": "Verificar",
-			"english": "Verify",
-			"japanese": "確認",
-			"korean": "검증",
-			"german": "Verifizieren"
-		},
-		"reconstruct-title": {
-			"mandarin": "验证您的登录名",
-			"spanish": "Verifique su inicio de sesión",
-			"english": "Verify your login",
-			"japanese": "ログインを確認する",
-			"korean": "로그인 확인",
-			"german": "Überprüfen Sie Ihr Login"
-		},
-		"popup-subtitle": {
-			"mandarin": "选择您想继续的方式",
-			"spanish": "Seleccione cómo le gustaría continuar",
-			"english": "Select how you would like to continue",
-			"japanese": "続行する方法を選択してください",
-			"korean": "계속할 방법을 선택하십시오.",
-			"german": "Wählen Sie aus, wie Sie fortfahren möchten"
-		},
-		"2fa-verify-multi-subhead2": {
-			"mandarin": "登录请求将发送到您保存的浏览器",
-			"spanish": "Se enviará una solicitud de inicio de sesión a su navegador guardado",
-			"english": "A login request will be sent to your saved browser",
-			"japanese": "保存したブラウザにログインリクエストが送信されます",
-			"korean": "저장된 브라우저로 로그인 요청이 전송됩니다.",
-			"german": "Eine Anmeldeanfrage wird an Ihren gespeicherten Browser gesendet"
-		},
-		"returning-confirm-btn": {
-			"mandarin": "是的，继续生物识别",
-			"spanish": "Sí, continuar con la biometría",
-			"english": "Yes, continue with biometrics",
-			"japanese": "はい、生体認証を続行します",
-			"korean": "예, 생체 인식을 계속합니다.",
-			"german": "Ja, weiter mit Biometrie"
-		},
-		"register-subtitle": {
-			"mandarin": "选择以下之一",
-			"spanish": "Selecciona uno de los siguientes",
-			"english": "Select one of the following",
-			"japanese": "次のいずれかを選択してください",
-			"korean": "다음 중 하나를 선택하십시오.",
-			"german": "Wählen Sie eine der folgenden Optionen"
-		},
-		"reconstruct-subtitle": {
-			"mandarin": "验证以下内容之一以访问您的帐户",
-			"spanish": "Verifique con uno de los siguientes para acceder a su cuenta",
-			"english": "Verify with one of the following to access your account",
-			"japanese": "アカウントにアクセスするには、次のいずれかで確認してください",
-			"korean": "계정에 액세스하려면 다음 중 하나로 확인하세요.",
-			"german": "Überprüfen Sie mit einem der folgenden Punkte, um auf Ihr Konto zuzugreifen"
-		},
-		"register-title": {
-			"mandarin": "保护您的{0}帐户",
-			"spanish": "Asegurar su cuenta de {0}",
-			"english": "Securing your {0} account",
-			"japanese": "{0}アカウントを保護する",
-			"korean": "{0} 계정 보안",
-			"german": "Sichern Sie Ihr {0} Konto"
-		},
-		"register-title-try-webauth": {
-			"mandarin": "保护您的帐户",
-			"spanish": "Asegurar su cuenta",
-			"english": "Securing your account",
-			"japanese": "アカウントを保護する",
-			"korean": "계정 보안",
-			"german": "Sichern Sie Ihr Konto"
-		},
-		"reconstruct-device-prev3": {
-			"mandarin": "从下面存储的浏览器中验证您的身份。",
-			"spanish": "desde el navegador almacenado a continuación para verificar su identidad.",
-			"english": "from the stored browser below to verify your identity.",
-			"japanese": "以下の保存されているブラウザから本人確認を行ってください。",
-			"korean": "아래 저장된 브라우저에서 귀하의 신원을 확인하십시오.",
-			"german": "über den unten gespeicherten Browser, um Ihre Identität zu überprüfen."
-		},
-		"verifier-email-placeholder": {
-			"mandarin": "电子邮件",
-			"spanish": "Correo electrónico",
-			"english": "Email",
-			"japanese": "Eメール",
-			"korean": "이메일",
-			"german": "Email"
-		},
-		"social-2fa-warning-cta-1": {
-			"mandarin": "是的，我接受风险",
-			"spanish": "Sí, acepto el riesgo",
-			"english": "Yes, I accept the risk",
-			"japanese": "はい、私はリスクを受け入れます",
-			"korean": "예, 위험을 받아들입니다",
-			"german": "Ja, ich akzeptiere das Risiko"
-		},
-		"subtitle": {
-			"mandarin": "点击开始以继续",
-			"spanish": "Haga clic en comenzar para continuar",
-			"english": "Click Get Started to continue",
-			"japanese": "[開始]をクリックして続行します",
-			"korean": "계속하려면 시작하기를 클릭하세요.",
-			"german": "Klicken Sie auf Erste Schritte, um fortzufahren"
-		},
-		"2fa-verify-save-subhead": {
-			"mandarin": "您想将此设备保存为受信任的设备吗？",
-			"spanish": "¿Le gustaría guardar este dispositivo como dispositivo de confianza?",
-			"english": "Would you like to save this device as a trusted device?",
-			"japanese": "このデバイスを信頼できるデバイスとして保存しますか？",
-			"korean": "이 장치를 신뢰할 수 있는 장치로 저장하시겠습니까?",
-			"german": "Möchten Sie dieses Gerät als vertrauenswürdiges Gerät speichern?"
-		},
-		"2fa-setup-title5": {
-			"mandarin": "2FA 激活",
-			"spanish": "2FA activado",
-			"english": "2FA activated",
-			"japanese": "2FAがアクティブ化",
-			"korean": "2FA 활성화",
-			"german": "2FA aktiviert"
-		},
-		"mpc-2fa-setup-step3-sub2": {
-			"mandarin": "如果您无法访问保存的浏览器，您可以使用恢复短语进行身份验证。",
-			"spanish": "En caso de que pierda el acceso a su navegador guardado, puede autenticarse con su frase de recuperación.",
-			"english": "In case you lose access to your saved browser, you can authenticate with your recovery factor.",
-			"japanese": "保存したブラウザにアクセスできなくなった場合は、リカバリフレーズで認証できます。",
-			"korean": "저장된 브라우저에 액세스할 수 없는 경우 복구 문구로 인증할 수 있습니다.",
-			"german": "Falls Sie den Zugriff auf Ihren gespeicherten Browser verlieren, können Sie sich mit Ihrer Wiederherstellungsphrase authentifizieren."
-		},
-		"register-password-password": {
-			"mandarin": "输入密码",
-			"spanish": "Ingresa tu contraseña",
-			"english": "Enter your password",
-			"japanese": "パスワードを入力してください",
-			"korean": "비밀번호를 입력하세요",
-			"german": "Geben Sie Ihr Passwort ein"
-		},
-		"social-2fa-verify-heading": {
-			"mandarin": "社会恢复因素",
-			"spanish": "Factor de recuperación social",
-			"english": "Social Recovery factor",
-			"japanese": "社会的回復要因",
-			"korean": "사회 복구 요인",
-			"german": "Sozialer Genesungsfaktor"
-		},
-		"register-backup-phrase-additional-security-desc1": {
-			"mandarin": "将向您发送一封包含备份短语的电子邮件。",
-			"spanish": "Se le enviará un correo electrónico con la frase de respaldo.",
-			"english": "An email will be sent to you containing the backup phrase.",
-			"japanese": "バックアップ フレーズを含むメールが送信されます。",
-			"korean": "백업 문구가 포함 된 이메일이 발송됩니다.",
-			"german": "Sie erhalten eine E-Mail mit der Backup-Phrase."
-		},
-		"popup-manage": {
-			"mandarin": "管理帐户",
-			"spanish": "Administrar cuenta",
-			"english": "Manage account",
-			"japanese": "アカウントを管理する",
-			"korean": "계정 관리",
-			"german": "Konto verwalten"
-		},
-		"2fa-verify-try-other": {
-			"mandarin": "尝试其他方法",
-			"spanish": "Pruebe otros métodos",
-			"english": "Try other methods",
-			"japanese": "他の方法を試す",
-			"korean": "다른 방법 시도",
-			"german": "Probieren Sie andere Methoden aus"
-		},
-		"2fa-setup-title21": {
-			"mandarin": "第 1 步：保存您的设备",
-			"spanish": "Paso 1: Guarde su dispositivo",
-			"english": "Step 1: Save your device",
-			"japanese": "ステップ1：デバイスを保存する",
-			"korean": "1단계: 기기 저장",
-			"german": "Schritt 1: Speichern Sie Ihr Gerät"
-		},
-		"2fa-setup-step3-next2": {
-			"mandarin": "核实",
-			"spanish": "Verificar",
-			"english": "Verify",
-			"japanese": "確認",
-			"korean": "확인하다",
-			"german": "Verifizieren"
-		},
-		"migrate-list2": {
-			"mandarin": "由SSO和设备保护",
-			"spanish": "Asegurado por SSO y dispositivo",
-			"english": "Secured by SSO and device",
-			"japanese": "SSOとデバイスによって保護されています",
-			"korean": "SSO 및 장치로 보호",
-			"german": "Durch SSO und Gerät gesichert"
-		},
-		"2fa-verify-step1-verify": {
-			"mandarin": "核实",
-			"spanish": "Verificar",
-			"english": "Verify",
-			"japanese": "確認",
-			"korean": "검증",
-			"german": "Verifizieren"
-		}
-	}
+  "login": {
+    "2fa-verify-share-send": {
+      "mandarin": "发送请求",
+      "spanish": "Enviar petición",
+      "english": "Send request",
+      "japanese": "リクエストを送信",
+      "korean": "요청 보내기",
+      "german": "Anfrage senden",
+      "portuguese": "Enviar pedido"
+    },
+    "2fa-setup-step5-return-app": {
+      "mandarin": "返回申请",
+      "spanish": "Volver a la aplicación",
+      "english": "Return to application",
+      "japanese": "アプリケーションに戻る",
+      "korean": "애플리케이션으로 돌아가기",
+      "german": "Zurück zur Anwendung",
+      "portuguese": "Voltar ao aplicativo"
+    },
+    "2fa-setup-step3-sub21": {
+      "mandarin": "粘贴您发送到 {0} 的辅助短语",
+      "spanish": "Pegue su frase de recuperación enviada a {0}",
+      "english": "Paste your recovery phrase sent to {0}",
+      "japanese": "{0}に送信されたリカバリフレーズを貼り付けます",
+      "korean": "{0}(으)로 전송된 복구 문구를 붙여넣으세요.",
+      "german": "Fügen Sie Ihren Wiederherstellungssatz ein, der an {0} gesendet wurde",
+      "portuguese": "Cole sua frase de recuperação enviada para {0}"
+    },
+    "reconstruct-backup-phrase-desc-2": {
+      "mandarin": "确认已设置的备份集",
+      "spanish": "Compruebe el conjunto de copia de seguridad establecido",
+      "english": "Verify with your backup phrase that was setup on",
+      "japanese": "セットしたバックアップセットを確認する",
+      "korean": "설정된 백업 세트 확인",
+      "german": "Bestätigen Sie mit Ihrem Backup-Satz, der eingerichtet wurde",
+      "portuguese": "Verifique com sua frase de backup que foi configurada em"
+    },
+    "2fa-verify-share-subhead": {
+      "mandarin": "您需要以下其中一项才能登录",
+      "spanish": "Necesita uno de los siguientes para iniciar sesión",
+      "english": "You need one of the following to login",
+      "japanese": "ログインするには、次のいずれかが必要です",
+      "korean": "로그인하려면 다음 중 하나가 필요합니다.",
+      "german": "Sie benötigen eine der folgenden Möglichkeiten, um sich anzumelden",
+      "portuguese": "Você precisa de um dos seguintes para fazer login"
+    },
+    "reconstruct-biometrics-verify": {
+      "mandarin": "使用Touch ID / Face ID进行验证",
+      "spanish": "Verificar con Touch ID / Face ID",
+      "english": "Verify with Touch ID / Face ID",
+      "japanese": "Touch ID / FaceIDで確認する",
+      "korean": "Touch ID / Face ID로 확인",
+      "german": "Überprüfen Sie mit Touch ID / Face ID",
+      "portuguese": "Verificar com Touch ID / Face ID"
+    },
+    "2fa-setup-step3-next": {
+      "mandarin": "继续",
+      "spanish": "Continuar",
+      "english": "Continue",
+      "japanese": "継続する",
+      "korean": "계속하다",
+      "german": "Weitermachen",
+      "portuguese": "Continuar"
+    },
+    "migrate-desc1": {
+      "mandarin": "最新版本的Torus Wallet由OpenLogin提供支持。",
+      "spanish": "La última versión de Torus Wallet funciona con OpenLogin.",
+      "english": "The latest version of Torus Wallet is powered by OpenLogin.",
+      "japanese": "Torus Walletの最新バージョンは、OpenLoginを利用しています。",
+      "korean": "최신 버전의 Torus Wallet은 OpenLogin에 의해 구동됩니다.",
+      "german": "Die neueste Version von Torus Wallet wird von OpenLogin unterstützt.",
+      "portuguese": "A versão mais recente da Torus Wallet é fornecida pelo OpenLogin."
+    },
+    "2fa-setup-title1": {
+      "mandarin": "保护您的帐户",
+      "spanish": "Asegure su cuenta",
+      "english": "Secure your account",
+      "japanese": "アカウントを保護する",
+      "korean": "계정 보안",
+      "german": "Sichern Sie Ihr Konto",
+      "portuguese": "Proteja sua conta"
+    },
+    "register-password-title": {
+      "mandarin": "设置帐号密码",
+      "spanish": "Configurar la contraseña de la cuenta",
+      "english": "Set up account password",
+      "japanese": "アカウントのパスワードを設定する",
+      "korean": "계정 비밀번호 설정",
+      "german": "Richten Sie das Kontokennwort ein",
+      "portuguese": "Configurar senha da conta"
+    },
+    "reconstruct-support": {
+      "mandarin": "联系支持",
+      "spanish": "Soporte de contacto",
+      "english": "Contact support",
+      "japanese": "サポート問い合わせ先",
+      "korean": "연락처 지원",
+      "german": "Kontaktieren Sie Support",
+      "portuguese": "Entre em contato com o suporte"
+    },
+    "returning-sign-in-header1": {
+      "mandarin": "使用其他帐户",
+      "spanish": "Usa otra cuenta",
+      "english": "Use another account",
+      "japanese": "別のアカウントを使用する",
+      "korean": "다른 계정 사용",
+      "german": "Benutze einen anderen Account",
+      "portuguese": "Usar outra conta"
+    },
+    "2fa-verify-multi-head": {
+      "mandarin": "允许从您保存的浏览器访问",
+      "spanish": "Permitir el acceso desde su navegador guardado",
+      "english": "Allow access from your saved browser",
+      "japanese": "保存したブラウザからのアクセスを許可する",
+      "korean": "저장된 브라우저에서 액세스 허용",
+      "german": "Erlauben Sie den Zugriff von Ihrem gespeicherten Browser",
+      "portuguese": "Permita o acesso do seu navegador salvo"
+    },
+    "social-2fa-subtitle-1": {
+      "mandarin": "用任何社会帐户登录将其设置为恢复因素",
+      "spanish": "Inicie sesión con cualquiera de la cuenta social para establecerla como factor de recuperación",
+      "english": "Login with any of the social account to set it as recovery factor",
+      "japanese": "ソーシャルアカウントのいずれかでログインして、回復要因として設定します",
+      "korean": "소셜 계정에 로그인하여 복구 계수로 설정",
+      "german": "Melden Sie sich mit einem der sozialen Konto an, um es als Wiederherstellungsfaktor festzulegen",
+      "portuguese": "Faça login com qualquer conta social para defini-la como fator de recuperação"
+    },
+    "social-2fa-warning-text": {
+      "mandarin": "您正在使用同一电子邮件进行帐户登录和社会因素。这是不安全的。您还想继续吗？",
+      "spanish": "Está utilizando el mismo correo electrónico para el inicio de sesión de la cuenta y el factor social. Esto es inseguro. ¿Todavía te gustaría continuar?",
+      "english": "You are using the same email for account login and social factor. This is insecure. Would you still like to proceed?",
+      "japanese": "アカウントログインとソーシャルファクターに同じメールを使用しています。これは不安です。まだ進みたいですか？",
+      "korean": "계정 로그인 및 소셜 요소에 동일한 이메일을 사용하고 있습니다. 이것은 안전하지 않습니다. 아직도 진행하고 싶습니까?",
+      "german": "Sie verwenden dieselbe E -Mail für Kontoanmeldung und sozialer Faktor. Das ist unsicher. Möchten Sie immer noch fortfahren?",
+      "portuguese": "Você está usando o mesmo e-mail para login da conta e fator social. Isso é inseguro. Você ainda gostaria de prosseguir?"
+    },
+    "2fa-setup-step3-download-phrase": {
+      "mandarin": "下载短语",
+      "spanish": "Descargar frase",
+      "english": "Download phrase",
+      "japanese": "フレーズをダウンロード",
+      "korean": "구문 다운로드",
+      "german": "Redewendung herunterladen",
+      "portuguese": "Baixar frase"
+    },
+    "2fa-setup-step1-sub2": {
+      "mandarin": "为您的帐户添加额外的安全层",
+      "spanish": "Agregue una capa adicional de seguridad a su cuenta",
+      "english": "Add an extra layer of security to your account",
+      "japanese": "アカウントにセキュリティの層を追加します",
+      "korean": "계정에 보안 계층 추가",
+      "german": "Fügen Sie Ihrem Konto eine zusätzliche Sicherheitsebene hinzu",
+      "portuguese": "Adicione uma camada extra de segurança à sua conta"
+    },
+    "2fa-verify-title2": {
+      "mandarin": "2FA 激活",
+      "spanish": "2FA activado",
+      "english": "2FA activated",
+      "japanese": "2FAがアクティブ化",
+      "korean": "2FA 활성화",
+      "german": "2FA aktiviert",
+      "portuguese": "2FA ativado"
+    },
+    "2fa-setup-step5-next": {
+      "mandarin": "完毕",
+      "spanish": "Hecho",
+      "english": "Done",
+      "japanese": "終わり",
+      "korean": "완료",
+      "german": "Fertig",
+      "portuguese": "Concluído"
+    },
+    "reconstruct-fail": {
+      "mandarin": "无法找回帐户？",
+      "spanish": "¿No puede recuperar la cuenta?",
+      "english": "Unable to recover account?",
+      "japanese": "アカウントを回復できませんか？",
+      "korean": "계정을 복구 할 수 없습니까?",
+      "german": "Konto kann nicht wiederhergestellt werden?",
+      "portuguese": "Não é possível recuperar a conta?"
+    },
+    "2fa-setup-step2-sub2": {
+      "mandarin": "使用当前浏览器批准来自新设备/浏览器的访问。",
+      "spanish": "Utilice el navegador actual para aprobar el acceso desde nuevos dispositivos / navegadores.",
+      "english": "Use the current browser to approve access from new devices/browsers.",
+      "japanese": "現在のブラウザを使用して、新しいデバイス/ブラウザからのアクセスを承認します。",
+      "korean": "현재 브라우저를 사용하여 새 장치/브라우저에서 액세스를 승인합니다.",
+      "german": "Verwenden Sie den aktuellen Browser, um den Zugriff von neuen Geräten/Browsern zu genehmigen.",
+      "portuguese": "Use o navegador atual para aprovar o acesso de novos dispositivos/navegadores."
+    },
+    "reconstruct-device-desc1": {
+      "mandarin": "登录到",
+      "spanish": "Iniciar sesión en",
+      "english": "Login to",
+      "japanese": "ログインする",
+      "korean": "로그인",
+      "german": "Einloggen in",
+      "portuguese": "Logar em"
+    },
+    "migrate-title": {
+      "mandarin": "变得简单而安全",
+      "spanish": "hecho simple y seguro con",
+      "english": "made simple and secure with",
+      "japanese": "シンプルで安全に",
+      "korean": "간단하고 안전하게",
+      "german": "einfach und sicher gemacht mit",
+      "portuguese": "simples e seguro com"
+    },
+    "social-2fa-warn-text-2": {
+      "mandarin": "在登录页面上使用此社交因素签名将为您提供一个新帐户。",
+      "spanish": "Iniciar sesión con este factor social en la página de inicio de sesión le dará una nueva cuenta.",
+      "english": "Signing in with this Social factor at the login page will give you a new account.",
+      "japanese": "ログインページでこのソーシャルファクターにサインインすると、新しいアカウントが提供されます。",
+      "korean": "로그인 페이지 에서이 소셜 요소에 로그인하면 새 계정이 제공됩니다.",
+      "german": "Wenn Sie sich bei diesem sozialen Faktor auf der Anmeldeseite anmelden, erhalten Sie ein neues Konto.",
+      "portuguese": "Entrar com este fator social na página de login lhe dará uma nova conta."
+    },
+    "reconstruct-always-skip": {
+      "mandarin": "总是跳过",
+      "spanish": "Saltar siempre",
+      "english": "Always skip",
+      "japanese": "常にスキップする",
+      "korean": "항상 건너뛰기",
+      "german": "Immer überspringen",
+      "portuguese": "Sempre pular"
+    },
+    "2fa-setup-step1-desc21": {
+      "mandarin": "我们强烈建议为像您这样的活跃用户设置 2FA。",
+      "spanish": "Recomendamos encarecidamente una configuración 2FA para un usuario activo como usted.",
+      "english": "We highly recommend a 2FA set up for an active user like yourself.",
+      "japanese": "あなたのようなアクティブユーザーには2FAを設定することを強くお勧めします。",
+      "korean": "귀하와 같은 활성 사용자를 위해 2FA 설정을 적극 권장합니다.",
+      "german": "Wir empfehlen dringend ein 2FA-Setup für einen aktiven Benutzer wie Sie.",
+      "portuguese": "Recomendamos uma configuração 2FA para um usuário ativo como você."
+    },
+    "2fa-setup-step3-copy-phrase": {
+      "mandarin": "复制短语",
+      "spanish": "Copiar frase",
+      "english": "Copy phrase",
+      "japanese": "フレーズをコピーする",
+      "korean": "문구 복사",
+      "german": "Satz kopieren",
+      "portuguese": "Copiar frase"
+    },
+    "2fa-verify-recovery-placeholder": {
+      "mandarin": "恢复短语",
+      "spanish": "Frase de recuperación",
+      "english": "Recovery phrase",
+      "japanese": "回復フレーズ",
+      "korean": "복구 문구",
+      "german": "Wiederherstellungsphrase",
+      "portuguese": "Frase de recuperação"
+    },
+    "2fa-verify-share-resend": {
+      "mandarin": "重新发送请求",
+      "spanish": "Reenviar solicitud",
+      "english": "Resend request",
+      "japanese": "再送信リクエスト",
+      "korean": "재전송 요청",
+      "german": "Anfrage erneut senden",
+      "portuguese": "Reenviar solicitação"
+    },
+    "reconstruct-password-desc": {
+      "mandarin": "在此处输入您的帐户恢复密码",
+      "spanish": "Ingrese la contraseña de recuperación de su cuenta aquí",
+      "english": "Enter your account recovery password here",
+      "japanese": "ここにアカウント回復パスワードを入力してください",
+      "korean": "여기에 계정 복구 비밀번호를 입력하세요.",
+      "german": "Geben Sie hier Ihr Passwort für die Kontowiederherstellung ein",
+      "portuguese": "Digite aqui a sua senha de recuperação de conta"
+    },
+    "2fa-setup-step3-cancel": {
+      "mandarin": "后退",
+      "spanish": "atrás",
+      "english": "Back",
+      "japanese": "戻る",
+      "korean": "뒤",
+      "german": "Zurück",
+      "portuguese": "Voltar"
+    },
+    "2fa-verify-step1-panel2": {
+      "mandarin": "恢复短语",
+      "spanish": "Frase de recuperación",
+      "english": "Recovery phrase",
+      "japanese": "回復フレーズ",
+      "korean": "복구 문구",
+      "german": "Wiederherstellungsphrase",
+      "portuguese": "Frase de recuperação"
+    },
+    "popup-title": {
+      "mandarin": "欢迎登机",
+      "spanish": "La bienvenida a bordo",
+      "english": "Welcome onboard",
+      "japanese": "ご乗車（搭乗）ありがとうございます",
+      "korean": "보드에 오신 것을 환영합니다",
+      "german": "Willkommen an Bord",
+      "portuguese": "Bem-vindo a bordo"
+    },
+    "2fa-setup-step5-sub2": {
+      "mandarin": "在 app.openlogin.com 上管理未来的帐户设置",
+      "spanish": "Administre la configuración de la cuenta futura en app.openlogin.com",
+      "english": "Manage future account settings on app.openlogin.com",
+      "japanese": "app.openlogin.comで将来のアカウント設定を管理します",
+      "korean": "app.openlogin.com에서 향후 계정 설정 관리",
+      "german": "Verwalten Sie zukünftige Kontoeinstellungen auf app.openlogin.com",
+      "portuguese": "Gerencie as configurações futuras da conta em app.openlogin.com"
+    },
+    "reconstruct-password-placeholder": {
+      "mandarin": "户口密码",
+      "spanish": "Contraseña de la cuenta",
+      "english": "Account password",
+      "japanese": "アカウントパスワード",
+      "korean": "계정 비밀번호",
+      "german": "Konto Passwort",
+      "portuguese": "Senha da conta"
+    },
+    "reconstruct-device-title": {
+      "mandarin": "设备",
+      "spanish": "Dispositivos",
+      "english": "Device(s)",
+      "japanese": "デバイス",
+      "korean": "장치",
+      "german": "Geräte",
+      "portuguese": "Dispositivo(s)"
+    },
+    "2fa-verify-recovery-title": {
+      "mandarin": "恢复代码",
+      "spanish": "Código de recuperación",
+      "english": "Recovery code",
+      "japanese": "リカバリコード",
+      "korean": "복구 코드",
+      "german": "Wiederherstellungscode",
+      "portuguese": "Código de recuperação"
+    },
+    "migrate-list1": {
+      "mandarin": "支持面部识别/触摸识别",
+      "spanish": "Soporta Face ID / Touch ID",
+      "english": "Supports Face ID / Touch ID",
+      "japanese": "Face ID / TouchIDをサポート",
+      "korean": "Face ID / Touch ID 지원",
+      "german": "Unterstützt Face ID / Touch ID",
+      "portuguese": "Suporta Face ID / Touch ID"
+    },
+    "register-biometrics-title": {
+      "mandarin": "继续使用Face ID或Touch ID",
+      "spanish": "Continuar con Face ID o Touch ID",
+      "english": "Continue with Face ID or Touch ID",
+      "japanese": "FaceIDまたはTouchIDに進む",
+      "korean": "Face ID 또는 Touch ID로 계속",
+      "german": "Fahren Sie mit Face ID oder Touch ID fort",
+      "portuguese": "Continue com Face ID ou Touch ID"
+    },
+    "popup-view-more": {
+      "mandarin": "查看更多选项",
+      "spanish": "Ver más opciones",
+      "english": "View more options",
+      "japanese": "その他のオプションを表示",
+      "korean": "더 많은 옵션보기",
+      "german": "Weitere Optionen anzeigen",
+      "portuguese": "Ver mais opções"
+    },
+    "returning-confirm-title": {
+      "mandarin": "我们只是想确定一下。",
+      "spanish": "Solo queremos estar seguros.",
+      "english": "We just want to be sure.",
+      "japanese": "確認したいだけです。",
+      "korean": "우리는 확신하고 싶습니다.",
+      "german": "Wir wollen nur sicher sein.",
+      "portuguese": "Só queremos ter certeza."
+    },
+    "migrate-subtitle": {
+      "mandarin": "迁移您的tKey",
+      "spanish": "Migrar su tKey",
+      "english": "Migrating your tKey",
+      "japanese": "tKeyの移行",
+      "korean": "tKey 마이그레이션",
+      "german": "Migrieren Sie Ihren tKey",
+      "portuguese": "Migrando sua tKey"
+    },
+    "2fa-setup-step4-recovery": {
+      "mandarin": "恢复短语",
+      "spanish": "Frase de recuperación",
+      "english": "Recovery phrase",
+      "japanese": "回復フレーズ",
+      "korean": "복구 문구",
+      "german": "Wiederherstellungsphrase",
+      "portuguese": "Frase de recuperação"
+    },
+    "reconstruct-device-prev1": {
+      "mandarin": "登录到您的",
+      "spanish": "Inicie sesión en su",
+      "english": "Login to your",
+      "japanese": "あなたのログイン",
+      "korean": "귀하의",
+      "german": "Melden Sie sich bei Ihrem an",
+      "portuguese": "Entre no seu"
+    },
+    "register-backup-phrase-confirm-desc3": {
+      "mandarin": "重新输入辅助邮箱",
+      "spanish": "vuelve a ingresar el correo de recuperación",
+      "english": "re-enter recovery email",
+      "japanese": "リカバリメールを再入力してください",
+      "korean": "복구 이메일 다시 입력",
+      "german": "wiederherstellungs-E-Mail erneut eingeben",
+      "portuguese": "digite novamente o e-mail de recuperação"
+    },
+    "2fa-verify-step1-rec-label": {
+      "mandarin": "输入恢复短语",
+      "spanish": "Ingrese la frase de recuperación",
+      "english": "Enter recovery phrase",
+      "japanese": "回復フレーズを入力してください",
+      "korean": "복구 문구 입력",
+      "german": "Geben Sie den Wiederherstellungssatz ein",
+      "portuguese": "Digite a frase de recuperação"
+    },
+    "migrate-continue": {
+      "mandarin": "继续",
+      "spanish": "Continuar",
+      "english": "Continue",
+      "japanese": "継続する",
+      "korean": "계속하다",
+      "german": "Fortsetzen",
+      "portuguese": "Continuar"
+    },
+    "2fa-setup-step3-enter-email": {
+      "mandarin": "输入你的电子邮箱地址",
+      "spanish": "Ingrese su dirección de correo electrónico",
+      "english": "Enter your email address",
+      "japanese": "メールアドレスを入力してください",
+      "korean": "이메일 주소를 입력하세요",
+      "german": "Geben sie ihre E-Mailadresse ein",
+      "portuguese": "Insira o seu endereço de email"
+    },
+    "reconstruct-password-title": {
+      "mandarin": "找回密码",
+      "spanish": "Contraseña de recuperación",
+      "english": "Recovery password",
+      "japanese": "回復パスワード",
+      "korean": "복구 암호",
+      "german": "Passwort zum Zurücksetzen",
+      "portuguese": "Senha de recuperação"
+    },
+    "2fa-setup-step5-sub1": {
+      "mandarin": "您的 2FA 已激活！",
+      "spanish": "¡Su 2FA ha sido activado!",
+      "english": "Your 2FA has been activated!",
+      "japanese": "2FAがアクティブになりました！",
+      "korean": "2FA가 활성화되었습니다!",
+      "german": "Ihre 2FA wurde aktiviert!",
+      "portuguese": "Seu 2FA foi ativado!"
+    },
+    "2fa-setup-title32": {
+      "mandarin": "第 3 步：验证恢复短语",
+      "spanish": "Paso 3: Verificar la frase de recuperación",
+      "english": "Step 3: Verify Recovery Phrase",
+      "japanese": "ステップ3：リカバリフレーズを確認する",
+      "korean": "3단계: 복구 문구 확인",
+      "german": "Schritt 3: Überprüfen Sie die Wiederherstellungsphrase",
+      "portuguese": "Etapa 3: verificar a frase de recuperação"
+    },
+    "2fa-setup-step3-verified": {
+      "mandarin": "已验证",
+      "spanish": "Verificado",
+      "english": "Verified",
+      "japanese": "確認済み",
+      "korean": "확인됨",
+      "german": "Verifiziert",
+      "portuguese": "Verificado"
+    },
+    "register-backup-phrase-additional-security-desc2": {
+      "mandarin": "如果您丢失带有 Touch ID / Face ID 的设备，它可以帮助您恢复帐户。",
+      "spanish": "Le ayuda con la recuperación de la cuenta en caso de que pierda su dispositivo con Touch ID / Face ID.",
+      "english": "It helps you with account recovery in case you lose your device with Touch ID / Face ID.",
+      "japanese": "Touch ID / Face ID でデバイスを紛失した場合のアカウント回復に役立ちます。",
+      "korean": "Touch ID / Face ID로 기기를 분실 한 경우 계정 복구에 도움이됩니다.",
+      "german": "Es hilft Ihnen bei der Kontowiederherstellung, falls Sie Ihr Gerät mit Touch ID / Face ID verlieren.",
+      "portuguese": "Ele ajuda na recuperação da conta caso você perca seu dispositivo com Touch ID/Face ID."
+    },
+    "2fa-setup-title2": {
+      "mandarin": "设置 2FA",
+      "spanish": "Configurar 2FA",
+      "english": "Set up 2FA",
+      "japanese": "2FAを設定する",
+      "korean": "2FA 설정",
+      "german": "2FA einrichten",
+      "portuguese": "Configurar 2FA"
+    },
+    "2fa-verify-verify": {
+      "mandarin": "核实",
+      "spanish": "Verificar",
+      "english": "Verify",
+      "japanese": "確認",
+      "korean": "검증",
+      "german": "Verifizieren",
+      "portuguese": "Verificar"
+    },
+    "2fa-setup-step3-enter-recovery": {
+      "mandarin": "输入您的辅助短语",
+      "spanish": "Introduce tu frase de recuperación",
+      "english": "Enter your recovery phrase",
+      "japanese": "回復フレーズを入力してください",
+      "korean": "복구 문구를 입력하세요",
+      "german": "Geben Sie Ihren Wiederherstellungssatz ein",
+      "portuguese": "Digite sua frase de recuperação"
+    },
+    "social-2fa-heading": {
+      "mandarin": "设定社会恢复因素",
+      "spanish": "Establecer factor de recuperación social",
+      "english": "Set Social recovery factor",
+      "japanese": "社会的回復要因を設定します",
+      "korean": "사회 복구 요인을 설정하십시오",
+      "german": "Setzen Sie den sozialen Genesungsfaktor",
+      "portuguese": "Definir fator de recuperação social"
+    },
+    "mpc-2fa-verify-step1-rec-label": {
+      "mandarin": "输入恢复系数",
+      "spanish": "Ingrese el factor de recuperación",
+      "english": "Enter recovery factor",
+      "japanese": "回復係数を入力してください",
+      "korean": "회복 계수 입력",
+      "german": "Erholungsfaktor eingeben",
+      "portuguese": "Insira o fator de recuperação"
+    },
+    "reconstruct-device-desc": {
+      "mandarin": "从下面存储的浏览器登录到{0}以验证您的身份。",
+      "spanish": "Inicie sesión en {0} desde el navegador almacenado a continuación para verificar su identidad.",
+      "english": "Login to {0} from the stored browser below to verify your identity.",
+      "japanese": "以下の保存されているブラウザから{0}にログインして、本人確認を行ってください。",
+      "korean": "아래 저장된 브라우저에서 {0}에 로그인하여 신원을 확인하세요.",
+      "german": "Melden Sie sich über den unten gespeicherten Browser bei {0} an, um Ihre Identität zu überprüfen.",
+      "portuguese": "Faça login em {0} no navegador armazenado abaixo para verificar sua identidade."
+    },
+    "2fa-setup-step2-current-browser": {
+      "mandarin": "当前浏览器",
+      "spanish": "Navegador actual",
+      "english": "Current browser",
+      "japanese": "現在のブラウザ",
+      "korean": "현재 브라우저",
+      "german": "Aktueller Browser",
+      "portuguese": "Navegador atual"
+    },
+    "2fa-setup-step4-cancel": {
+      "mandarin": "后退",
+      "spanish": "atrás",
+      "english": "Back",
+      "japanese": "戻る",
+      "korean": "뒤",
+      "german": "Zurück",
+      "portuguese": "Voltar"
+    },
+    "social-2fa-view-less": {
+      "mandarin": "少查看",
+      "spanish": "Ver menos",
+      "english": "View less",
+      "japanese": "表示が少なくなります",
+      "korean": "덜보십시오",
+      "german": "Weniger anzeigen",
+      "portuguese": "Ver menos"
+    },
+    "2fa-verify-success-title": {
+      "mandarin": "2FA 验证",
+      "spanish": "2FA verificado",
+      "english": "2FA verified",
+      "japanese": "2FA検証済み",
+      "korean": "2FA 인증",
+      "german": "2FA verifiziert",
+      "portuguese": "2FA verificado"
+    },
+    "popup-terms": {
+      "mandarin": "使用条款",
+      "spanish": "Condiciones de uso",
+      "english": "Terms of use",
+      "japanese": "利用規約",
+      "korean": "이용 약관",
+      "german": "Nutzungsbedingungen",
+      "portuguese": "Termos de uso"
+    },
+    "migrate-list3": {
+      "mandarin": "受保护的用户数据和隐私",
+      "spanish": "Privacidad y datos de usuario protegidos",
+      "english": "Protected user Data and Privacy",
+      "japanese": "保護されたユーザーデータとプライバシー",
+      "korean": "보호 된 사용자 데이터 및 개인 정보",
+      "german": "Geschützte Benutzerdaten und Datenschutz",
+      "portuguese": "Dados e privacidade protegidos do usuário"
+    },
+    "popup-continue": {
+      "mandarin": "继续",
+      "spanish": "Continuar",
+      "english": "Continue",
+      "japanese": "継続する",
+      "korean": "계속하다",
+      "german": "Fortsetzen",
+      "portuguese": "Continuar"
+    },
+    "reconstruct-backup-phrase-title": {
+      "mandarin": "备用词组",
+      "spanish": "Frase de respaldo",
+      "english": "Backup phrase",
+      "japanese": "バックアップフレーズ",
+      "korean": "백업 문구",
+      "german": "Sicherungssatz",
+      "portuguese": "Frase de backup"
+    },
+    "2fa-verify-save-nosave": {
+      "mandarin": "下次吧",
+      "spanish": "Quizás la próxima vez",
+      "english": "Maybe next time",
+      "japanese": "また今度",
+      "korean": "아마 다음 번에",
+      "german": "Vielleicht nächstes Mal",
+      "portuguese": "Talvez na próxima vez"
+    },
+    "2fa-setup-step2-save-device": {
+      "mandarin": "保存当前设备",
+      "spanish": "Guardar dispositivo actual",
+      "english": "Save current device",
+      "japanese": "現在のデバイスを保存",
+      "korean": "현재 장치 저장",
+      "german": "Aktuelles Gerät speichern",
+      "portuguese": "Salvar dispositivo atual"
+    },
+    "2fa-setup-step4-sub22": {
+      "mandarin": "粘贴发送到您的电子邮件的恢复短语 {0}",
+      "spanish": "Pega la frase de recuperación enviada a tu correo electrónico {0}",
+      "english": "Paste the recovery phrase sent to your email {0}",
+      "japanese": "メールに送信されたリカバリフレーズを貼り付けます{0}",
+      "korean": "이메일로 전송된 복구 문구를 붙여넣으세요 {0}",
+      "german": "Fügen Sie den Wiederherstellungssatz ein, der an Ihre E-Mail-Adresse {0} gesendet wurde.",
+      "portuguese": "Cole a frase de recuperação enviada para seu e-mail {0}"
+    },
+    "returning-sign-in-header2": {
+      "mandarin": "您似乎尚未登录帐户",
+      "spanish": "Parece que aún no ha iniciado sesión en una cuenta",
+      "english": "It seems like you are not signed in to an account yet",
+      "japanese": "アカウントにまだサインインしていないようです",
+      "korean": "아직 계정에 로그인하지 않은 것 같습니다.",
+      "german": "Anscheinend bist du noch nicht bei einem Konto angemeldet",
+      "portuguese": "Parece que você ainda não está conectado a uma conta"
+    },
+    "register-backup-phrase-confirm-desc1": {
+      "mandarin": "我确认我已收到恢复电子邮件。",
+      "spanish": "Confirmo que he recibido el correo de recuperación.",
+      "english": "I confirm that I have received the recovery email.",
+      "japanese": "復旧メールを受信したことを確認しました。",
+      "korean": "我确认我已收到恢复电子邮件。",
+      "german": "Ich bestätige, dass ich die Wiederherstellungs-E-Mail erhalten habe.",
+      "portuguese": "Confirmo que recebi o e-mail de recuperação."
+    },
+    "2fa-verify-recovery-label": {
+      "mandarin": "输入恢复短语",
+      "spanish": "Ingrese la frase de recuperación",
+      "english": "Enter recovery phrase",
+      "japanese": "回復フレーズを入力してください",
+      "korean": "복구 문구 입력",
+      "german": "Geben Sie den Wiederherstellungssatz ein",
+      "portuguese": "Digite a frase de recuperação"
+    },
+    "constructYourKey": {
+      "mandarin": "构建您的密钥",
+      "spanish": "Construyendo tu clave en",
+      "english": "Constructing your key on",
+      "japanese": "キーを作成する",
+      "korean": "키 구성",
+      "german": "Bauen Sie Ihren Schlüssel auf",
+      "portuguese": "Construindo sua chave em"
+    },
+    "2fa-verify-save-head": {
+      "mandarin": "帐户已恢复",
+      "spanish": "Cuenta recuperada",
+      "english": "Account recovered",
+      "japanese": "アカウントが回復しました",
+      "korean": "계정 복구됨",
+      "german": "Konto wiederhergestellt",
+      "portuguese": "Conta recuperada"
+    },
+    "register-backup-phrase-desc": {
+      "mandarin": "包含备用短语的电子邮件将发送给您。如果您丢失了设备，它将帮助您进行帐户恢复。",
+      "spanish": "Se le enviará un correo electrónico con la frase de respaldo. Le ayuda con la recuperación de la cuenta en caso de que pierda su dispositivo.",
+      "english": "An email will be sent to you containing the backup phrase. It helps you with account recovery in case you lose your device.",
+      "japanese": "バックアップフレーズを記載したメールが送信されます。デバイスを紛失した場合のアカウントの復旧に役立ちます。",
+      "korean": "백업 문구가 포함 된 이메일이 전송됩니다.  기기 분실시 계정 복구에 도움이됩니다.",
+      "german": "Sie erhalten eine E-Mail mit der Sicherungsphrase. Sie hilft Ihnen bei der Wiederherstellung des Kontos, falls Sie Ihr Gerät verlieren.",
+      "portuguese": "Um e-mail será enviado para você contendo a frase de backup. Ele ajuda na recuperação da conta caso você perca seu dispositivo."
+    },
+    "2fa-setup-step3-note11": {
+      "mandarin": "笔记：",
+      "spanish": "Nota:",
+      "english": "Note:",
+      "japanese": "ノート：",
+      "korean": "메모:",
+      "german": "Notiz:",
+      "portuguese": "Observação:"
+    },
+    "verifier-webauth-desc": {
+      "mandarin": "继续使用WebAuthn",
+      "spanish": "Continuar con WebAuthn",
+      "english": "Continue with WebAuthn",
+      "japanese": "WebAuthnを続行します",
+      "korean": "WebAuthn으로 계속",
+      "german": "Fahren Sie mit WebAuthn fort",
+      "portuguese": "Continuar com WebAuthn"
+    },
+    "2fa-setup-step4-not-received": {
+      "mandarin": "没有收到吗？",
+      "spanish": "¿No lo recibiste?",
+      "english": "Did not receive it?",
+      "japanese": "受け取りませんでしたか？",
+      "korean": "받지 못하셨나요?",
+      "german": "Nicht erhalten?",
+      "portuguese": "Não recebeu?"
+    },
+    "reconstruct-biometrics-title": {
+      "mandarin": "支持面部识别/触摸识别的设备*",
+      "spanish": "Dispositivos habilitados con Face ID / Touch ID *",
+      "english": "Face ID / Touch ID enabled device(s) *",
+      "japanese": "Face ID / TouchID対応デバイス*",
+      "korean": "Face ID / Touch ID 지원 장치 *",
+      "german": "Face ID / Touch ID-fähige Geräte *",
+      "portuguese": "Dispositivo(s) habilitado(s) para Face ID/Touch ID *"
+    },
+    "returning-sign-in-desc": {
+      "mandarin": "继续执行以下操作之一以继续",
+      "spanish": "Continúe con uno de los siguientes para continuar",
+      "english": "Continue with one of the following to proceed",
+      "japanese": "次のいずれかを続行して続行します",
+      "korean": "계속하려면 다음 중 하나를 계속하십시오.",
+      "german": "Fahren Sie mit einem der folgenden Schritte fort, um fortzufahren",
+      "portuguese": "Continue com um dos seguintes para continuar"
+    },
+    "2fa-verify-step1-sub2": {
+      "mandarin": "您需要以下其中一项才能登录",
+      "spanish": "Necesita uno de los siguientes para iniciar sesión",
+      "english": "You need one of the following to login",
+      "japanese": "ログインするには、次のいずれかが必要です",
+      "korean": "로그인하려면 다음 중 하나가 필요합니다.",
+      "german": "Sie benötigen eine der folgenden Möglichkeiten, um sich anzumelden",
+      "portuguese": "Você precisa de um dos seguintes para fazer login"
+    },
+    "2fa-setup-step3-email": {
+      "mandarin": "电子邮件",
+      "spanish": "Correo electrónico",
+      "english": "Email",
+      "japanese": "Eメール",
+      "korean": "이메일",
+      "german": "Email",
+      "portuguese": "E-mail"
+    },
+    "2fa-setup-title4": {
+      "mandarin": "恢复验证",
+      "spanish": "Verificación de recuperación",
+      "english": "Recovery verification",
+      "japanese": "回復の検証",
+      "korean": "복구 확인",
+      "german": "Wiederherstellungsüberprüfung",
+      "portuguese": "Verificação de recuperação"
+    },
+    "2fa-setup-step4-resend": {
+      "mandarin": "重发",
+      "spanish": "Reenviar",
+      "english": "Resend",
+      "japanese": "再送",
+      "korean": "재전송",
+      "german": "Erneut senden",
+      "portuguese": "Reenviar"
+    },
+    "2fa-setup-step1-sub1": {
+      "mandarin": "启用 2 因素身份验证 (2FA)",
+      "spanish": "Habilitar la autenticación de 2 factores (2FA)",
+      "english": "Enable 2 Factor Authentication (2FA)",
+      "japanese": "2要素認証（2FA）を有効にする",
+      "korean": "2단계 인증(2FA) 활성화",
+      "german": "2-Faktor-Authentifizierung (2FA) aktivieren",
+      "portuguese": "Ativar autenticação de 2 fatores (2FA)"
+    },
+    "2fa-verify-multi-title": {
+      "mandarin": "{0} 台设备可用",
+      "spanish": "{0} dispositivos disponibles",
+      "english": "{0} devices available",
+      "japanese": "利用可能な{0}デバイス",
+      "korean": "사용 가능한 기기 {0}대",
+      "german": "{0} Geräte verfügbar",
+      "portuguese": "{0} dispositivos disponíveis"
+    },
+    "start": {
+      "mandarin": "开始使用",
+      "spanish": "Empezar",
+      "english": "Get Started",
+      "japanese": "はじめに",
+      "korean": "시작하다",
+      "german": "Loslegen",
+      "portuguese": "Iniciar"
+    },
+    "2fa-setup-step4-sub1": {
+      "mandarin": "验证您的恢复短语",
+      "spanish": "Verifica tu frase de recuperación",
+      "english": "Verify your recovery phrase",
+      "japanese": "回復フレーズを確認する",
+      "korean": "복구 문구 확인",
+      "german": "Bestätigen Sie Ihren Wiederherstellungssatz",
+      "portuguese": "Verifique sua frase de recuperação"
+    },
+    "popup-already": {
+      "mandarin": "已经有账户？",
+      "spanish": "¿Ya tienes una cuenta?",
+      "english": "Already have an account?",
+      "japanese": "すでにアカウントをお持ちですか？",
+      "korean": "이미 계정이 있습니까?",
+      "german": "Sie haben bereits ein Konto?",
+      "portuguese": "Já tem uma conta?"
+    },
+    "social-2fa-continue-text": {
+      "mandarin": "选择您喜欢如何继续",
+      "spanish": "Seleccione cómo le gusta continuar",
+      "english": "Select how you like to continue",
+      "japanese": "続行する方法を選択してください",
+      "korean": "계속하는 방법을 선택하십시오",
+      "german": "Wählen Sie, wie Sie fortfahren möchten",
+      "portuguese": "Selecione como você gostaria de continuar"
+    },
+    "social-2fa-view-more": {
+      "mandarin": "查看更多",
+      "spanish": "Ver más",
+      "english": "View more",
+      "japanese": "もっと見る",
+      "korean": "더보기",
+      "german": "Mehr sehen",
+      "portuguese": "Veja mais"
+    },
+    "2fa-setup-step3-confirm-phrase": {
+      "mandarin": "作为高级用户，我知道如果我丢失了此恢复短语，我将承担丢失帐户的风险。",
+      "spanish": "Como usuario avanzado, sé que si pierdo esta frase de recuperación, corro el riesgo de perder mi cuenta.",
+      "english": "As an advanced user, I know that if I lose this recovery phrase, I bear the risk of losing my account.",
+      "japanese": "上級ユーザーとして、この回復フレーズを失うと、アカウントを失うリスクがあることを私は知っています。",
+      "korean": "고급 사용자로서 나는 이 복구 문구를 잃어버리면 내 계정을 잃을 위험을 감수해야 한다는 것을 알고 있습니다.",
+      "german": "Als fortgeschrittener Benutzer weiß ich, dass ich das Risiko trage, mein Konto zu verlieren, wenn ich diesen Wiederherstellungssatz verliere.",
+      "portuguese": "Como usuário avançado, sei que, se perder esta frase de recuperação, corro o risco de perder minha conta."
+    },
+    "2fa-setup-step1-cancel": {
+      "mandarin": "下次吧",
+      "spanish": "Quizás la próxima vez",
+      "english": "Maybe next time",
+      "japanese": "また今度",
+      "korean": "아마 다음 번에",
+      "german": "Vielleicht nächstes Mal",
+      "portuguese": "Talvez na próxima vez"
+    },
+    "2fa-setup-step2-cancel": {
+      "mandarin": "后退",
+      "spanish": "atrás",
+      "english": "Back",
+      "japanese": "戻る",
+      "korean": "뒤",
+      "german": "Zurück",
+      "portuguese": "Voltar"
+    },
+    "popup-privacy": {
+      "mandarin": "隐私政策",
+      "spanish": "Política de privacidad",
+      "english": "Privacy policy",
+      "japanese": "個人情報保護方針",
+      "korean": "개인 정보 정책",
+      "german": "Datenschutz-Bestimmungen",
+      "portuguese": "Política de privacidade"
+    },
+    "2fa-setup-step3-toggle1": {
+      "mandarin": "无需电子邮件即可保存我的恢复短语",
+      "spanish": "Guardar mi frase de recuperación sin correo electrónico",
+      "english": "Save my recovery phrase without email",
+      "japanese": "メールなしで回復フレーズを保存する",
+      "korean": "이메일 없이 내 복구 문구 저장",
+      "german": "Meine Wiederherstellungsphrase ohne E-Mail speichern",
+      "portuguese": "Salvar minha frase de recuperação sem e-mail"
+    },
+    "register-backup-phrase-confirm-desc2": {
+      "mandarin": "如果不，",
+      "spanish": "Que no,",
+      "english": "If not,",
+      "japanese": "そうでない場合は、",
+      "korean": "如果不，",
+      "german": "Wenn nicht,",
+      "portuguese": "Se não,"
+    },
+    "register-backup-phrase-desc2": {
+      "mandarin": "它可以帮助您在丢失设备时恢复帐户。",
+      "spanish": "Le ayuda con la recuperación de la cuenta en caso de que pierda su dispositivo.",
+      "english": "It helps you with account recovery in case you lose your device.",
+      "japanese": "デバイスを紛失した場合のアカウントの回復に役立ちます。",
+      "korean": "기기 분실시 계정 복구에 도움이됩니다.",
+      "german": "Es hilft Ihnen bei der Kontowiederherstellung, falls Sie Ihr Gerät verlieren.",
+      "portuguese": "Ele ajuda na recuperação da conta caso você perca seu dispositivo."
+    },
+    "mpc-2fa-setup-step4-sub1": {
+      "mandarin": "验证您的恢复系数",
+      "spanish": "Verifique su factor de recuperación",
+      "english": "Verify your recovery factor",
+      "japanese": "回復率を確認する",
+      "korean": "회복 계수 확인",
+      "german": "Überprüfen Sie Ihren Erholungsfaktor",
+      "portuguese": "Verifique seu fator de recuperação"
+    },
+    "register-continue": {
+      "mandarin": "继续",
+      "spanish": "Continuar",
+      "english": "Continue",
+      "japanese": "継続する",
+      "korean": "계속하다",
+      "german": "Fortsetzen",
+      "portuguese": "Continuar"
+    },
+    "social-2fa-warning-cta-2": {
+      "mandarin": "不，使用另一封电子邮件",
+      "spanish": "No, usa otro correo electrónico",
+      "english": "No, use another email",
+      "japanese": "いいえ、別のメールを使用してください",
+      "korean": "아니요, 다른 이메일을 사용하십시오",
+      "german": "Nein, verwenden Sie eine andere E -Mail",
+      "portuguese": "Não, use outro e-mail"
+    },
+    "reconstruct-always-skip-note": {
+      "mandarin": "通过选择“始终跳过”，您将不会收到再次登录 OpenLogin 帐户的提示。 如果您改变主意，您可以随时在“设置”中更改此首选项。",
+      "spanish": "Si selecciona 'Omitir siempre', no se le pedirá que vuelva a iniciar sesión en su cuenta de OpenLogin. Si cambia de opinión, puede cambiar esta preferencia en cualquier momento en 'Configuración'.",
+      "english": "By selecting 'Always skip', you will not be prompted to login to your OpenLogin account again. If you change your mind, you may change this preference anytime in 'Settings'.",
+      "japanese": "[常にスキップ]を選択すると、OpenLoginアカウントに再度ログインするように求められることはありません。 気が変わった場合は、「設定」でいつでもこの設定を変更できます。",
+      "korean": "'항상 건너뛰기'를 선택하면 OpenLogin 계정에 다시 로그인하라는 메시지가 표시되지 않습니다. 마음이 바뀌면 '설정'에서 언제든지 이 환경설정을 변경할 수 있습니다.",
+      "german": "Wenn Sie „Immer überspringen“ auswählen, werden Sie nicht aufgefordert, sich erneut bei Ihrem OpenLogin-Konto anzumelden. Wenn Sie Ihre Meinung ändern, können Sie diese Einstellung jederzeit in den \"Einstellungen\" ändern.",
+      "portuguese": "Ao selecionar 'Sempre pular', você não será solicitado a fazer login na sua conta OpenLogin novamente. Se mudar de ideia, você pode alterar essa preferência a qualquer momento em 'Configurações'."
+    },
+    "2fa-setup-step1-desc1": {
+      "mandarin": "每次登录需要 2 个身份验证因素",
+      "spanish": "Cada inicio de sesión requiere 2 factores para la autenticación",
+      "english": "Each login requires 2 factors for authentication",
+      "japanese": "各ログインには、認証のために2つの要素が必要です",
+      "korean": "각 로그인에는 인증을 위해 2가지 요소가 필요합니다.",
+      "german": "Jede Anmeldung erfordert 2 Faktoren zur Authentifizierung",
+      "portuguese": "Cada login requer 2 fatores para autenticação"
+    },
+    "mpc-2fa-setup-step4-sub22": {
+      "mandarin": "粘贴发送到您的电子邮件 {0} 的恢复因素",
+      "spanish": "Pegue el factor de recuperación enviado a su correo electrónico {0}",
+      "english": "Paste the recovery factor sent to your email {0}",
+      "japanese": "メール {0} に送信された回復係数を貼り付けます",
+      "korean": "이메일로 전송된 복구 요소를 붙여넣습니다. {0}",
+      "german": "Fügen Sie den an Ihre E-Mail gesendeten Wiederherstellungsfaktor ein {0}",
+      "portuguese": "Cole o fator de recuperação enviado para seu e-mail {0}"
+    },
+    "2fa-setup-step2-next": {
+      "mandarin": "继续",
+      "spanish": "Continuar",
+      "english": "Continue",
+      "japanese": "継続する",
+      "korean": "계속하다",
+      "german": "Weitermachen",
+      "portuguese": "Continuar"
+    },
+    "migrate-desc21": {
+      "mandarin": "享受Torus钱包的最新功能",
+      "spanish": "Para disfrutar de las últimas funciones de Torus Wallet",
+      "english": "To enjoy the latest features of the Torus Wallet",
+      "japanese": "トーラスウォレットの最新機能をお楽しみください",
+      "korean": "Torus Wallet의 최신 기능을 즐기려면",
+      "german": "Genießen Sie die neuesten Funktionen der Torus-Brieftasche",
+      "portuguese": "Para aproveitar os recursos mais recentes da Carteira Torus"
+    },
+    "mpc-2fa-verify-step1-panel2": {
+      "mandarin": "恢复系数",
+      "spanish": "Factor de recuperación",
+      "english": "Recovery factor",
+      "japanese": "回収率",
+      "korean": "회복 계수",
+      "german": "Erholungsfaktor",
+      "portuguese": "Fator de recuperação"
+    },
+    "social-2fa-warn-text-1": {
+      "mandarin": "这个社会因素仅充当备份共享，以恢复您的帐户链接到“ abcd@xyz.com”。",
+      "spanish": "Este factor social solo actúa como una participación de respaldo para recuperar su cuenta vinculada a \"abcd@xyz.com\".",
+      "english": "This Social factor only acts as a backup share to recover your account linked to “abcd@xyz.com”.",
+      "japanese": "このソーシャルファクターは、「abcd@xyz.com」にリンクされたアカウントを回復するためのバックアップ共有としてのみ機能します。",
+      "korean": "이 사회적 요소는 \"abcd@xyz.com\"에 링크 된 계정을 복구하기위한 백업 공유 역할을합니다.",
+      "german": "Dieser soziale Faktor fungiert nur als Sicherungsanteil, um Ihr mit „abcd@xyz.com“ verknüpfter Konto wiederherzustellen.",
+      "portuguese": "Este fator social atua apenas como um compartilhamento de backup para recuperar sua conta vinculada a “abcd@xyz.com”."
+    },
+    "mpc-2fa-setup-step3-download": {
+      "mandarin": "下载我的恢复因子",
+      "spanish": "Descargar mi factor de recuperación",
+      "english": "Download my recovery factor",
+      "japanese": "私のリカバリーファクターをダウンロードする",
+      "korean": "내 회복 인자 다운로드",
+      "german": "Laden Sie meinen Wiederherstellungsfaktor herunter",
+      "portuguese": "Baixar meu fator de recuperação"
+    },
+    "returning-exist-title": {
+      "mandarin": "欢迎回来，{0}",
+      "spanish": "Bienvenido de nuevo, {0}",
+      "english": "Welcome back, {0}",
+      "japanese": "おかえりなさい、{0}",
+      "korean": "다시 오신 것을 환영합니다. {0}",
+      "german": "Willkommen zurück, {0}",
+      "portuguese": "Bem-vindo de volta, {0}"
+    },
+    "returning-header-title": {
+      "mandarin": "登入",
+      "spanish": "Registrarse",
+      "english": "Sign in",
+      "japanese": "サインイン",
+      "korean": "로그인",
+      "german": "Einloggen",
+      "portuguese": "Entrar"
+    },
+    "2fa-verify-success-head": {
+      "mandarin": "成功的",
+      "spanish": "Exitoso",
+      "english": "Successful",
+      "japanese": "成功",
+      "korean": "성공적인",
+      "german": "Erfolgreich",
+      "portuguese": "Bem sucedido"
+    },
+    "2fa-setup-step3-next1": {
+      "mandarin": "完成设置",
+      "spanish": "Terminar de configurar",
+      "english": "Finish setting up",
+      "japanese": "セットアップを完了します",
+      "korean": "설정 완료",
+      "german": "Beenden Sie die Einrichtung",
+      "portuguese": "Concluir a configuração"
+    },
+    "reconstruct-device-desc2": {
+      "mandarin": "从以下任何设备中完成安全性验证。",
+      "spanish": "desde cualquiera de los siguientes dispositivos para completar la verificación de seguridad.",
+      "english": "from any of the following devices to complete the security verification.",
+      "japanese": "次のいずれかのデバイスからセキュリティ検証を完了します。",
+      "korean": "다음 장치 중 하나에서 보안 확인을 완료하십시오.",
+      "german": "von einem der folgenden Geräte, um die Sicherheitsüberprüfung abzuschließen.",
+      "portuguese": "de qualquer um dos seguintes dispositivos para concluir a verificação de segurança."
+    },
+    "reconstruct-backup-phrase-desc": {
+      "mandarin": "输入先前发送到您的辅助邮箱的备份短语。",
+      "spanish": "Ingrese la frase de respaldo enviada a su correo electrónico de recuperación anteriormente.",
+      "english": "Enter the backup phrase sent to your recovery email previously.",
+      "japanese": "以前にリカバリメールに送信されたバックアップフレーズを入力します。",
+      "korean": "이전에 복구 이메일로 전송 된 백업 문구를 입력하십시오.",
+      "german": "Geben Sie den Sicherungssatz ein, der zuvor an Ihre Wiederherstellungs-E-Mail gesendet wurde.",
+      "portuguese": "Digite a frase de backup enviada para seu e-mail de recuperação anteriormente."
+    },
+    "returning-continue": {
+      "mandarin": "继续{0}",
+      "spanish": "Continuar con {0}",
+      "english": "Continue with {0}",
+      "japanese": "{0}に進む",
+      "korean": "{0}로 계속",
+      "german": "Weiter mit {0}",
+      "portuguese": "Continuar com {0}"
+    },
+    "register-password-password-confirm": {
+      "mandarin": "重新输入密码",
+      "spanish": "reingresa tu contraseña",
+      "english": "Re-enter your password",
+      "japanese": "パスワードを再入力してください",
+      "korean": "비밀번호 재 입력",
+      "german": "Wiederhole die Eingabe deines Passwortes",
+      "portuguese": "Redigite sua senha"
+    },
+    "2fa-setup-step4-contact-support": {
+      "mandarin": "联系支持",
+      "spanish": "Soporte de contacto",
+      "english": "Contact Support",
+      "japanese": "サポート問い合わせ先",
+      "korean": "연락처 지원",
+      "german": "Kontaktieren Sie Support",
+      "portuguese": "Entre em contato com o suporte"
+    },
+    "reconstruct-backup-phrase-placeholder": {
+      "mandarin": "输入备用词组",
+      "spanish": "Ingrese la frase de respaldo",
+      "english": "Enter backup phrase",
+      "japanese": "バックアップフレーズを入力してください",
+      "korean": "백업 문구 입력",
+      "german": "Geben Sie die Sicherungsphrase ein",
+      "portuguese": "Digite a frase de backup"
+    },
+    "register-subtitle-try-webauth": {
+      "mandarin": "您要在此设备上启用Touch ID / Face ID吗？",
+      "spanish": "¿Le gustaría habilitar Touch ID / Face ID en este dispositivo?",
+      "english": "Would you like to enable Touch ID / Face ID on this device?",
+      "japanese": "このデバイスでTouchID / Face IDを有効にしますか？",
+      "korean": "이 장치에서 Touch ID / Face ID를 활성화 하시겠습니까?",
+      "german": "Möchten Sie die Touch ID / Face ID auf diesem Gerät aktivieren?",
+      "portuguese": "Gostaria de ativar o Touch ID/Face ID neste dispositivo?"
+    },
+    "2fa-setup-step3-note12": {
+      "mandarin": "您需要在下一个屏幕上确认此短语",
+      "spanish": "Deberá confirmar esta frase en la siguiente pantalla",
+      "english": "You will need to confirm this phrase on the next screen",
+      "japanese": "次の画面でこのフレーズを確認する必要があります",
+      "korean": "다음 화면에서 이 문구를 확인해야 합니다.",
+      "german": "Sie müssen diesen Satz auf dem nächsten Bildschirm bestätigen",
+      "portuguese": "Você precisará confirmar esta frase na próxima tela"
+    },
+    "2fa-setup-title31": {
+      "mandarin": "第 2 步：保存恢复短语",
+      "spanish": "Paso 2: Guarda la frase de recuperación",
+      "english": "Step 2: Save recovery phrase",
+      "japanese": "ステップ2：リカバリフレーズを保存する",
+      "korean": "2단계: 복구 문구 저장",
+      "german": "Schritt 2: Speichern Sie die Wiederherstellungsphrase",
+      "portuguese": "Etapa 2: salvar a frase de recuperação"
+    },
+    "2fa-verify-step1-go-app": {
+      "mandarin": "转到应用程序",
+      "spanish": "Ir a la aplicación",
+      "english": "Go to App",
+      "japanese": "アプリに行きます",
+      "korean": "앱으로 이동",
+      "german": "Gehe zu App",
+      "portuguese": "Vá para o aplicativo"
+    },
+    "2fa-setup-step3-sub2": {
+      "mandarin": "如果您无法访问保存的浏览器，您可以使用恢复短语进行身份验证。",
+      "spanish": "En caso de que pierda el acceso a su navegador guardado, puede autenticarse con su frase de recuperación.",
+      "english": "In case you lose access to your saved browser, you can authenticate with your recovery phrase.",
+      "japanese": "保存したブラウザにアクセスできなくなった場合は、リカバリフレーズで認証できます。",
+      "korean": "저장된 브라우저에 액세스할 수 없는 경우 복구 문구로 인증할 수 있습니다.",
+      "german": "Falls Sie den Zugriff auf Ihren gespeicherten Browser verlieren, können Sie sich mit Ihrer Wiederherstellungsphrase authentifizieren.",
+      "portuguese": "Caso perca o acesso ao seu navegador salvo, você pode autenticar com sua frase de recuperação."
+    },
+    "2fa-verify-save-save": {
+      "mandarin": "保存此设备",
+      "spanish": "Guardar este dispositivo",
+      "english": "Save this device",
+      "japanese": "このデバイスを保存します",
+      "korean": "이 기기 저장",
+      "german": "Speichern Sie dieses Gerät",
+      "portuguese": "Salvar este dispositivo"
+    },
+    "2fa-verify-share-head": {
+      "mandarin": "选择以下之一",
+      "spanish": "Selecciona uno de los siguientes",
+      "english": "Select one of the following",
+      "japanese": "次のいずれかを選択してください",
+      "korean": "다음 중 하나를 선택하십시오.",
+      "german": "Wählen Sie eine der folgenden Optionen",
+      "portuguese": "Selecione um dos seguintes"
+    },
+    "mpc-2fa-setup-step4-recovery": {
+      "mandarin": "恢复系数",
+      "spanish": "Factor de recuperación",
+      "english": "Recovery factor",
+      "japanese": "回収率",
+      "korean": "회복 계수",
+      "german": "Erholungsfaktor",
+      "portuguese": "Fator de recuperação"
+    },
+    "2fa-verify-reference-id": {
+      "mandarin": "参考编号",
+      "spanish": "Identificación de referencia",
+      "english": "Reference ID",
+      "japanese": "参照ID",
+      "korean": "참조 ID",
+      "german": "Referenz ID",
+      "portuguese": "ID de referência"
+    },
+    "2fa-setup-step4-sub21": {
+      "mandarin": "粘贴恢复短语",
+      "spanish": "Pega la frase de recuperación",
+      "english": "Paste the recovery phrase",
+      "japanese": "回復フレーズを貼り付けます",
+      "korean": "복구 문구 붙여넣기",
+      "german": "Fügen Sie den Wiederherstellungssatz ein",
+      "portuguese": "Cole a frase de recuperação"
+    },
+    "2fa-verify-recovery-note": {
+      "mandarin": "如果您无法验证上述任何一项，则无法登录您的帐户。",
+      "spanish": "Si no puede verificar ninguno de los anteriores, no puede iniciar sesión en su cuenta.",
+      "english": "If you are unable to verify any of the above, you are unable to login to your account.",
+      "japanese": "上記のいずれかを確認できない場合は、アカウントにログインできません。",
+      "korean": "위의 항목 중 하나라도 확인할 수 없으면 계정에 로그인할 수 없습니다.",
+      "german": "Wenn Sie keinen der oben genannten Punkte bestätigen können, können Sie sich nicht bei Ihrem Konto anmelden.",
+      "portuguese": "Se você não conseguir verificar nenhum dos itens acima, não poderá fazer login na sua conta."
+    },
+    "register-backup-phrase-placeholder": {
+      "mandarin": "输入辅助邮箱",
+      "spanish": "Ingresa el correo de recuperación",
+      "english": "Enter recovery email",
+      "japanese": "復旧メールを入力してください",
+      "korean": "복구 이메일 입력",
+      "german": "Geben Sie die Wiederherstellungs-E-Mail ein",
+      "portuguese": "Digite o e-mail de recuperação"
+    },
+    "2fa-setup-step3-sub1": {
+      "mandarin": "提供电子邮件以接收恢复短语",
+      "spanish": "Proporcione un correo electrónico para recibir la frase de recuperación",
+      "english": "Provide an email to receive recovery phrase",
+      "japanese": "回復フレーズを受け取るための電子メールを提供する",
+      "korean": "복구 문구를 받을 이메일 제공",
+      "german": "Geben Sie eine E-Mail an, um die Wiederherstellungsphrase zu erhalten",
+      "portuguese": "Forneça um e-mail para receber a frase de recuperação"
+    },
+    "register-skip": {
+      "mandarin": "立即跳过",
+      "spanish": "Saltar por ahora",
+      "english": "Skip for Now",
+      "japanese": "今はスキップ",
+      "korean": "일단은 스킵",
+      "german": "Für jetzt überspringen",
+      "portuguese": "Pular por agora"
+    },
+    "returning-confirm-desc": {
+      "mandarin": "继续通过生物识别登录？",
+      "spanish": "¿Continuar con el inicio de sesión mediante datos biométricos?",
+      "english": "Continue your sign in via biometrics?",
+      "japanese": "生体認証を介してサインインを続行しますか？",
+      "korean": "생체 인식을 통해 계속 로그인 하시겠습니까?",
+      "german": "Mit der Anmeldung über Biometrie fortfahren?",
+      "portuguese": "Continuar seu login via biometria?"
+    },
+    "register-biometrics-enable": {
+      "mandarin": "启用触摸ID /面部ID",
+      "spanish": "Habilitar Touch ID / Face ID",
+      "english": "Enable Touch ID / Face ID",
+      "japanese": "Touch ID / FaceIDを有効にする",
+      "korean": "Touch ID / Face ID 활성화",
+      "german": "Aktivieren Sie Touch ID / Face ID",
+      "portuguese": "Ativar Touch ID / Face ID"
+    },
+    "reconstruct-backup-phrase-desc-3": {
+      "mandarin": "并发送到电子邮件：",
+      "spanish": "y enviado al correo electrónico:",
+      "english": "and sent to email: ",
+      "japanese": "そして電子メールに送られる：",
+      "korean": "이메일로 전송:",
+      "german": "und an E-Mail gesendet:",
+      "portuguese": "e enviado para o e-mail:"
+    },
+    "2fa-verify-share-browser": {
+      "mandarin": "浏览器",
+      "spanish": "Navegador",
+      "english": "Browser",
+      "japanese": "ブラウザ",
+      "korean": "브라우저",
+      "german": "Browser",
+      "portuguese": "Navegador"
+    },
+    "2fa-setup-step4-check-time": {
+      "mandarin": "没有收到吗？ 反感。 再次签入{0}",
+      "spanish": "¿No lo recibiste? Resentirse de. Vuelve a comprobar en {0}",
+      "english": "Did not receive it? Resent. Check again in {0}",
+      "japanese": "受け取りませんでしたか？ 憤る。 {0}でもう一度確認してください",
+      "korean": "받지 못하셨나요? 화내다. {0}에서 다시 확인",
+      "german": "Nicht erhalten? Übelnehmen. Erneut einchecken in {0}",
+      "portuguese": "Não recebeu? Reenviar. Verifique novamente em {0}"
+    },
+    "2fa-verify-multi-subhead": {
+      "mandarin": "登录到以下已保存的浏览器以批准访问",
+      "spanish": "Inicie sesión en el siguiente navegador guardado para aprobar el acceso",
+      "english": "Login to the following saved browser to approve access",
+      "japanese": "次の保存されたブラウザにログインして、アクセスを承認します",
+      "korean": "액세스를 승인하려면 다음 저장된 브라우저에 로그인하십시오.",
+      "german": "Melden Sie sich beim folgenden gespeicherten Browser an, um den Zugriff zu genehmigen",
+      "portuguese": "Faça login no seguinte navegador salvo para aprovar o acesso"
+    },
+    "2fa-setup-title12": {
+      "mandarin": "设置 2 因素身份验证",
+      "spanish": "Configurar autenticación de 2 factores",
+      "english": "Set up 2 Factor Authentication",
+      "japanese": "2要素認証を設定する",
+      "korean": "2단계 인증 설정",
+      "german": "2-Faktor-Authentifizierung einrichten",
+      "portuguese": "Configure a autenticação de 2 fatores"
+    },
+    "verifier-google-desc": {
+      "mandarin": "继续使用Google",
+      "spanish": "Continuar con Google",
+      "english": "Continue with Google",
+      "japanese": "Googleで続行",
+      "korean": "Google로 계속",
+      "german": "Fahren Sie mit Google fort",
+      "portuguese": "Continuar com o Google"
+    },
+    "2fa-setup-step3-manual-save": {
+      "mandarin": "手动保存您的短语",
+      "spanish": "Guarde manualmente su frase",
+      "english": "Manually save your phrase",
+      "japanese": "フレーズを手動で保存する",
+      "korean": "수동으로 문구 저장",
+      "german": "Speichern Sie Ihren Satz manuell",
+      "portuguese": "Salve manualmente sua frase"
+    },
+    "2fa-setup-step3-toggle2": {
+      "mandarin": "通过电子邮件向我发送恢复短语",
+      "spanish": "Envíame mi frase de recuperación por correo electrónico",
+      "english": "Email me my recovery phrase",
+      "japanese": "私の回復フレーズを私にメールしてください",
+      "korean": "내 복구 문구를 이메일로 보내주세요",
+      "german": "Senden Sie mir meinen Wiederherstellungssatz per E-Mail",
+      "portuguese": "Envie-me um e-mail com minha frase de recuperação"
+    },
+    "2fa-setup-step1-next": {
+      "mandarin": "设置 2FA",
+      "spanish": "Configurar 2FA",
+      "english": "Set up 2FA",
+      "japanese": "2FAを設定する",
+      "korean": "2FA 설정",
+      "german": "2FA einrichten",
+      "portuguese": "Configurar 2FA"
+    },
+    "2fa-setup-step2-confirm-note": {
+      "mandarin": "我了解清除浏览器历史记录和 cookie 将删除我浏览器上的这个因素。",
+      "spanish": "Entiendo que borrar el historial del navegador y las cookies eliminará este factor en mi navegador.",
+      "english": "I understand that clearing browser history and cookies will delete this factor on my browser.",
+      "japanese": "ブラウザの履歴とCookieをクリアすると、ブラウザのこの要素が削除されることを理解しています。",
+      "korean": "브라우저 기록 및 쿠키를 지우면 내 브라우저에서 이 요소가 삭제된다는 것을 이해합니다.",
+      "german": "Mir ist bewusst, dass das Löschen des Browserverlaufs und der Cookies diesen Faktor in meinem Browser löscht.",
+      "portuguese": "Entendo que limpar o histórico e os cookies do navegador excluirá esse fator do meu navegador."
+    },
+    "2fa-verify-step1-panel1": {
+      "mandarin": "保存的浏览器/设备",
+      "spanish": "Navegadores / dispositivos guardados",
+      "english": "Saved browser(s) / devices",
+      "japanese": "保存されたブラウザ/デバイス",
+      "korean": "저장된 브라우저/기기",
+      "german": "Gespeicherte(r) Browser/Geräte",
+      "portuguese": "Navegadores/dispositivos salvos"
+    },
+    "mpc-2fa-verify-step1-rec-placeholder": {
+      "mandarin": "恢复系数",
+      "spanish": "Factor de recuperación",
+      "english": "Recovery factor",
+      "japanese": "回収率",
+      "korean": "회복 계수",
+      "german": "Erholungsfaktor",
+      "portuguese": "Fator de recuperação"
+    },
+    "social-2fa-verify-email": {
+      "mandarin": "通过电子邮件验证",
+      "spanish": "Verifique con su correo electrónico",
+      "english": "Verify with your email",
+      "japanese": "メールで確認してください",
+      "korean": "이메일로 확인하십시오",
+      "german": "Überprüfen Sie mit Ihrer E -Mail",
+      "portuguese": "Verifique com seu e-mail"
+    },
+    "popup-continue-existing": {
+      "mandarin": "继续使用现有的{0}",
+      "spanish": "Continuar con {0} existente",
+      "english": "Continue with existing {0}",
+      "japanese": "既存の{0}を続行します",
+      "korean": "기존 {0} 계속",
+      "german": "Weiter mit vorhandenem {0}",
+      "portuguese": "Continuar com {0} existente"
+    },
+    "register-title-additional-security": {
+      "mandarin": "出发前的最后一步",
+      "spanish": "Un último paso antes de irte",
+      "english": "One last step before you go",
+      "japanese": "行く前の最後の一歩",
+      "korean": "가기 전에 마지막 단계",
+      "german": "Ein letzter Schritt bevor du gehst",
+      "portuguese": "Um último passo antes de ir"
+    },
+    "2fa-setup-step2-sub1": {
+      "mandarin": "使用当前浏览器设置",
+      "spanish": "Configurar usando el navegador actual",
+      "english": "Set up using current browser",
+      "japanese": "現在のブラウザを使用して設定",
+      "korean": "현재 브라우저를 사용하여 설정",
+      "german": "Mit aktuellem Browser einrichten",
+      "portuguese": "Configurar usando o navegador atual"
+    },
+    "register-backup-phrase-desc1": {
+      "mandarin": "将向您发送一封包含备份短语的电子邮件。",
+      "spanish": "Se le enviará un correo electrónico con la frase de respaldo.",
+      "english": "An email will be sent to you containing the backup phrase.",
+      "japanese": "バックアップ フレーズを含むメールが送信されます。",
+      "korean": "백업 문구가 포함 된 이메일이 발송됩니다.",
+      "german": "Sie erhalten eine E-Mail mit der Backup-Phrase.",
+      "portuguese": "Um e-mail será enviado para você contendo a frase de backup."
+    },
+    "2fa-setup-step3-hide-adv": {
+      "mandarin": "隐藏高级选项",
+      "spanish": "Ocultar opción avanzada",
+      "english": "Hide advanced option",
+      "japanese": "詳細オプションを非表示",
+      "korean": "고급 옵션 숨기기",
+      "german": "Erweiterte Option ausblenden",
+      "portuguese": "Ocultar opção avançada"
+    },
+    "2fa-verify-success-subtitle": {
+      "mandarin": "登录",
+      "spanish": "iniciando sesión",
+      "english": "Logging you in",
+      "japanese": "ログインします",
+      "korean": "로그인",
+      "german": "Melden Sie sich an",
+      "portuguese": "Conectando você"
+    },
+    "2fa-setup-step1-desc22": {
+      "mandarin": "只需 3 个简单的步骤即可完成设置！",
+      "spanish": "¡Configúralo en 3 sencillos pasos!",
+      "english": "Set it up in 3 simple steps!",
+      "japanese": "3つの簡単なステップでセットアップしてください！",
+      "korean": "간단한 3단계로 설정하세요!",
+      "german": "Richten Sie es in 3 einfachen Schritten ein!",
+      "portuguese": "Configure em 3 passos simples!"
+    },
+    "2fa-setup-step3-next3": {
+      "mandarin": "发送恢复短语",
+      "spanish": "Enviar frase de recuperación",
+      "english": "Send recovery phrase",
+      "japanese": "回復フレーズを送信する",
+      "korean": "복구 문구 보내기",
+      "german": "Wiederherstellungsphrase senden",
+      "portuguese": "Enviar frase de recuperação"
+    },
+    "register-backup-phrase-send": {
+      "mandarin": "发送恢复电子邮件",
+      "spanish": "Enviar correo de recuperación",
+      "english": "Send recovery email",
+      "japanese": "復旧メールを送信する",
+      "korean": "복구 이메일 보내기",
+      "german": "Wiederherstellungs-E-Mail senden",
+      "portuguese": "Enviar e-mail de recuperação"
+    },
+    "mpc-2fa-setup-step3-sub1": {
+      "mandarin": "提供电子邮件以接收恢复短语",
+      "spanish": "Proporcione un correo electrónico para recibir la frase de recuperación",
+      "english": "Provide an email to receive recovery factor",
+      "japanese": "回復フレーズを受け取るための電子メールを提供する",
+      "korean": "복구 문구를 받을 이메일 제공",
+      "german": "Geben Sie eine E-Mail an, um die Wiederherstellungsphrase zu erhalten",
+      "portuguese": "Forneça um e-mail para receber o fator de recuperação"
+    },
+    "2fa-setup-step3-show-adv": {
+      "mandarin": "查看高级选项",
+      "spanish": "Ver opción avanzada",
+      "english": "View advanced option",
+      "japanese": "詳細オプションを表示",
+      "korean": "고급 옵션 보기",
+      "german": "Erweiterte Option anzeigen",
+      "portuguese": "Ver opção avançada"
+    },
+    "2fa-verify-step1-rec-placeholder": {
+      "mandarin": "恢复短语",
+      "spanish": "Frase de recuperación",
+      "english": "Recovery phrase",
+      "japanese": "回復フレーズ",
+      "korean": "복구 문구",
+      "german": "Wiederherstellungsphrase",
+      "portuguese": "Frase de recuperação"
+    },
+    "2fa-verify-step2-sub1": {
+      "mandarin": "验证成功",
+      "spanish": "Verificación exitosa",
+      "english": "Successful verification",
+      "japanese": "検証の成功",
+      "korean": "인증 성공",
+      "german": "Erfolgreiche Verifizierung",
+      "portuguese": "Verificação bem-sucedida"
+    },
+    "title": {
+      "mandarin": "一站式管理所有网络互动",
+      "spanish": "Administre todas sus interacciones web en un solo lugar",
+      "english": "Manage all your web interactions in one place",
+      "japanese": "すべてのWebインタラクションを1か所で管理します",
+      "korean": "모든 웹 상호 작용을 한 곳에서 관리",
+      "german": "Verwalten Sie alle Ihre Webinteraktionen an einem Ort",
+      "portuguese": "Gerencie todas as suas interações na web em um só lugar"
+    },
+    "register-biometrics-desc": {
+      "mandarin": "使用面容 ID 或触控 ID 注册您的设备。 生物识别技术永远不会离开您的设备。",
+      "spanish": "Registre su dispositivo con Face ID o Touch ID. La biometría nunca abandona su dispositivo.",
+      "english": "Register your device with Face ID or Touch ID. Biometrics never leave your device.",
+      "japanese": "デバイスを Face ID または Touch ID で登録します。 生体認証がデバイスから離れることはありません。",
+      "korean": "Face ID 또는 Touch ID로 기기를 등록하세요. 생체 인식은 장치를 떠나지 않습니다.",
+      "german": "Registrieren Sie Ihr Gerät mit Face ID oder Touch ID. Biometrie verlässt Ihr Gerät nie.",
+      "portuguese": "Registre seu dispositivo com Face ID ou Touch ID. A biometria nunca sai do seu dispositivo."
+    },
+    "mpc-2fa-setup-title3": {
+      "mandarin": "保存恢复短语",
+      "spanish": "Guardar frase de recuperación",
+      "english": "Save recovery factor",
+      "japanese": "回復フレーズを保存する",
+      "korean": "복구 문구 저장",
+      "german": "Wiederherstellungsphrase speichern",
+      "portuguese": "Salvar fator de recuperação"
+    },
+    "reconstruct-device-prev2": {
+      "mandarin": "Torus钱包的先前版本",
+      "spanish": "versión anterior de Torus Wallet",
+      "english": "previous version of the Torus Wallet",
+      "japanese": "トーラスウォレットの以前のバージョン",
+      "korean": "이전 버전의 토러스 지갑",
+      "german": "vorherige Version der Torus-Brieftasche",
+      "portuguese": "versão anterior da Carteira Torus"
+    },
+    "2fa-setup-step3-next4": {
+      "mandarin": "我已经保存了我的恢复短语",
+      "spanish": "He guardado mi frase de recuperación",
+      "english": "I have saved my recovery phrase",
+      "japanese": "回復フレーズを保存しました",
+      "korean": "복구 문구를 저장했습니다",
+      "german": "Ich habe meine Wiederherstellungsphrase gespeichert",
+      "portuguese": "Salvei minha frase de recuperação"
+    },
+    "2fa-setup-step3-download": {
+      "mandarin": "下载我的恢复短语",
+      "spanish": "Descarga mi frase de recuperación",
+      "english": "Download my recovery phrase",
+      "japanese": "私の回復フレーズをダウンロードする",
+      "korean": "내 복구 문구 다운로드",
+      "german": "Laden Sie meinen Wiederherstellungssatz herunter",
+      "portuguese": "Baixar minha frase de recuperação"
+    },
+    "reconstruct-biometrics-desc": {
+      "mandarin": "*仅适用于先前在以下设备上设置的Touch ID / Face ID：",
+      "spanish": "* Solo para Touch ID / Face ID configurado previamente en los siguientes dispositivos:",
+      "english": "* Only for Touch ID / Face ID previously set up on the following device(s):",
+      "japanese": "*以下のデバイスで以前に設定されたTouchID / Face IDの場合のみ：",
+      "korean": "* 다음 장치에서 이전에 설정 한 Touch ID / Face ID에만 해당됩니다.",
+      "german": "* Nur für Touch ID / Face ID, die zuvor auf den folgenden Geräten eingerichtet wurden:",
+      "portuguese": "* Apenas para Touch ID / Face ID previamente configurado no(s) seguinte(s) dispositivo(s):"
+    },
+    "register-password-confirm": {
+      "mandarin": "设定密码",
+      "spanish": "Configurar contraseña",
+      "english": "Set up password",
+      "japanese": "パスワードを設定する",
+      "korean": "비밀번호 설정",
+      "german": "Passwort einrichten",
+      "portuguese": "Configurar senha"
+    },
+    "register-backup-phrase-title": {
+      "mandarin": "继续发送辅助邮箱",
+      "spanish": "Continuar con un correo de recuperación",
+      "english": "Continue with a recovery email",
+      "japanese": "復旧メールを続行します",
+      "korean": "복구 이메일로 계속",
+      "german": "Fahren Sie mit einer Wiederherstellungs-E-Mail fort",
+      "portuguese": "Continuar com um e-mail de recuperação"
+    },
+    "mpc-2fa-setup-step4-sub21": {
+      "mandarin": "粘贴恢复因子",
+      "spanish": "Pegar el factor de recuperación",
+      "english": "Paste the recovery factor",
+      "japanese": "回復係数を貼り付けます",
+      "korean": "회복 인자 붙여넣기",
+      "german": "Fügen Sie den Wiederherstellungsfaktor ein",
+      "portuguese": "Cole o fator de recuperação"
+    },
+    "2fa-verify-step1-sub1": {
+      "mandarin": "使用以下之一进行身份验证",
+      "spanish": "Autenticarse con uno de los siguientes",
+      "english": "Authenticate with one of the following",
+      "japanese": "次のいずれかで認証します",
+      "korean": "다음 중 하나로 인증",
+      "german": "Authentifizieren Sie sich mit einer der folgenden Optionen",
+      "portuguese": "Autenticar com um dos seguintes"
+    },
+    "2fa-verify-title1": {
+      "mandarin": "验证您的登录信息",
+      "spanish": "Verifique su inicio de sesión",
+      "english": "Verify your login",
+      "japanese": "ログインを確認する",
+      "korean": "로그인 확인",
+      "german": "Bestätigen Sie Ihre Anmeldung",
+      "portuguese": "Verifique seu login"
+    },
+    "migrate-desc22": {
+      "mandarin": "请在此新版本上验证您的身份",
+      "spanish": "por favor verifique su identidad en esta nueva versión",
+      "english": "kindly verify your identity on this new version",
+      "japanese": "この新しいバージョンであなたの身元を確認してください",
+      "korean": "이 새 버전에서 신원을 확인하십시오.",
+      "german": "Bitte überprüfen Sie Ihre Identität in dieser neuen Version",
+      "portuguese": "gentilmente verifique sua identidade nesta nova versão"
+    },
+    "social-2fa-verify-account": {
+      "mandarin": "验证您的社交帐户",
+      "spanish": "Verifique con su cuenta social",
+      "english": "Verify with your social account",
+      "japanese": "ソーシャルアカウントで確認します",
+      "korean": "소셜 계정으로 확인하십시오",
+      "german": "Überprüfen Sie mit Ihrem sozialen Konto",
+      "portuguese": "Verifique com sua conta social"
+    },
+    "register-subtitle-additional-security": {
+      "mandarin": "您的帐户安全很重要。 让我们支持它。",
+      "spanish": "La seguridad de su cuenta es importante. Hagamos una copia de seguridad.",
+      "english": "Your account security matters. Let’s back it up.",
+      "japanese": "アカウントのセキュリティが重要です。 後押ししましょう。",
+      "korean": "귀하의 계정 보안이 중요합니다. 백업합시다.",
+      "german": "Die Sicherheit Ihres Kontos ist wichtig. Lass es uns sichern.",
+      "portuguese": "A segurança da sua conta é importante. Vamos fazer backup."
+    },
+    "2fa-setup-step1-sub3": {
+      "mandarin": "为您的帐户添加额外的安全层并妥善保管您的资产。",
+      "spanish": "Agregue una capa adicional de seguridad a su cuenta y proteja sus activos.",
+      "english": "Add an extra layer of security to your account and safekeep your assets.",
+      "japanese": "アカウントにセキュリティの層を追加し、資産を保護します。",
+      "korean": "계정에 보안 계층을 추가하고 자산을 보호하십시오.",
+      "german": "Fügen Sie Ihrem Konto eine zusätzliche Sicherheitsebene hinzu und bewahren Sie Ihre Vermögenswerte sicher auf.",
+      "portuguese": "Adicione uma camada extra de segurança à sua conta e proteja seus ativos."
+    },
+    "social-2fa-subtitle-2": {
+      "mandarin": "如果您无法访问保存的浏览器，则可以通过社交帐户进行身份验证。",
+      "spanish": "En caso de que pierda acceso a su navegador guardado, puede autenticarse con su cuenta social.",
+      "english": "In case you lose access to your saved browser, you can authenticate with your Social account.",
+      "japanese": "保存されたブラウザへのアクセスを失う場合は、ソーシャルアカウントで認証できます。",
+      "korean": "저장된 브라우저에 대한 액세스 권한을 잃어버린 경우 소셜 계정으로 인증 할 수 있습니다.",
+      "german": "Falls Sie den Zugriff auf Ihren gespeicherten Browser verlieren, können Sie sich mit Ihrem sozialen Konto authentifizieren.",
+      "portuguese": "Caso perca o acesso ao seu navegador salvo, você pode se autenticar com sua conta Social."
+    },
+    "popup-here": {
+      "mandarin": "这里",
+      "spanish": "aquí",
+      "english": "here",
+      "japanese": "ここに",
+      "korean": "여기",
+      "german": "Hier",
+      "portuguese": "aqui"
+    },
+    "verifier-email-desc": {
+      "mandarin": "继续发送电子邮件",
+      "spanish": "Continuar con el correo electrónico",
+      "english": "Continue with Email",
+      "japanese": "メールを続ける",
+      "korean": "이메일로 계속",
+      "german": "Fahren Sie mit E-Mail fort",
+      "portuguese": "Continuar com e-mail"
+    },
+    "returning-exist-use-another": {
+      "mandarin": "使用其他帐户",
+      "spanish": "Usa otra cuenta",
+      "english": "Use another account",
+      "japanese": "別のアカウントを使用する",
+      "korean": "다른 계정 사용",
+      "german": "Benutze einen anderen Account",
+      "portuguese": "Usar outra conta"
+    },
+    "popup-view-less": {
+      "mandarin": "查看较少的选项",
+      "spanish": "Ver menos opciones",
+      "english": "View less options",
+      "japanese": "少ないオプションを表示",
+      "korean": "옵션 간략히보기",
+      "german": "Weniger Optionen anzeigen",
+      "portuguese": "Ver menos opções"
+    },
+    "2fa-setup-title3": {
+      "mandarin": "保存恢复短语",
+      "spanish": "Guardar frase de recuperación",
+      "english": "Save recovery phrase",
+      "japanese": "回復フレーズを保存する",
+      "korean": "복구 문구 저장",
+      "german": "Wiederherstellungsphrase speichern",
+      "portuguese": "Salvar frase de recuperação"
+    },
+    "2fa-verify-step1-do-not-save": {
+      "mandarin": "不要保存此浏览器/设备。",
+      "spanish": "No guarde este navegador / dispositivo.",
+      "english": "Do not save this brower/device.",
+      "japanese": "このブラウザ/デバイスを保存しないでください。",
+      "korean": "이 브라우저/장치를 저장하지 마십시오.",
+      "german": "Speichern Sie diesen Browser/dieses Gerät nicht.",
+      "portuguese": "Não salve este navegador/dispositivo."
+    },
+    "2fa-setup-step3-sub22": {
+      "mandarin": "我知道如果我丢失了这个恢复短语，我将承担丢失帐户的风险。",
+      "spanish": "Sé que si pierdo esta frase de recuperación, correré el riesgo de perder mi cuenta.",
+      "english": "I know that if I lose this recovery phrase, I will bear the risk of losing my account.",
+      "japanese": "この回復フレーズを失った場合、アカウントを失うリスクを負うことを私は知っています。",
+      "korean": "이 복구 문구를 잃어버리면 계정을 잃을 위험을 감수해야 한다는 것을 알고 있습니다.",
+      "german": "Ich weiß, dass ich das Risiko trage, mein Konto zu verlieren, wenn ich diesen Wiederherstellungssatz verliere.",
+      "portuguese": "Sei que se eu perder esta frase de recuperação, correrei o risco de perder minha conta."
+    },
+    "returning-header-desc": {
+      "mandarin": "您的数字钱包通过",
+      "spanish": "Tu billetera digital a través de",
+      "english": "Your digital wallet via",
+      "japanese": "経由であなたのデジタルウォレット",
+      "korean": "디지털 지갑을 통해",
+      "german": "Ihre digitale Geldbörse über",
+      "portuguese": "Sua carteira digital via"
+    },
+    "2fa-setup-step4-next": {
+      "mandarin": "核实",
+      "spanish": "Verificar",
+      "english": "Verify",
+      "japanese": "確認",
+      "korean": "검증",
+      "german": "Verifizieren",
+      "portuguese": "Verificar"
+    },
+    "reconstruct-title": {
+      "mandarin": "验证您的登录名",
+      "spanish": "Verifique su inicio de sesión",
+      "english": "Verify your login",
+      "japanese": "ログインを確認する",
+      "korean": "로그인 확인",
+      "german": "Überprüfen Sie Ihr Login",
+      "portuguese": "Verifique seu login"
+    },
+    "popup-subtitle": {
+      "mandarin": "选择您想继续的方式",
+      "spanish": "Seleccione cómo le gustaría continuar",
+      "english": "Select how you would like to continue",
+      "japanese": "続行する方法を選択してください",
+      "korean": "계속할 방법을 선택하십시오.",
+      "german": "Wählen Sie aus, wie Sie fortfahren möchten",
+      "portuguese": "Selecione como você gostaria de continuar"
+    },
+    "2fa-verify-multi-subhead2": {
+      "mandarin": "登录请求将发送到您保存的浏览器",
+      "spanish": "Se enviará una solicitud de inicio de sesión a su navegador guardado",
+      "english": "A login request will be sent to your saved browser",
+      "japanese": "保存したブラウザにログインリクエストが送信されます",
+      "korean": "저장된 브라우저로 로그인 요청이 전송됩니다.",
+      "german": "Eine Anmeldeanfrage wird an Ihren gespeicherten Browser gesendet",
+      "portuguese": "Uma solicitação de login será enviada para o seu navegador salvo"
+    },
+    "returning-confirm-btn": {
+      "mandarin": "是的，继续生物识别",
+      "spanish": "Sí, continuar con la biometría",
+      "english": "Yes, continue with biometrics",
+      "japanese": "はい、生体認証を続行します",
+      "korean": "예, 생체 인식을 계속합니다.",
+      "german": "Ja, weiter mit Biometrie",
+      "portuguese": "Sim, continuar com a biometria"
+    },
+    "register-subtitle": {
+      "mandarin": "选择以下之一",
+      "spanish": "Selecciona uno de los siguientes",
+      "english": "Select one of the following",
+      "japanese": "次のいずれかを選択してください",
+      "korean": "다음 중 하나를 선택하십시오.",
+      "german": "Wählen Sie eine der folgenden Optionen",
+      "portuguese": "Selecione um dos seguintes"
+    },
+    "reconstruct-subtitle": {
+      "mandarin": "验证以下内容之一以访问您的帐户",
+      "spanish": "Verifique con uno de los siguientes para acceder a su cuenta",
+      "english": "Verify with one of the following to access your account",
+      "japanese": "アカウントにアクセスするには、次のいずれかで確認してください",
+      "korean": "계정에 액세스하려면 다음 중 하나로 확인하세요.",
+      "german": "Überprüfen Sie mit einem der folgenden Punkte, um auf Ihr Konto zuzugreifen",
+      "portuguese": "Verifique com um dos seguintes para acessar sua conta"
+    },
+    "register-title": {
+      "mandarin": "保护您的{0}帐户",
+      "spanish": "Asegurar su cuenta de {0}",
+      "english": "Securing your {0} account",
+      "japanese": "{0}アカウントを保護する",
+      "korean": "{0} 계정 보안",
+      "german": "Sichern Sie Ihr {0} Konto",
+      "portuguese": "Protegendo sua conta {0}"
+    },
+    "register-title-try-webauth": {
+      "mandarin": "保护您的帐户",
+      "spanish": "Asegurar su cuenta",
+      "english": "Securing your account",
+      "japanese": "アカウントを保護する",
+      "korean": "계정 보안",
+      "german": "Sichern Sie Ihr Konto",
+      "portuguese": "Protegendo sua conta"
+    },
+    "reconstruct-device-prev3": {
+      "mandarin": "从下面存储的浏览器中验证您的身份。",
+      "spanish": "desde el navegador almacenado a continuación para verificar su identidad.",
+      "english": "from the stored browser below to verify your identity.",
+      "japanese": "以下の保存されているブラウザから本人確認を行ってください。",
+      "korean": "아래 저장된 브라우저에서 귀하의 신원을 확인하십시오.",
+      "german": "über den unten gespeicherten Browser, um Ihre Identität zu überprüfen.",
+      "portuguese": "do navegador armazenado abaixo para verificar sua identidade."
+    },
+    "verifier-email-placeholder": {
+      "mandarin": "电子邮件",
+      "spanish": "Correo electrónico",
+      "english": "Email",
+      "japanese": "Eメール",
+      "korean": "이메일",
+      "german": "Email",
+      "portuguese": "E-mail"
+    },
+    "social-2fa-warning-cta-1": {
+      "mandarin": "是的，我接受风险",
+      "spanish": "Sí, acepto el riesgo",
+      "english": "Yes, I accept the risk",
+      "japanese": "はい、私はリスクを受け入れます",
+      "korean": "예, 위험을 받아들입니다",
+      "german": "Ja, ich akzeptiere das Risiko",
+      "portuguese": "Sim, eu aceito o risco"
+    },
+    "subtitle": {
+      "mandarin": "点击开始以继续",
+      "spanish": "Haga clic en comenzar para continuar",
+      "english": "Click Get Started to continue",
+      "japanese": "[開始]をクリックして続行します",
+      "korean": "계속하려면 시작하기를 클릭하세요.",
+      "german": "Klicken Sie auf Erste Schritte, um fortzufahren",
+      "portuguese": "Clique em Começar para continuar"
+    },
+    "2fa-verify-save-subhead": {
+      "mandarin": "您想将此设备保存为受信任的设备吗？",
+      "spanish": "¿Le gustaría guardar este dispositivo como dispositivo de confianza?",
+      "english": "Would you like to save this device as a trusted device?",
+      "japanese": "このデバイスを信頼できるデバイスとして保存しますか？",
+      "korean": "이 장치를 신뢰할 수 있는 장치로 저장하시겠습니까?",
+      "german": "Möchten Sie dieses Gerät als vertrauenswürdiges Gerät speichern?",
+      "portuguese": "Deseja salvar este dispositivo como um dispositivo confiável?"
+    },
+    "2fa-setup-title5": {
+      "mandarin": "2FA 激活",
+      "spanish": "2FA activado",
+      "english": "2FA activated",
+      "japanese": "2FAがアクティブ化",
+      "korean": "2FA 활성화",
+      "german": "2FA aktiviert",
+      "portuguese": "2FA ativado"
+    },
+    "mpc-2fa-setup-step3-sub2": {
+      "mandarin": "如果您无法访问保存的浏览器，您可以使用恢复短语进行身份验证。",
+      "spanish": "En caso de que pierda el acceso a su navegador guardado, puede autenticarse con su frase de recuperación.",
+      "english": "In case you lose access to your saved browser, you can authenticate with your recovery factor.",
+      "japanese": "保存したブラウザにアクセスできなくなった場合は、リカバリフレーズで認証できます。",
+      "korean": "저장된 브라우저에 액세스할 수 없는 경우 복구 문구로 인증할 수 있습니다.",
+      "german": "Falls Sie den Zugriff auf Ihren gespeicherten Browser verlieren, können Sie sich mit Ihrer Wiederherstellungsphrase authentifizieren.",
+      "portuguese": "Caso perca o acesso ao seu navegador salvo, você pode autenticar com seu fator de recuperação."
+    },
+    "register-password-password": {
+      "mandarin": "输入密码",
+      "spanish": "Ingresa tu contraseña",
+      "english": "Enter your password",
+      "japanese": "パスワードを入力してください",
+      "korean": "비밀번호를 입력하세요",
+      "german": "Geben Sie Ihr Passwort ein",
+      "portuguese": "Coloque sua senha"
+    },
+    "social-2fa-verify-heading": {
+      "mandarin": "社会恢复因素",
+      "spanish": "Factor de recuperación social",
+      "english": "Social Recovery factor",
+      "japanese": "社会的回復要因",
+      "korean": "사회 복구 요인",
+      "german": "Sozialer Genesungsfaktor",
+      "portuguese": "Fator de Recuperação Social"
+    },
+    "register-backup-phrase-additional-security-desc1": {
+      "mandarin": "将向您发送一封包含备份短语的电子邮件。",
+      "spanish": "Se le enviará un correo electrónico con la frase de respaldo.",
+      "english": "An email will be sent to you containing the backup phrase.",
+      "japanese": "バックアップ フレーズを含むメールが送信されます。",
+      "korean": "백업 문구가 포함 된 이메일이 발송됩니다.",
+      "german": "Sie erhalten eine E-Mail mit der Backup-Phrase.",
+      "portuguese": "Um e-mail será enviado para você contendo a frase de backup."
+    },
+    "popup-manage": {
+      "mandarin": "管理帐户",
+      "spanish": "Administrar cuenta",
+      "english": "Manage account",
+      "japanese": "アカウントを管理する",
+      "korean": "계정 관리",
+      "german": "Konto verwalten",
+      "portuguese": "Gerenciar conta"
+    },
+    "2fa-verify-try-other": {
+      "mandarin": "尝试其他方法",
+      "spanish": "Pruebe otros métodos",
+      "english": "Try other methods",
+      "japanese": "他の方法を試す",
+      "korean": "다른 방법 시도",
+      "german": "Probieren Sie andere Methoden aus",
+      "portuguese": "Tente outros métodos"
+    },
+    "2fa-setup-title21": {
+      "mandarin": "第 1 步：保存您的设备",
+      "spanish": "Paso 1: Guarde su dispositivo",
+      "english": "Step 1: Save your device",
+      "japanese": "ステップ1：デバイスを保存する",
+      "korean": "1단계: 기기 저장",
+      "german": "Schritt 1: Speichern Sie Ihr Gerät",
+      "portuguese": "Etapa 1: salve seu dispositivo"
+    },
+    "2fa-setup-step3-next2": {
+      "mandarin": "核实",
+      "spanish": "Verificar",
+      "english": "Verify",
+      "japanese": "確認",
+      "korean": "확인하다",
+      "german": "Verifizieren",
+      "portuguese": "Verificar"
+    },
+    "migrate-list2": {
+      "mandarin": "由SSO和设备保护",
+      "spanish": "Asegurado por SSO y dispositivo",
+      "english": "Secured by SSO and device",
+      "japanese": "SSOとデバイスによって保護されています",
+      "korean": "SSO 및 장치로 보호",
+      "german": "Durch SSO und Gerät gesichert",
+      "portuguese": "Protegido por SSO e dispositivo"
+    },
+    "2fa-verify-step1-verify": {
+      "mandarin": "核实",
+      "spanish": "Verificar",
+      "english": "Verify",
+      "japanese": "確認",
+      "korean": "검증",
+      "german": "Verifizieren",
+      "portuguese": "Verificar"
+    }
+  }
 }

--- a/Openlogin-locale/locales-nav.json
+++ b/Openlogin-locale/locales-nav.json
@@ -1,44 +1,49 @@
 {
-	"nav": {
-		"link-apps": {
-			"mandarin": "授权应用",
-			"japanese": "認定アプリ",
-			"spanish": "Aplicaciones autorizadas",
-			"english": "Authorized Apps",
-			"german": "Autorisierte Apps",
-			"korean": "승인 된 앱"
-		},
-		"link-home": {
-			"mandarin": "主页",
-			"japanese": "ホームページ",
-			"spanish": "página principal",
-			"english": "Home",
-			"german": "Startseite",
-			"korean": "홈페이지"
-		},
-		"link-support": {
-			"mandarin": "支持",
-			"japanese": "サポート",
-			"spanish": "Apoyo",
-			"english": "Support",
-			"german": "Unterstützung",
-			"korean": "지원하다"
-		},
-		"link-account": {
-			"mandarin": "帐户",
-			"japanese": "アカウント",
-			"spanish": "Cuenta",
-			"english": "Account",
-			"german": "Konto",
-			"korean": "계정"
-		},
-		"link-logout": {
-			"mandarin": "登出",
-			"japanese": "ログアウト",
-			"spanish": "Cerrar sesión",
-			"english": "Logout",
-			"german": "Ausloggen",
-			"korean": "로그 아웃"
-		}
-	}
+  "nav": {
+    "link-apps": {
+      "mandarin": "授权应用",
+      "japanese": "認定アプリ",
+      "spanish": "Aplicaciones autorizadas",
+      "english": "Authorized Apps",
+      "german": "Autorisierte Apps",
+      "korean": "승인 된 앱",
+      "portuguese": "Aplicativos autorizados"
+    },
+    "link-home": {
+      "mandarin": "主页",
+      "japanese": "ホームページ",
+      "spanish": "página principal",
+      "english": "Home",
+      "german": "Startseite",
+      "korean": "홈페이지",
+      "portuguese": "Início"
+    },
+    "link-support": {
+      "mandarin": "支持",
+      "japanese": "サポート",
+      "spanish": "Apoyo",
+      "english": "Support",
+      "german": "Unterstützung",
+      "korean": "지원하다",
+      "portuguese": "Suporte"
+    },
+    "link-account": {
+      "mandarin": "帐户",
+      "japanese": "アカウント",
+      "spanish": "Cuenta",
+      "english": "Account",
+      "german": "Konto",
+      "korean": "계정",
+      "portuguese": "Conta"
+    },
+    "link-logout": {
+      "mandarin": "登出",
+      "japanese": "ログアウト",
+      "spanish": "Cerrar sesión",
+      "english": "Logout",
+      "german": "Ausloggen",
+      "korean": "로그 아웃",
+      "portuguese": "Sair"
+    }
+  }
 }

--- a/Openlogin-locale/locales-passwordless.json
+++ b/Openlogin-locale/locales-passwordless.json
@@ -1,268 +1,301 @@
 {
-	"passwordless": {
-		"verify-invalid-link-error": {
-			"mandarin": "无效的链接",
-			"german": "Ungültiger Link",
-			"japanese": "無効なリンク",
-			"korean": "유효하지 않은 링크",
-			"spanish": "Enlace inválido",
-			"english": "Invalid link"
-		},
-		"start-invalid-url-sub": {
-			"mandarin": "网址包含无效参数",
-			"german": "URL enthält ungültige Parameter",
-			"japanese": "URLに無効なパラメータが含まれています",
-			"korean": "URL에 잘못된 매개변수가 있습니다.",
-			"spanish": "La URL contiene parámetros no válidos",
-			"english": "Url contains invalid params"
-		},
-		"verify-link-expired-guide1": {
-			"mandarin": "返回原始窗口以请求新链接",
-			"german": "Kehren Sie zum ursprünglichen Fenster zurück, um einen neuen Link anzufordern",
-			"japanese": "元のウィンドウに戻って、新しいリンクをリクエストします",
-			"korean": "새 링크를 요청하려면 원래 창으로 돌아가십시오.",
-			"spanish": "Regrese a la ventana original para solicitar un nuevo enlace",
-			"english": "Return to original window to request for a new link"
-		},
-		"verify-link-expired-info": {
-			"mandarin": "超时",
-			"german": "Auszeit",
-			"japanese": "タイムアウト",
-			"korean": "시간 초과",
-			"spanish": "Se acabó el tiempo",
-			"english": "Timeout"
-		},
-		"start-resend-subtitle": {
-			"mandarin": "请求发送另一封电子邮件以继续验证。",
-			"german": "Fordern Sie an, eine weitere E-Mail zu senden, um mit der Bestätigung fortzufahren.",
-			"japanese": "確認を続行するには、別のメールを送信するようにリクエストしてください。",
-			"korean": "확인을 계속하려면 다른 이메일을 보내도록 요청하세요.",
-			"spanish": "Solicite enviar otro correo electrónico para continuar con la verificación.",
-			"english": "Request to send another email to continue with verification."
-		},
-		"loader-done-note": {
-			"mandarin": "关闭它并返回上一个窗口",
-			"german": "Schließen Sie dieses und kehren Sie zu Ihrem vorherigen Fenster zurück",
-			"japanese": "これを閉じて、前のウィンドウに戻ります",
-			"korean": "이것을 닫고 이전 창으로 돌아가십시오.",
-			"spanish": "Cierra esto y vuelve a tu ventana anterior",
-			"english": "Close this and return to your previous window"
-		},
-		"start-invalid-url-error": {
-			"mandarin": "验证网址无效",
-			"german": "Ungültige Authentifizierungs-URL",
-			"japanese": "無効な認証URL",
-			"korean": "잘못된 인증 URL",
-			"spanish": "URL de autenticación no válida",
-			"english": "Invalid authentication url"
-		},
-		"loader-done": {
-			"mandarin": "完毕",
-			"german": "Erledigt",
-			"japanese": "終わり",
-			"korean": "완료",
-			"spanish": "Hecho",
-			"english": "Done"
-		},
-		"start-link-error": {
-			"mandarin": "该链接已过期。再次登录以获取新链接",
-			"german": "Der Link ist abgelaufen. Bitte melden Sie sich erneut an, um einen neuen Link zu erhalten",
-			"japanese": "リンクの有効期限が切れています。もう一度ログインして、新しいリンクを取得します",
-			"korean": "링크가 만료되었습니다. 새로운 링크를 얻으려면 다시 로그인하십시오",
-			"spanish": "El enlace ha expirado. Por favor, inicie sesión nuevamente para obtener un nuevo enlace",
-			"english": "The link has expired. Kindly login again to get a new link"
-		},
-		"start-something-wrong-error": {
-			"mandarin": "出问题了",
-			"german": "Etwas ist schief gelaufen",
-			"japanese": "何かがうまくいかなかった",
-			"korean": "문제가 발생했습니다.",
-			"spanish": "Algo salió mal",
-			"english": "Something went wrong"
-		},
-		"start-verification-subtitle4": {
-			"mandarin": "没收到邮件吗？",
-			"german": "Hast du die E-mail nicht bekommen?",
-			"japanese": "メールは届きませんでしたか？",
-			"korean": "이메일을받지 못했습니까?",
-			"spanish": "no recibiste el email?",
-			"english": "Did not get the email?"
-		},
-		"start-resend-btn": {
-			"mandarin": "重发电子邮件",
-			"german": "E-Mail zurücksenden",
-			"japanese": "メールを再送",
-			"korean": "이메일 재전송",
-			"spanish": "Reenviar email",
-			"english": "Resend email"
-		},
-		"verify-link-expired-error": {
-			"mandarin": "链接已过期",
-			"german": "Link abgelaufen",
-			"japanese": "リンクの有効期限が切れました",
-			"korean": "링크 만료됨",
-			"spanish": "Enlace expirado",
-			"english": "Link expired"
-		},
-		"error-boundary-title": {
-			"mandarin": "服务器无法处理请求。 重定向。",
-			"german": "Server kann Anfrage nicht verarbeiten. Umleitung.",
-			"japanese": "サーバーはリクエストを処理できません。 リダイレクト。",
-			"korean": "서버가 요청을 처리할 수 없습니다. 리디렉션 중.",
-			"spanish": "El servidor no puede procesar la solicitud. Redirigiendo.",
-			"english": "Server unable to process request. Redirecting."
-		},
-		"error-boundary-btn-home": {
-			"mandarin": "点击这里回家",
-			"german": "Klicken Sie hier, um nach Hause zu gehen",
-			"japanese": "家に帰るにはここをクリック",
-			"korean": "집으로 이동하려면 여기를 클릭하세요",
-			"spanish": "Presione aqui para ir a la pagina de inicio",
-			"english": "Click here to go home"
-		},
-		"start-verification-subtitle3": {
-			"mandarin": "请验证您的电子邮件以继续。",
-			"german": "Bitte bestätigen Sie Ihre E-Mail, um fortzufahren.",
-			"japanese": "続行するには、メールアドレスを確認してください。",
-			"korean": "계속하려면 이메일을 확인하세요.",
-			"spanish": "Verifique su correo electrónico para continuar.",
-			"english": "Please verify your email to continue."
-		},
-		"verify-invalid-link-tempkey-error": {
-			"mandarin": "无效链接，有效链接应包含 tempPubKey",
-			"german": "Ungültiger Link, gültiger Link sollte tempPubKey enthalten",
-			"japanese": "無効なリンク、有効なリンクにはtempPubKeyが含まれている必要があります",
-			"korean": "잘못된 링크, 유효한 링크에는 tempPubKey가 포함되어야 합니다.",
-			"spanish": "Enlace no válido, el enlace válido debe contener tempPubKey",
-			"english": "Invalid link, valid link should contain tempPubKey"
-		},
-		"loader-not-done-note": {
-			"mandarin": "我们将在几秒钟内到达",
-			"german": "Wir sind in wenigen Sekunden da",
-			"japanese": "数秒で到着します",
-			"korean": "우리는 몇 초 안에 거기에있을 것입니다",
-			"spanish": "Estaremos allí en unos segundos",
-			"english": "We will be there in a few seconds"
-		},
-		"start-verification-btn-toinbox": {
-			"mandarin": "转到我的收件箱",
-			"german": "Gehe zu meinem Posteingang",
-			"japanese": "受信トレイに移動します",
-			"korean": "내 받은 편지함으로 이동",
-			"spanish": "Ir a mi bandeja de entrada",
-			"english": "Go to my inbox"
-		},
-		"start-link-sub": {
-			"mandarin": "超时",
-			"german": "Auszeit",
-			"japanese": "タイムアウト",
-			"korean": "시간 초과",
-			"spanish": "Se acabó el tiempo",
-			"english": "Timeout"
-		},
-		"start-verification-title": {
-			"mandarin": "确认",
-			"german": "Überprüfung",
-			"japanese": "検証",
-			"korean": "확인",
-			"spanish": "Verificación",
-			"english": "Verification"
-		},
-		"start-verification-subtitle2": {
-			"mandarin": "一封电子邮件已经发送至",
-			"german": "Eine email wurde gesendet an",
-			"japanese": "メールがに送信されました",
-			"korean": "로 이메일이 전송되었습니다.",
-			"spanish": "Se ha enviado un correo electrónico a",
-			"english": "An email has been sent to"
-		},
-		"start-verification-subtitle1": {
-			"mandarin": "请验证您的电子邮件",
-			"german": "Bitte bestätige deine E-Mail",
-			"japanese": "メールアドレスを確認してください",
-			"korean": "이메일을 확인하세요",
-			"spanish": "Verifique su correo electrónico",
-			"english": "Please verify your email"
-		},
-		"start-something-wrong-sub": {
-			"mandarin": "意外的错误。",
-			"german": "Unerwarteter Fehler.",
-			"japanese": "予期しないエラー。",
-			"korean": "예기치 않은 오류.",
-			"spanish": "Error inesperado.",
-			"english": "Unexpected error."
-		},
-		"verify-error-error": {
-			"mandarin": "出问题了",
-			"german": "Etwas ist schief gelaufen",
-			"japanese": "何かがうまくいかなかった",
-			"korean": "문제가 발생했습니다.",
-			"spanish": "Algo salió mal",
-			"english": "Something went wrong"
-		},
-		"error-something-wrong-error": {
-			"mandarin": "出问题了",
-			"german": "Etwas ist schief gelaufen",
-			"japanese": "何かがうまくいかなかった",
-			"korean": "문제가 발생했습니다.",
-			"spanish": "Algo salió mal",
-			"english": "Something went wrong"
-		},
-		"start-magic-link-error": {
-			"mandarin": "魔法链接已过期",
-			"german": "Magic-Link abgelaufen",
-			"japanese": "マジックリンクの有効期限が切れました",
-			"korean": "매직 링크 만료",
-			"spanish": "Enlace mágico caducado",
-			"english": "Magic link expired"
-		},
-		"verify-error-info": {
-			"mandarin": "错误",
-			"german": "Fehler",
-			"japanese": "エラー",
-			"korean": "오류",
-			"spanish": "Error",
-			"english": "Error"
-		},
-		"loading": {
-			"mandarin": "加载中",
-			"german": "Wird geladen",
-			"japanese": "読み込み中",
-			"korean": "로딩 중",
-			"spanish": "Cargando",
-			"english": "Loading"
-		},
-		"verify-invalid-link-info": {
-			"mandarin": "在链接中发现无效参数",
-			"german": "Ungültige Parameter im Link gefunden",
-			"japanese": "リンクで無効なパラメータが見つかりました",
-			"korean": "링크에 잘못된 매개변수가 있습니다.",
-			"spanish": "Se encontraron parámetros no válidos en el enlace",
-			"english": "Invalid params found in link"
-		},
-		"loader-logging-in": {
-			"mandarin": "登录",
-			"german": "Ich melde dich an",
-			"japanese": "ログインします",
-			"korean": "로그인",
-			"spanish": "Iniciar sesión",
-			"english": "Logging you in"
-		},
-		"verify-link-expired-guide2": {
-			"mandarin": "您可以关闭此窗口",
-			"german": "Sie können dieses Fenster schließen",
-			"japanese": "このウィンドウを閉じることができます",
-			"korean": "이 창을 닫을 수 있습니다",
-			"spanish": "Puedes cerrar esta ventana",
-			"english": "You can close this window"
-		},
-		"verify-loggedin": {
-			"mandarin": "您已登录，您可以返回原来的选项卡。",
-			"german": "Sie sind eingeloggt, Sie können zu Ihrem ursprünglichen Tab zurückkehren.",
-			"japanese": "ログインすると、元のタブに戻ることができます。",
-			"korean": "로그인하면 원래 탭으로 돌아갈 수 있습니다.",
-			"spanish": "Ha iniciado sesión, puede volver a la pestaña original.",
-			"english": "You are logged in, you can move back to your original tab."
-		}
-	}
+  "passwordless": {
+    "verify-invalid-link-error": {
+      "mandarin": "无效的链接",
+      "german": "Ungültiger Link",
+      "japanese": "無効なリンク",
+      "korean": "유효하지 않은 링크",
+      "spanish": "Enlace inválido",
+      "english": "Invalid link",
+      "portuguese": "Link inválido"
+    },
+    "start-invalid-url-sub": {
+      "mandarin": "网址包含无效参数",
+      "german": "URL enthält ungültige Parameter",
+      "japanese": "URLに無効なパラメータが含まれています",
+      "korean": "URL에 잘못된 매개변수가 있습니다.",
+      "spanish": "La URL contiene parámetros no válidos",
+      "english": "Url contains invalid params",
+      "portuguese": "URL contém parâmetros inválidos"
+    },
+    "verify-link-expired-guide1": {
+      "mandarin": "返回原始窗口以请求新链接",
+      "german": "Kehren Sie zum ursprünglichen Fenster zurück, um einen neuen Link anzufordern",
+      "japanese": "元のウィンドウに戻って、新しいリンクをリクエストします",
+      "korean": "새 링크를 요청하려면 원래 창으로 돌아가십시오.",
+      "spanish": "Regrese a la ventana original para solicitar un nuevo enlace",
+      "english": "Return to original window to request for a new link",
+      "portuguese": "Retorne à janela original para solicitar um novo link"
+    },
+    "verify-link-expired-info": {
+      "mandarin": "超时",
+      "german": "Auszeit",
+      "japanese": "タイムアウト",
+      "korean": "시간 초과",
+      "spanish": "Se acabó el tiempo",
+      "english": "Timeout",
+      "portuguese": "Tempo esgotado"
+    },
+    "start-resend-subtitle": {
+      "mandarin": "请求发送另一封电子邮件以继续验证。",
+      "german": "Fordern Sie an, eine weitere E-Mail zu senden, um mit der Bestätigung fortzufahren.",
+      "japanese": "確認を続行するには、別のメールを送信するようにリクエストしてください。",
+      "korean": "확인을 계속하려면 다른 이메일을 보내도록 요청하세요.",
+      "spanish": "Solicite enviar otro correo electrónico para continuar con la verificación.",
+      "english": "Request to send another email to continue with verification.",
+      "portuguese": "Solicite o envio de outro e-mail para continuar com a verificação."
+    },
+    "loader-done-note": {
+      "mandarin": "关闭它并返回上一个窗口",
+      "german": "Schließen Sie dieses und kehren Sie zu Ihrem vorherigen Fenster zurück",
+      "japanese": "これを閉じて、前のウィンドウに戻ります",
+      "korean": "이것을 닫고 이전 창으로 돌아가십시오.",
+      "spanish": "Cierra esto y vuelve a tu ventana anterior",
+      "english": "Close this and return to your previous window",
+      "portuguese": "Feche isso e volte para a janela anterior"
+    },
+    "start-invalid-url-error": {
+      "mandarin": "验证网址无效",
+      "german": "Ungültige Authentifizierungs-URL",
+      "japanese": "無効な認証URL",
+      "korean": "잘못된 인증 URL",
+      "spanish": "URL de autenticación no válida",
+      "english": "Invalid authentication url",
+      "portuguese": "URL de autenticação inválido"
+    },
+    "loader-done": {
+      "mandarin": "完毕",
+      "german": "Erledigt",
+      "japanese": "終わり",
+      "korean": "완료",
+      "spanish": "Hecho",
+      "english": "Done",
+      "portuguese": "Feito"
+    },
+    "start-link-error": {
+      "mandarin": "该链接已过期。再次登录以获取新链接",
+      "german": "Der Link ist abgelaufen. Bitte melden Sie sich erneut an, um einen neuen Link zu erhalten",
+      "japanese": "リンクの有効期限が切れています。もう一度ログインして、新しいリンクを取得します",
+      "korean": "링크가 만료되었습니다. 새로운 링크를 얻으려면 다시 로그인하십시오",
+      "spanish": "El enlace ha expirado. Por favor, inicie sesión nuevamente para obtener un nuevo enlace",
+      "english": "The link has expired. Kindly login again to get a new link",
+      "portuguese": "O link expirou. Faça o login novamente para obter um novo link"
+    },
+    "start-something-wrong-error": {
+      "mandarin": "出问题了",
+      "german": "Etwas ist schief gelaufen",
+      "japanese": "何かがうまくいかなかった",
+      "korean": "문제가 발생했습니다.",
+      "spanish": "Algo salió mal",
+      "english": "Something went wrong",
+      "portuguese": "Algo deu errado"
+    },
+    "start-verification-subtitle4": {
+      "mandarin": "没收到邮件吗？",
+      "german": "Hast du die E-mail nicht bekommen?",
+      "japanese": "メールは届きませんでしたか？",
+      "korean": "이메일을받지 못했습니까?",
+      "spanish": "no recibiste el email?",
+      "english": "Did not get the email?",
+      "portuguese": "Não recebeu o email?"
+    },
+    "start-resend-btn": {
+      "mandarin": "重发电子邮件",
+      "german": "E-Mail zurücksenden",
+      "japanese": "メールを再送",
+      "korean": "이메일 재전송",
+      "spanish": "Reenviar email",
+      "english": "Resend email",
+      "portuguese": "Reenviar email"
+    },
+    "verify-link-expired-error": {
+      "mandarin": "链接已过期",
+      "german": "Link abgelaufen",
+      "japanese": "リンクの有効期限が切れました",
+      "korean": "링크 만료됨",
+      "spanish": "Enlace expirado",
+      "english": "Link expired",
+      "portuguese": "Link expirado"
+    },
+    "error-boundary-title": {
+      "mandarin": "服务器无法处理请求。 重定向。",
+      "german": "Server kann Anfrage nicht verarbeiten. Umleitung.",
+      "japanese": "サーバーはリクエストを処理できません。 リダイレクト。",
+      "korean": "서버가 요청을 처리할 수 없습니다. 리디렉션 중.",
+      "spanish": "El servidor no puede procesar la solicitud. Redirigiendo.",
+      "english": "Server unable to process request. Redirecting.",
+      "portuguese": "O servidor não pode processar a solicitação. Redirecionando."
+    },
+    "error-boundary-btn-home": {
+      "mandarin": "点击这里回家",
+      "german": "Klicken Sie hier, um nach Hause zu gehen",
+      "japanese": "家に帰るにはここをクリック",
+      "korean": "집으로 이동하려면 여기를 클릭하세요",
+      "spanish": "Presione aqui para ir a la pagina de inicio",
+      "english": "Click here to go home",
+      "portuguese": "Clique aqui para ir para a página inicial"
+    },
+    "start-verification-subtitle3": {
+      "mandarin": "请验证您的电子邮件以继续。",
+      "german": "Bitte bestätigen Sie Ihre E-Mail, um fortzufahren.",
+      "japanese": "続行するには、メールアドレスを確認してください。",
+      "korean": "계속하려면 이메일을 확인하세요.",
+      "spanish": "Verifique su correo electrónico para continuar.",
+      "english": "Please verify your email to continue.",
+      "portuguese": "Verifique seu e-mail para continuar."
+    },
+    "verify-invalid-link-tempkey-error": {
+      "mandarin": "无效链接，有效链接应包含 tempPubKey",
+      "german": "Ungültiger Link, gültiger Link sollte tempPubKey enthalten",
+      "japanese": "無効なリンク、有効なリンクにはtempPubKeyが含まれている必要があります",
+      "korean": "잘못된 링크, 유효한 링크에는 tempPubKey가 포함되어야 합니다.",
+      "spanish": "Enlace no válido, el enlace válido debe contener tempPubKey",
+      "english": "Invalid link, valid link should contain tempPubKey",
+      "portuguese": "Link inválido, link válido deve conter tempPubKey"
+    },
+    "loader-not-done-note": {
+      "mandarin": "我们将在几秒钟内到达",
+      "german": "Wir sind in wenigen Sekunden da",
+      "japanese": "数秒で到着します",
+      "korean": "우리는 몇 초 안에 거기에있을 것입니다",
+      "spanish": "Estaremos allí en unos segundos",
+      "english": "We will be there in a few seconds",
+      "portuguese": "Estaremos lá em alguns segundos"
+    },
+    "start-verification-btn-toinbox": {
+      "mandarin": "转到我的收件箱",
+      "german": "Gehe zu meinem Posteingang",
+      "japanese": "受信トレイに移動します",
+      "korean": "내 받은 편지함으로 이동",
+      "spanish": "Ir a mi bandeja de entrada",
+      "english": "Go to my inbox",
+      "portuguese": "Ir para minha caixa de entrada"
+    },
+    "start-link-sub": {
+      "mandarin": "超时",
+      "german": "Auszeit",
+      "japanese": "タイムアウト",
+      "korean": "시간 초과",
+      "spanish": "Se acabó el tiempo",
+      "english": "Timeout",
+      "portuguese": "Tempo esgotado"
+    },
+    "start-verification-title": {
+      "mandarin": "确认",
+      "german": "Überprüfung",
+      "japanese": "検証",
+      "korean": "확인",
+      "spanish": "Verificación",
+      "english": "Verification",
+      "portuguese": "Verificação"
+    },
+    "start-verification-subtitle2": {
+      "mandarin": "一封电子邮件已经发送至",
+      "german": "Eine email wurde gesendet an",
+      "japanese": "メールがに送信されました",
+      "korean": "로 이메일이 전송되었습니다.",
+      "spanish": "Se ha enviado un correo electrónico a",
+      "english": "An email has been sent to",
+      "portuguese": "Um e-mail foi enviado para"
+    },
+    "start-verification-subtitle1": {
+      "mandarin": "请验证您的电子邮件",
+      "german": "Bitte bestätige deine E-Mail",
+      "japanese": "メールアドレスを確認してください",
+      "korean": "이메일을 확인하세요",
+      "spanish": "Verifique su correo electrónico",
+      "english": "Please verify your email",
+      "portuguese": "Verifique seu e-mail"
+    },
+    "start-something-wrong-sub": {
+      "mandarin": "意外的错误。",
+      "german": "Unerwarteter Fehler.",
+      "japanese": "予期しないエラー。",
+      "korean": "예기치 않은 오류.",
+      "spanish": "Error inesperado.",
+      "english": "Unexpected error.",
+      "portuguese": "Erro inesperado."
+    },
+    "verify-error-error": {
+      "mandarin": "出问题了",
+      "german": "Etwas ist schief gelaufen",
+      "japanese": "何かがうまくいかなかった",
+      "korean": "문제가 발생했습니다.",
+      "spanish": "Algo salió mal",
+      "english": "Something went wrong",
+      "portuguese": "Algo deu errado"
+    },
+    "error-something-wrong-error": {
+      "mandarin": "出问题了",
+      "german": "Etwas ist schief gelaufen",
+      "japanese": "何かがうまくいかなかった",
+      "korean": "문제가 발생했습니다.",
+      "spanish": "Algo salió mal",
+      "english": "Something went wrong",
+      "portuguese": "Algo deu errado"
+    },
+    "start-magic-link-error": {
+      "mandarin": "魔法链接已过期",
+      "german": "Magic-Link abgelaufen",
+      "japanese": "マジックリンクの有効期限が切れました",
+      "korean": "매직 링크 만료",
+      "spanish": "Enlace mágico caducado",
+      "english": "Magic link expired",
+      "portuguese": "Link mágico expirado"
+    },
+    "verify-error-info": {
+      "mandarin": "错误",
+      "german": "Fehler",
+      "japanese": "エラー",
+      "korean": "오류",
+      "spanish": "Error",
+      "english": "Error",
+      "portuguese": "Erro"
+    },
+    "loading": {
+      "mandarin": "加载中",
+      "german": "Wird geladen",
+      "japanese": "読み込み中",
+      "korean": "로딩 중",
+      "spanish": "Cargando",
+      "english": "Loading",
+      "portuguese": "Carregando"
+    },
+    "verify-invalid-link-info": {
+      "mandarin": "在链接中发现无效参数",
+      "german": "Ungültige Parameter im Link gefunden",
+      "japanese": "リンクで無効なパラメータが見つかりました",
+      "korean": "링크에 잘못된 매개변수가 있습니다.",
+      "spanish": "Se encontraron parámetros no válidos en el enlace",
+      "english": "Invalid params found in link",
+      "portuguese": "Parâmetros inválidos encontrados no link"
+    },
+    "loader-logging-in": {
+      "mandarin": "登录",
+      "german": "Ich melde dich an",
+      "japanese": "ログインします",
+      "korean": "로그인",
+      "spanish": "Iniciar sesión",
+      "english": "Logging you in",
+      "portuguese": "Conectando você"
+    },
+    "verify-link-expired-guide2": {
+      "mandarin": "您可以关闭此窗口",
+      "german": "Sie können dieses Fenster schließen",
+      "japanese": "このウィンドウを閉じることができます",
+      "korean": "이 창을 닫을 수 있습니다",
+      "spanish": "Puedes cerrar esta ventana",
+      "english": "You can close this window",
+      "portuguese": "Você pode fechar esta janela"
+    },
+    "verify-loggedin": {
+      "mandarin": "您已登录，您可以返回原来的选项卡。",
+      "german": "Sie sind eingeloggt, Sie können zu Ihrem ursprünglichen Tab zurückkehren.",
+      "japanese": "ログインすると、元のタブに戻ることができます。",
+      "korean": "로그인하면 원래 탭으로 돌아갈 수 있습니다.",
+      "spanish": "Ha iniciado sesión, puede volver a la pestaña original.",
+      "english": "You are logged in, you can move back to your original tab.",
+      "portuguese": "Você está logado, você pode voltar para sua guia original."
+    }
+  }
 }

--- a/Openlogin-locale/locales-wallet-account.json
+++ b/Openlogin-locale/locales-wallet-account.json
@@ -1,313 +1,356 @@
 {
-	"account": {
-		"auth-factors-threshold-factor": {
-			"korean": "{0} 인증 요소",
-			"spanish": "{0} Factor de autenticación",
-			"english": "{0} Authentication factor",
-			"mandarin": "{0}认证因素",
-			"german": "{0} Authentifizierungsfaktor",
-			"japanese": "{0}認証要素"
-		},
-		"auth-factors-threshold-desc": {
-			"korean": "계정에 액세스하기 위해 인증 할 요소의 수입니다.",
-			"spanish": "La cantidad de factores que se deben autenticar para acceder a su cuenta.",
-			"english": "The number of factors to authenticate in order to access your account.",
-			"mandarin": "要访问您的帐户进行身份验证的因素数量。",
-			"german": "Die Anzahl der Faktoren, die authentifiziert werden müssen, um auf Ihr Konto zuzugreifen.",
-			"japanese": "アカウントにアクセスするために認証する要素の数。"
-		},
-		"auth-factors-email-enter": {
-			"korean": "복구 이메일 입력",
-			"spanish": "Ingresa el correo de recuperación",
-			"english": "Enter recovery email",
-			"mandarin": "输入辅助邮箱",
-			"german": "Geben Sie die Wiederherstellungs-E-Mail ein",
-			"japanese": "復旧メールを入力してください"
-		},
-		"export-onkey-2fa": {
-			"english": "Two-factor authentication"
-		},
-		"auth-factors-enable-biometrics": {
-			"korean": "생체 인식 등록",
-			"spanish": "Habilitar la biometría",
-			"english": "Enable biometrics",
-			"mandarin": "生物识别注册",
-			"german": "Biometrie aktivieren",
-			"japanese": "登録されたバイオメトリクス"
-		},
-		"auth-factors-device-current": {
-			"korean": "흐름",
-			"spanish": "Actual",
-			"english": "Current",
-			"mandarin": "当前的",
-			"german": "Strom",
-			"japanese": "電流"
-		},
-		"mpc-export-share-note": {
-			"korean": "참고: 이 복구 요소는 계정을 인증하는 데 필요한 요소 중 하나입니다. 향후 계정 복구의 일환으로 안전한 곳에 보관하십시오.",
-			"spanish": "Nota: este factor de recuperación es uno de los factores necesarios para autenticar su cuenta. Manténgalo en un lugar seguro como parte de la recuperación de su cuenta en el futuro.",
-			"english": "Note: This recovery factor is 1 of the factors needed to authenticate your account. Keep it somewhere safe as a part of your account recovery in the future.",
-			"mandarin": "注意：此恢复因素是验证您的帐户所需的因素之一。将其保存在安全的地方，作为您未来帐户恢复的一部分。",
-			"german": "Hinweis: Dieser Wiederherstellungsfaktor ist einer der Faktoren, die zur Authentifizierung Ihres Kontos erforderlich sind. Bewahren Sie es im Rahmen Ihrer zukünftigen Kontowiederherstellung an einem sicheren Ort auf.",
-			"japanese": "注: この回復要素は、アカウントの認証に必要な要素の 1 つです。将来のアカウント復旧の一環として、安全な場所に保管してください。"
-		},
-		"delete-share-desc-1": {
-			"english": "Be very sure as"
-		},
-		"auth-factors-password-set": {
-			"korean": "비밀번호를 설정하세요",
-			"spanish": "Establece tu contraseña",
-			"english": "Set your password",
-			"mandarin": "设置你的密码",
-			"german": "Lege ein Passwort fest",
-			"japanese": "パスワードを作る"
-		},
-		"title": {
-			"korean": "계정",
-			"spanish": "Cuenta",
-			"english": "Account",
-			"mandarin": "帐户",
-			"german": "Konto",
-			"japanese": "アカウント"
-		},
-		"auth-factors-title": {
-			"korean": "보안 설정",
-			"spanish": "Configuraciones de seguridad",
-			"english": "Security Settings",
-			"mandarin": "安全设定",
-			"german": "Sicherheitseinstellungen",
-			"japanese": "セキュリティ設定"
-		},
-		"remove-share-button": {
-			"english": "Remove share"
-		},
-		"social-factor-change": {
-			"korean": "사회적 요인을 변경하십시오",
-			"spanish": "Cambiar el factor social",
-			"english": "Change Social Factor",
-			"mandarin": "改变社会因素",
-			"german": "Ändern Sie den sozialen Faktor",
-			"japanese": "社会的要因を変えます"
-		},
-		"auth-factors-password-change": {
-			"korean": "비밀번호 변경",
-			"spanish": "Cambia la contraseña",
-			"english": "Change Password",
-			"mandarin": "更改密码",
-			"german": "Passwort ändern",
-			"japanese": "パスワードを変更する"
-		},
-		"auth-factors-recovery-phrase": {
-			"korean": "복구 문구",
-			"spanish": "Frase de recuperación",
-			"english": "Recovery phrase",
-			"mandarin": "恢复短语",
-			"german": "Wiederherstellungsphrase",
-			"japanese": "回復フレーズ"
-		},
-		"auth-factors-network": {
-			"korean": "Torus 노드를 통한 소셜 로그인",
-			"spanish": "Inicios de sesión sociales a través de nodos Torus",
-			"english": "Social logins via Torus nodes",
-			"mandarin": "通过Torus节点进行社交登录",
-			"german": "Soziale Anmeldungen über Torus-Knoten",
-			"japanese": "Torusノードを介したソーシャルログイン"
-		},
-		"export-share-note": {
-			"korean": "참고: 이 복구 문구는 계정을 인증하는 데 필요한 요소 중 하나입니다. 향후 계정 복구의 일환으로 안전한 곳에 보관하십시오.",
-			"spanish": "Nota: Esta frase de recuperación es uno de los factores necesarios para autenticar su cuenta. Guárdelo en un lugar seguro como parte de la recuperación de su cuenta en el futuro.",
-			"english": "Note: This recovery phrase is 1 of the factors needed to authenticate your account. Keep it somewhere safe as a part of your account recovery in the future.",
-			"mandarin": "注意：此恢复短语是验证您的帐户所需的因素之一。 将其保存在安全的地方，作为将来恢复帐户的一部分。",
-			"german": "Hinweis: Dieser Wiederherstellungssatz ist einer der Faktoren, die zur Authentifizierung Ihres Kontos erforderlich sind. Bewahren Sie es für die zukünftige Kontowiederherstellung an einem sicheren Ort auf.",
-			"japanese": "注：この回復フレーズは、アカウントの認証に必要な要素の1つです。 将来のアカウント復旧の一環として、安全な場所に保管してください。"
-		},
-		"auth-factors-email": {
-			"korean": "복구 이메일",
-			"spanish": "Correo electrónico de recuperación",
-			"english": "Recovery email",
-			"mandarin": "辅助邮箱",
-			"german": "Wiederherstellungs-E-Mail",
-			"japanese": "回復メール"
-		},
-		"auth-factors-email-resend": {
-			"korean": "재전송",
-			"spanish": "Reenviar",
-			"english": "Resend",
-			"mandarin": "重发",
-			"german": "Erneut senden",
-			"japanese": "再送"
-		},
-		"auth-factors-downloaded-on": {
-			"korean": "{0}에 다운로드됨",
-			"spanish": "Descargado el {0}",
-			"english": "Downloaded on {0}",
-			"mandarin": "于 {0} 下载",
-			"german": "Heruntergeladen am {0}",
-			"japanese": "{0}にダウンロード"
-		},
-		"auth-factors-password": {
-			"korean": "계정 비밀번호",
-			"spanish": "Contraseña de la cuenta",
-			"english": "Account password",
-			"mandarin": "户口密码",
-			"german": "Konto Passwort",
-			"japanese": "アカウントパスワード"
-		},
-		"auth-factors-device-empty": {
-			"korean": "장치 공유가 없습니다.",
-			"spanish": "No se encontraron recursos compartidos de dispositivos",
-			"english": "No device shares found",
-			"mandarin": "未找到设备共享",
-			"german": "Keine Gerätefreigaben gefunden",
-			"japanese": "デバイス共有が見つかりません"
-		},
-		"delete-share-desc-2": {
-			"english": "this action is permanent and cannot be undone."
-		},
-		"auth-factors-device-biometrics": {
-			"korean": "생체 인식 활성화",
-			"spanish": "biometría registrada",
-			"english": "biometrics registered",
-			"mandarin": "启用生物识别",
-			"german": "Biometrie registriert",
-			"japanese": "生体認証が有効"
-		},
-		"export-share-desc": {
-			"korean": "백업 문구 사본 저장",
-			"spanish": "Guarde una copia de su frase de respaldo",
-			"english": "Save a copy of your backup phrase",
-			"mandarin": "保存备份短语的副本",
-			"german": "Speichern Sie eine Kopie Ihrer Sicherungsphrase",
-			"japanese": "バックアップフレーズのコピーを保存します"
-		},
-		"auth-factors-email-sent": {
-			"korean": "보냄",
-			"spanish": "Enviado",
-			"english": "Sent",
-			"mandarin": "发送",
-			"german": "Geschickt",
-			"japanese": "送信済み"
-		},
-		"export-onkey-note": {
-			"korean": "2FA를 활성화하여 계정 보안 강화",
-			"spanish": "Aumente la seguridad de su cuenta habilitando 2FA",
-			"english": "Increase your account security by enabling 2FA",
-			"mandarin": "通过启用 2FA 提高您的帐户安全性",
-			"german": "Erhöhen Sie die Sicherheit Ihres Kontos, indem Sie 2FA aktivieren",
-			"japanese": "2FAを有効にして、アカウントのセキュリティを強化します"
-		},
-		"auth-factors-device-title": {
-			"korean": "장치",
-			"spanish": "Dispositivos",
-			"english": "Device(s)",
-			"mandarin": "设备",
-			"german": "Geräte",
-			"japanese": "デバイス"
-		},
-		"auth-factors-threshold": {
-			"korean": "보안 요소",
-			"spanish": "Factores de seguridad",
-			"english": "Security Factors",
-			"mandarin": "安全因素",
-			"german": "Sicherheitsfaktoren",
-			"japanese": "セキュリティ要因"
-		},
-		"auth-factors-device-desc": {
-			"korean": "이러한 장치는 귀하의 계정에 액세스 할 수있는 고유 한 요소입니다.",
-			"spanish": "Estos dispositivos son factores únicos autorizados para acceder a su cuenta.",
-			"english": "These devices are unique factors authorized to access your account.",
-			"mandarin": "这些设备是被授权访问您的帐户的独特因素。",
-			"german": "Diese Geräte sind einzigartige Faktoren, die für den Zugriff auf Ihr Konto berechtigt sind.",
-			"japanese": "これらのデバイスは、アカウントへのアクセスを許可された固有の要素です。"
-		},
-		"export-onkey-setup": {
-			"korean": "설정",
-			"spanish": "Prepararlo",
-			"english": "Set it up",
-			"mandarin": "设置它",
-			"german": "Es einrichten",
-			"japanese": "準備する"
-		},
-		"export-onkey-not-setup": {
-			"korean": "아직 설정되지 않음",
-			"spanish": "Aún no configurado",
-			"english": "Not setup yet",
-			"mandarin": "尚未设置",
-			"german": "Noch nicht eingerichtet",
-			"japanese": "まだセットアップされていません"
-		},
-		"export-share-title": {
-			"korean": "백업 문구",
-			"spanish": "Frase de respaldo",
-			"english": "Backup phrase",
-			"mandarin": "备用词组",
-			"german": "Sicherungssatz",
-			"japanese": "バックアップフレーズ"
-		},
-		"auth-factors-email-sent-to": {
-			"korean": "{0}에게 보냄",
-			"spanish": "Enviado a {0}",
-			"english": "Sent to {0}",
-			"mandarin": "发送到{0}",
-			"german": "Gesendet an {0}",
-			"japanese": "{0}に送信"
-		},
-		"auth-factors-password-confirm": {
-			"korean": "비밀번호 재 입력",
-			"spanish": "reingresa tu contraseña",
-			"english": "Re-enter your password",
-			"mandarin": "重新输入密码",
-			"german": "Wiederhole die Eingabe deines Passwortes",
-			"japanese": "パスワードを再入力してください"
-		},
-		"desc": {
-			"korean": "여기에서 OpenLogin 설정을 관리하세요.",
-			"spanish": "Administre su configuración de OpenLogin aquí",
-			"english": "Manage your OpenLogin settings here",
-			"mandarin": "在此处管理您的OpenLogin设置",
-			"german": "Verwalten Sie hier Ihre OpenLogin-Einstellungen",
-			"japanese": "ここでOpenLogin設定を管理します"
-		},
-		"auth-factors-subtitle": {
-			"korean": "인증 요인 목록",
-			"spanish": "Lista de factores de autenticación",
-			"english": "List of Authentication factors",
-			"mandarin": "认证因素清单",
-			"german": "Liste der Authentifizierungsfaktoren",
-			"japanese": "認証要素のリスト"
-		},
-		"auth-factors-email-old": {
-			"korean": "복구 이메일 (기존)",
-			"spanish": "Correo electrónico de recuperación (existente)",
-			"english": "Recovery email (existing)",
-			"mandarin": "辅助邮箱（现有）",
-			"german": "Wiederherstellungs-E-Mail (vorhanden)",
-			"japanese": "復旧メール（既存）"
-		},
-		"mpc-auth-factors-recovery-phrase": {
-			"korean": "회복 계수",
-			"spanish": "Factor de recuperación",
-			"english": "Recovery factor",
-			"mandarin": "恢复系数",
-			"german": "Erholungsfaktor",
-			"japanese": "回収率"
-		},
-		"delete-share-title": {
-			"english": "Delete authentication factor"
-		},
-		"export-share-copy": {
-			"korean": "복사하려면 클릭",
-			"spanish": "Haga clic para copiar",
-			"english": "Click to copy",
-			"mandarin": "点击复制",
-			"german": "Klicken Sie zum Kopieren",
-			"japanese": "クリックしてコピー"
-		},
-		"export-onkey-2fa-recommend": {
-			"english": "We strongly recommend you to enable 2FA on your account"
-		},
-		"export-onkey-2fa-enable": {
-			"english": "Enable 2FA"
-		}
-	}
+  "account": {
+    "auth-factors-threshold-factor": {
+      "korean": "{0} 인증 요소",
+      "spanish": "{0} Factor de autenticación",
+      "english": "{0} Authentication factor",
+      "mandarin": "{0}认证因素",
+      "german": "{0} Authentifizierungsfaktor",
+      "japanese": "{0}認証要素",
+      "portuguese": "{0} Fator de autenticação"
+    },
+    "auth-factors-threshold-desc": {
+      "korean": "계정에 액세스하기 위해 인증 할 요소의 수입니다.",
+      "spanish": "La cantidad de factores que se deben autenticar para acceder a su cuenta.",
+      "english": "The number of factors to authenticate in order to access your account.",
+      "mandarin": "要访问您的帐户进行身份验证的因素数量。",
+      "german": "Die Anzahl der Faktoren, die authentifiziert werden müssen, um auf Ihr Konto zuzugreifen.",
+      "japanese": "アカウントにアクセスするために認証する要素の数。",
+      "portuguese": "O número de fatores a serem autenticados para acessar sua conta."
+    },
+    "auth-factors-email-enter": {
+      "korean": "복구 이메일 입력",
+      "spanish": "Ingresa el correo de recuperación",
+      "english": "Enter recovery email",
+      "mandarin": "输入辅助邮箱",
+      "german": "Geben Sie die Wiederherstellungs-E-Mail ein",
+      "japanese": "復旧メールを入力してください",
+      "portuguese": "Digite o e-mail de recuperação"
+    },
+    "export-onkey-2fa": {
+      "english": "Two-factor authentication",
+      "portuguese": "Autenticação de dois fatores"
+    },
+    "auth-factors-enable-biometrics": {
+      "korean": "생체 인식 등록",
+      "spanish": "Habilitar la biometría",
+      "english": "Enable biometrics",
+      "mandarin": "生物识别注册",
+      "german": "Biometrie aktivieren",
+      "japanese": "登録されたバイオメトリクス",
+      "portuguese": "Ativar biometria"
+    },
+    "auth-factors-device-current": {
+      "korean": "흐름",
+      "spanish": "Actual",
+      "english": "Current",
+      "mandarin": "当前的",
+      "german": "Strom",
+      "japanese": "電流",
+      "portuguese": "Atual"
+    },
+    "mpc-export-share-note": {
+      "korean": "참고: 이 복구 요소는 계정을 인증하는 데 필요한 요소 중 하나입니다. 향후 계정 복구의 일환으로 안전한 곳에 보관하십시오.",
+      "spanish": "Nota: este factor de recuperación es uno de los factores necesarios para autenticar su cuenta. Manténgalo en un lugar seguro como parte de la recuperación de su cuenta en el futuro.",
+      "english": "Note: This recovery factor is 1 of the factors needed to authenticate your account. Keep it somewhere safe as a part of your account recovery in the future.",
+      "mandarin": "注意：此恢复因素是验证您的帐户所需的因素之一。将其保存在安全的地方，作为您未来帐户恢复的一部分。",
+      "german": "Hinweis: Dieser Wiederherstellungsfaktor ist einer der Faktoren, die zur Authentifizierung Ihres Kontos erforderlich sind. Bewahren Sie es im Rahmen Ihrer zukünftigen Kontowiederherstellung an einem sicheren Ort auf.",
+      "japanese": "注: この回復要素は、アカウントの認証に必要な要素の 1 つです。将来のアカウント復旧の一環として、安全な場所に保管してください。",
+      "portuguese": "Observação: esse fator de recuperação é um dos fatores necessários para autenticar sua conta. Guarde-o em algum lugar seguro como parte da recuperação de sua conta no futuro."
+    },
+    "delete-share-desc-1": {
+      "english": "Be very sure as",
+      "portuguese": "Tenha muita certeza como"
+    },
+    "auth-factors-password-set": {
+      "korean": "비밀번호를 설정하세요",
+      "spanish": "Establece tu contraseña",
+      "english": "Set your password",
+      "mandarin": "设置你的密码",
+      "german": "Lege ein Passwort fest",
+      "japanese": "パスワードを作る",
+      "portuguese": "Coloque sua senha"
+    },
+    "title": {
+      "korean": "계정",
+      "spanish": "Cuenta",
+      "english": "Account",
+      "mandarin": "帐户",
+      "german": "Konto",
+      "japanese": "アカウント",
+      "portuguese": "Conta"
+    },
+    "auth-factors-title": {
+      "korean": "보안 설정",
+      "spanish": "Configuraciones de seguridad",
+      "english": "Security Settings",
+      "mandarin": "安全设定",
+      "german": "Sicherheitseinstellungen",
+      "japanese": "セキュリティ設定",
+      "portuguese": "Configurações de segurança"
+    },
+    "remove-share-button": {
+      "english": "Remove share",
+      "portuguese": "Remover compartilhamento"
+    },
+    "social-factor-change": {
+      "korean": "사회적 요인을 변경하십시오",
+      "spanish": "Cambiar el factor social",
+      "english": "Change Social Factor",
+      "mandarin": "改变社会因素",
+      "german": "Ändern Sie den sozialen Faktor",
+      "japanese": "社会的要因を変えます",
+      "portuguese": "Alterar Fator Social"
+    },
+    "auth-factors-password-change": {
+      "korean": "비밀번호 변경",
+      "spanish": "Cambia la contraseña",
+      "english": "Change Password",
+      "mandarin": "更改密码",
+      "german": "Passwort ändern",
+      "japanese": "パスワードを変更する",
+      "portuguese": "Mudar senha"
+    },
+    "auth-factors-recovery-phrase": {
+      "korean": "복구 문구",
+      "spanish": "Frase de recuperación",
+      "english": "Recovery phrase",
+      "mandarin": "恢复短语",
+      "german": "Wiederherstellungsphrase",
+      "japanese": "回復フレーズ",
+      "portuguese": "Frase de recuperação"
+    },
+    "auth-factors-network": {
+      "korean": "Torus 노드를 통한 소셜 로그인",
+      "spanish": "Inicios de sesión sociales a través de nodos Torus",
+      "english": "Social logins via Torus nodes",
+      "mandarin": "通过Torus节点进行社交登录",
+      "german": "Soziale Anmeldungen über Torus-Knoten",
+      "japanese": "Torusノードを介したソーシャルログイン",
+      "portuguese": "Logins sociais via Torus nodes"
+    },
+    "export-share-note": {
+      "korean": "참고: 이 복구 문구는 계정을 인증하는 데 필요한 요소 중 하나입니다. 향후 계정 복구의 일환으로 안전한 곳에 보관하십시오.",
+      "spanish": "Nota: Esta frase de recuperación es uno de los factores necesarios para autenticar su cuenta. Guárdelo en un lugar seguro como parte de la recuperación de su cuenta en el futuro.",
+      "english": "Note: This recovery phrase is 1 of the factors needed to authenticate your account. Keep it somewhere safe as a part of your account recovery in the future.",
+      "mandarin": "注意：此恢复短语是验证您的帐户所需的因素之一。 将其保存在安全的地方，作为将来恢复帐户的一部分。",
+      "german": "Hinweis: Dieser Wiederherstellungssatz ist einer der Faktoren, die zur Authentifizierung Ihres Kontos erforderlich sind. Bewahren Sie es für die zukünftige Kontowiederherstellung an einem sicheren Ort auf.",
+      "japanese": "注：この回復フレーズは、アカウントの認証に必要な要素の1つです。 将来のアカウント復旧の一環として、安全な場所に保管してください。",
+      "portuguese": "Observação: esta frase de recuperação é um dos fatores necessários para autenticar sua conta. Guarde-o em algum lugar seguro como parte da recuperação de sua conta no futuro."
+    },
+    "auth-factors-email": {
+      "korean": "복구 이메일",
+      "spanish": "Correo electrónico de recuperación",
+      "english": "Recovery email",
+      "mandarin": "辅助邮箱",
+      "german": "Wiederherstellungs-E-Mail",
+      "japanese": "回復メール",
+      "portuguese": "Email de recuperação"
+    },
+    "auth-factors-email-resend": {
+      "korean": "재전송",
+      "spanish": "Reenviar",
+      "english": "Resend",
+      "mandarin": "重发",
+      "german": "Erneut senden",
+      "japanese": "再送",
+      "portuguese": "Reenviar"
+    },
+    "auth-factors-downloaded-on": {
+      "korean": "{0}에 다운로드됨",
+      "spanish": "Descargado el {0}",
+      "english": "Downloaded on {0}",
+      "mandarin": "于 {0} 下载",
+      "german": "Heruntergeladen am {0}",
+      "japanese": "{0}にダウンロード",
+      "portuguese": "Baixado em {0}"
+    },
+    "auth-factors-password": {
+      "korean": "계정 비밀번호",
+      "spanish": "Contraseña de la cuenta",
+      "english": "Account password",
+      "mandarin": "户口密码",
+      "german": "Konto Passwort",
+      "japanese": "アカウントパスワード",
+      "portuguese": "Senha da conta"
+    },
+    "auth-factors-device-empty": {
+      "korean": "장치 공유가 없습니다.",
+      "spanish": "No se encontraron recursos compartidos de dispositivos",
+      "english": "No device shares found",
+      "mandarin": "未找到设备共享",
+      "german": "Keine Gerätefreigaben gefunden",
+      "japanese": "デバイス共有が見つかりません",
+      "portuguese": "Nenhum compartilhamento de dispositivo encontrado"
+    },
+    "delete-share-desc-2": {
+      "english": "this action is permanent and cannot be undone.",
+      "portuguese": "esta ação é permanente e não pode ser desfeita."
+    },
+    "auth-factors-device-biometrics": {
+      "korean": "생체 인식 활성화",
+      "spanish": "biometría registrada",
+      "english": "biometrics registered",
+      "mandarin": "启用生物识别",
+      "german": "Biometrie registriert",
+      "japanese": "生体認証が有効",
+      "portuguese": "biometria cadastrada"
+    },
+    "export-share-desc": {
+      "korean": "백업 문구 사본 저장",
+      "spanish": "Guarde una copia de su frase de respaldo",
+      "english": "Save a copy of your backup phrase",
+      "mandarin": "保存备份短语的副本",
+      "german": "Speichern Sie eine Kopie Ihrer Sicherungsphrase",
+      "japanese": "バックアップフレーズのコピーを保存します",
+      "portuguese": "Salve uma cópia da sua frase de backup"
+    },
+    "auth-factors-email-sent": {
+      "korean": "보냄",
+      "spanish": "Enviado",
+      "english": "Sent",
+      "mandarin": "发送",
+      "german": "Geschickt",
+      "japanese": "送信済み",
+      "portuguese": "Enviado"
+    },
+    "export-onkey-note": {
+      "korean": "2FA를 활성화하여 계정 보안 강화",
+      "spanish": "Aumente la seguridad de su cuenta habilitando 2FA",
+      "english": "Increase your account security by enabling 2FA",
+      "mandarin": "通过启用 2FA 提高您的帐户安全性",
+      "german": "Erhöhen Sie die Sicherheit Ihres Kontos, indem Sie 2FA aktivieren",
+      "japanese": "2FAを有効にして、アカウントのセキュリティを強化します",
+      "portuguese": "Aumente a segurança da sua conta ativando o 2FA"
+    },
+    "auth-factors-device-title": {
+      "korean": "장치",
+      "spanish": "Dispositivos",
+      "english": "Device(s)",
+      "mandarin": "设备",
+      "german": "Geräte",
+      "japanese": "デバイス",
+      "portuguese": "Dispositivo(s)"
+    },
+    "auth-factors-threshold": {
+      "korean": "보안 요소",
+      "spanish": "Factores de seguridad",
+      "english": "Security Factors",
+      "mandarin": "安全因素",
+      "german": "Sicherheitsfaktoren",
+      "japanese": "セキュリティ要因",
+      "portuguese": "Fatores de segurança"
+    },
+    "auth-factors-device-desc": {
+      "korean": "이러한 장치는 귀하의 계정에 액세스 할 수있는 고유 한 요소입니다.",
+      "spanish": "Estos dispositivos son factores únicos autorizados para acceder a su cuenta.",
+      "english": "These devices are unique factors authorized to access your account.",
+      "mandarin": "这些设备是被授权访问您的帐户的独特因素。",
+      "german": "Diese Geräte sind einzigartige Faktoren, die für den Zugriff auf Ihr Konto berechtigt sind.",
+      "japanese": "これらのデバイスは、アカウントへのアクセスを許可された固有の要素です。",
+      "portuguese": "Esses dispositivos são fatores exclusivos autorizados a acessar sua conta."
+    },
+    "export-onkey-setup": {
+      "korean": "설정",
+      "spanish": "Prepararlo",
+      "english": "Set it up",
+      "mandarin": "设置它",
+      "german": "Es einrichten",
+      "japanese": "準備する",
+      "portuguese": "Configurá-lo"
+    },
+    "export-onkey-not-setup": {
+      "korean": "아직 설정되지 않음",
+      "spanish": "Aún no configurado",
+      "english": "Not setup yet",
+      "mandarin": "尚未设置",
+      "german": "Noch nicht eingerichtet",
+      "japanese": "まだセットアップされていません",
+      "portuguese": "Ainda não configurado"
+    },
+    "export-share-title": {
+      "korean": "백업 문구",
+      "spanish": "Frase de respaldo",
+      "english": "Backup phrase",
+      "mandarin": "备用词组",
+      "german": "Sicherungssatz",
+      "japanese": "バックアップフレーズ",
+      "portuguese": "Frase de backup"
+    },
+    "auth-factors-email-sent-to": {
+      "korean": "{0}에게 보냄",
+      "spanish": "Enviado a {0}",
+      "english": "Sent to {0}",
+      "mandarin": "发送到{0}",
+      "german": "Gesendet an {0}",
+      "japanese": "{0}に送信",
+      "portuguese": "Enviado para {0}"
+    },
+    "auth-factors-password-confirm": {
+      "korean": "비밀번호 재 입력",
+      "spanish": "reingresa tu contraseña",
+      "english": "Re-enter your password",
+      "mandarin": "重新输入密码",
+      "german": "Wiederhole die Eingabe deines Passwortes",
+      "japanese": "パスワードを再入力してください",
+      "portuguese": "Redigite sua senha"
+    },
+    "desc": {
+      "korean": "여기에서 OpenLogin 설정을 관리하세요.",
+      "spanish": "Administre su configuración de OpenLogin aquí",
+      "english": "Manage your OpenLogin settings here",
+      "mandarin": "在此处管理您的OpenLogin设置",
+      "german": "Verwalten Sie hier Ihre OpenLogin-Einstellungen",
+      "japanese": "ここでOpenLogin設定を管理します",
+      "portuguese": "Gerencie suas configurações do OpenLogin aqui"
+    },
+    "auth-factors-subtitle": {
+      "korean": "인증 요인 목록",
+      "spanish": "Lista de factores de autenticación",
+      "english": "List of Authentication factors",
+      "mandarin": "认证因素清单",
+      "german": "Liste der Authentifizierungsfaktoren",
+      "japanese": "認証要素のリスト",
+      "portuguese": "Lista de fatores de autenticação"
+    },
+    "auth-factors-email-old": {
+      "korean": "복구 이메일 (기존)",
+      "spanish": "Correo electrónico de recuperación (existente)",
+      "english": "Recovery email (existing)",
+      "mandarin": "辅助邮箱（现有）",
+      "german": "Wiederherstellungs-E-Mail (vorhanden)",
+      "japanese": "復旧メール（既存）",
+      "portuguese": "E-mail de recuperação (existente)"
+    },
+    "mpc-auth-factors-recovery-phrase": {
+      "korean": "회복 계수",
+      "spanish": "Factor de recuperación",
+      "english": "Recovery factor",
+      "mandarin": "恢复系数",
+      "german": "Erholungsfaktor",
+      "japanese": "回収率",
+      "portuguese": "Fator de recuperação"
+    },
+    "delete-share-title": {
+      "english": "Delete authentication factor",
+      "portuguese": "Excluir fator de autenticação"
+    },
+    "export-share-copy": {
+      "korean": "복사하려면 클릭",
+      "spanish": "Haga clic para copiar",
+      "english": "Click to copy",
+      "mandarin": "点击复制",
+      "german": "Klicken Sie zum Kopieren",
+      "japanese": "クリックしてコピー",
+      "portuguese": "Clique para copiar"
+    },
+    "export-onkey-2fa-recommend": {
+      "english": "We strongly recommend you to enable 2FA on your account",
+      "portuguese": "Recomendamos vivamente que ative o 2FA na sua conta"
+    },
+    "export-onkey-2fa-enable": {
+      "english": "Enable 2FA",
+      "portuguese": "Ativar 2FA"
+    }
+  }
 }

--- a/Openlogin-locale/locales-wallet-apps.json
+++ b/Openlogin-locale/locales-wallet-apps.json
@@ -1,60 +1,67 @@
 {
-	"apps": {
-		"apps-current-device": {
-			"mandarin": "当前设备",
-			"spanish": "Dispositivo actual",
-			"english": "Current device",
-			"german": "Aktuelles Gerät",
-			"japanese": "現在のデバイス",
-			"korean": "현재 기기"
-		},
-		"export-private-key": {
-			"mandarin": "私钥",
-			"spanish": "Llave privada",
-			"english": "Private Key",
-			"german": "Privat Schlüssel",
-			"japanese": "秘密鍵",
-			"korean": "개인 키"
-		},
-		"apps-title": {
-			"mandarin": "授权申请",
-			"spanish": "Aplicaciones autorizadas",
-			"english": "Authorized applications",
-			"german": "Autorisierte Anträge",
-			"japanese": "許可されたアプリケーション",
-			"korean": "승인 된 애플리케이션"
-		},
-		"apps-subtitle": {
-			"mandarin": "应用清单",
-			"spanish": "Lista de aplicaciones",
-			"english": "List of Apps",
-			"german": "Liste der Apps",
-			"japanese": "アプリのリスト",
-			"korean": "앱 목록"
-		},
-		"title": {
-			"mandarin": "授权应用",
-			"spanish": "Aplicaciones autorizadas",
-			"english": "Authorized Apps",
-			"german": "Autorisierte Apps",
-			"japanese": "認定アプリ",
-			"korean": "승인 된 앱"
-		},
-		"desc": {
-			"mandarin": "在这里管理您的授权应用程序",
-			"spanish": "Gestione sus aplicaciones autorizadas aquí",
-			"english": "Manage your authorized applications here",
-			"german": "Verwalten Sie hier Ihre autorisierten Anwendungen",
-			"japanese": "ここで承認されたアプリケーションを管理します",
-			"korean": "여기에서 승인 된 애플리케이션 관리"
-		},
-		"apps-empty": {
-			"mandarin": "您尚未连接到任何应用程序。",
-			"spanish": "Aún no estás conectado a ninguna aplicación.",
-			"english": "You are not connected to any applications yet.",
-			"german": "Sie sind noch nicht mit Anwendungen verbunden.",
-			"japanese": "まだどのアプリケーションにも接続していません。",
-			"korean": "아직 애플리케이션에 연결되어 있지 않습니다."
-		}
-	}
+  "apps": {
+    "apps-current-device": {
+      "mandarin": "当前设备",
+      "spanish": "Dispositivo actual",
+      "english": "Current device",
+      "german": "Aktuelles Gerät",
+      "japanese": "現在のデバイス",
+      "korean": "현재 기기",
+      "portuguese": "Dispositivo atual"
+    },
+    "export-private-key": {
+      "mandarin": "私钥",
+      "spanish": "Llave privada",
+      "english": "Private Key",
+      "german": "Privat Schlüssel",
+      "japanese": "秘密鍵",
+      "korean": "개인 키",
+      "portuguese": "Chave privada"
+    },
+    "apps-title": {
+      "mandarin": "授权申请",
+      "spanish": "Aplicaciones autorizadas",
+      "english": "Authorized applications",
+      "german": "Autorisierte Anträge",
+      "japanese": "許可されたアプリケーション",
+      "korean": "승인 된 애플리케이션",
+      "portuguese": "Aplicativos autorizados"
+    },
+    "apps-subtitle": {
+      "mandarin": "应用清单",
+      "spanish": "Lista de aplicaciones",
+      "english": "List of Apps",
+      "german": "Liste der Apps",
+      "japanese": "アプリのリスト",
+      "korean": "앱 목록",
+      "portuguese": "Lista de aplicativos"
+    },
+    "title": {
+      "mandarin": "授权应用",
+      "spanish": "Aplicaciones autorizadas",
+      "english": "Authorized Apps",
+      "german": "Autorisierte Apps",
+      "japanese": "認定アプリ",
+      "korean": "승인 된 앱",
+      "portuguese": "Apps autorizados"
+    },
+    "desc": {
+      "mandarin": "在这里管理您的授权应用程序",
+      "spanish": "Gestione sus aplicaciones autorizadas aquí",
+      "english": "Manage your authorized applications here",
+      "german": "Verwalten Sie hier Ihre autorisierten Anwendungen",
+      "japanese": "ここで承認されたアプリケーションを管理します",
+      "korean": "여기에서 승인 된 애플리케이션 관리",
+      "portuguese": "Gerencie seus aplicativos autorizados aqui"
+    },
+    "apps-empty": {
+      "mandarin": "您尚未连接到任何应用程序。",
+      "spanish": "Aún no estás conectado a ninguna aplicación.",
+      "english": "You are not connected to any applications yet.",
+      "german": "Sie sind noch nicht mit Anwendungen verbunden.",
+      "japanese": "まだどのアプリケーションにも接続していません。",
+      "korean": "아직 애플리케이션에 연결되어 있지 않습니다.",
+      "portuguese": "Você ainda não está conectado a nenhum aplicativo."
+    }
+  }
 }

--- a/Openlogin-locale/locales-wallet-home.json
+++ b/Openlogin-locale/locales-wallet-home.json
@@ -1,116 +1,130 @@
 {
-	"home": {
-		"share-approval-desc1": {
-			"english": "A new login is trying to access your account.",
-			"japanese": "新しいログインがあなたのアカウントにアクセスしようとしています。",
-			"german": "Ein neuer Login versucht, auf Ihr Konto zuzugreifen.",
-			"korean": "새 로그인으로 계정에 액세스하려고합니다.",
-			"spanish": "Un nuevo inicio de sesión está intentando acceder a su cuenta.",
-			"mandarin": "新的登录名正在尝试登记入您的帐户。"
-		},
-		"share-approval-desc2": {
-			"english": "Match the Reference ID and confirm this is you:",
-			"japanese": "参照IDを一致させ、これがあなたであることを確認します。",
-			"german": "Passen Sie die Referenz-ID an und bestätigen Sie, dass Sie es sind:",
-			"korean": "참조 ID를 일치 하고 본인임을 확인합니다.",
-			"spanish": "Haga coincidir la ID de referencia y confirme que es usted:",
-			"mandarin": "匹配参考ID，并确认这是您："
-		},
-		"share-approval-report": {
-			"english": "report it",
-			"japanese": "それを報告する",
-			"german": "berichten Sie",
-			"korean": "보고서",
-			"spanish": "Informe",
-			"mandarin": "举报"
-		},
-		"link-apps-name": {
-			"english": "View Authorized Apps",
-			"japanese": "承認されたアプリを表示する",
-			"german": "Autorisierte Apps anzeigen",
-			"korean": "승인 된 앱보기",
-			"spanish": "Ver aplicaciones autorizadas",
-			"mandarin": "查看授权的应用"
-		},
-		"title": {
-			"english": "Welcome, {0}",
-			"japanese": "ようこそ、{0}",
-			"german": "Willkommen, {0}",
-			"korean": "{0} 님, 환영합니다",
-			"spanish": "Bienvenido, {0}",
-			"mandarin": "欢迎，{0}"
-		},
-		"learn-more-title": {
-			"english": "Getting started",
-			"japanese": "開始",
-			"german": "Einstieg",
-			"korean": "시작하기",
-			"spanish": "Empezando",
-			"mandarin": "开始"
-		},
-		"share-approval-support": {
-			"english": "Contact Support",
-			"japanese": "サポート問い合わせ先",
-			"german": "Kontaktieren Sie Support",
-			"korean": "연락처 지원",
-			"spanish": "Soporte de contacto",
-			"mandarin": "联系支持人员"
-		},
-		"link-apps-type": {
-			"english": "apps",
-			"japanese": "アプリ",
-			"german": "apps",
-			"korean": "앱",
-			"spanish": "aplicaciones",
-			"mandarin": "应用"
-		},
-		"share-approval-secure": {
-			"english": "Secure Torus sign in",
-			"japanese": "セキュアトーラスサインイン",
-			"german": "Sichere Torus-Anmeldung",
-			"korean": "보안 토러스 로그인",
-			"spanish": "Iniciar sesión Secure Torus",
-			"mandarin": "安全Torus登录"
-		},
-		"share-approval-title": {
-			"english": "New login detected",
-			"japanese": "新しいログインが検出されました",
-			"german": "Neues Login erkannt",
-			"korean": "새 로그인 감지",
-			"spanish": "Nuevo inicio de sesión detectado",
-			"mandarin": "检测到新登录"
-		},
-		"link-account-type": {
-			"english": "account",
-			"japanese": "アカウント",
-			"german": "konto",
-			"korean": "계정",
-			"spanish": "cuenta",
-			"mandarin": "帐户"
-		},
-		"link-account-name": {
-			"english": "Manage account",
-			"japanese": "アカウントを管理する",
-			"german": "Konto verwalten",
-			"korean": "계정 관리",
-			"spanish": "Administrar cuenta",
-			"mandarin": "管理帐户"
-		},
-		"learn-more-desc": {
-			"english": "Take charge of your digital presence with OpenLogin.",
-			"japanese": "OpenLoginでデジタルプレゼンスを管理します。",
-			"german": "Übernehmen Sie mit OpenLogin die Kontrolle über Ihre digitale Präsenz.",
-			"korean": "OpenLogin으로 디지털 존재를 관리하십시오.",
-			"spanish": "Hágase cargo de su presencia digital con OpenLogin.",
-			"mandarin": "使用OpenLogin来管理您的数字业务。"
-		},
-		"share-approval-not-me": {
-			"english": "This is not me,",
-			"japanese": "これは私ではない、",
-			"german": "Das bin nicht ich,",
-			"korean": "이건 내가 아니다",
-			"spanish": "Este no soy yo,",
-			"mandarin": "这不是我，"
-		}
-	}
+  "home": {
+    "share-approval-desc1": {
+      "english": "A new login is trying to access your account.",
+      "japanese": "新しいログインがあなたのアカウントにアクセスしようとしています。",
+      "german": "Ein neuer Login versucht, auf Ihr Konto zuzugreifen.",
+      "korean": "새 로그인으로 계정에 액세스하려고합니다.",
+      "spanish": "Un nuevo inicio de sesión está intentando acceder a su cuenta.",
+      "mandarin": "新的登录名正在尝试登记入您的帐户。",
+      "portuguese": "Um novo login está tentando acessar sua conta."
+    },
+    "share-approval-desc2": {
+      "english": "Match the Reference ID and confirm this is you:",
+      "japanese": "参照IDを一致させ、これがあなたであることを確認します。",
+      "german": "Passen Sie die Referenz-ID an und bestätigen Sie, dass Sie es sind:",
+      "korean": "참조 ID를 일치 하고 본인임을 확인합니다.",
+      "spanish": "Haga coincidir la ID de referencia y confirme que es usted:",
+      "mandarin": "匹配参考ID，并确认这是您：",
+      "portuguese": "Corresponda ao ID de referência e confirme que é você:"
+    },
+    "share-approval-report": {
+      "english": "report it",
+      "japanese": "それを報告する",
+      "german": "berichten Sie",
+      "korean": "보고서",
+      "spanish": "Informe",
+      "mandarin": "举报",
+      "portuguese": "denuncie"
+    },
+    "link-apps-name": {
+      "english": "View Authorized Apps",
+      "japanese": "承認されたアプリを表示する",
+      "german": "Autorisierte Apps anzeigen",
+      "korean": "승인 된 앱보기",
+      "spanish": "Ver aplicaciones autorizadas",
+      "mandarin": "查看授权的应用",
+      "portuguese": "Ver aplicativos autorizados"
+    },
+    "title": {
+      "english": "Welcome, {0}",
+      "japanese": "ようこそ、{0}",
+      "german": "Willkommen, {0}",
+      "korean": "{0} 님, 환영합니다",
+      "spanish": "Bienvenido, {0}",
+      "mandarin": "欢迎，{0}",
+      "portuguese": "Bem-vindo, {0}"
+    },
+    "learn-more-title": {
+      "english": "Getting started",
+      "japanese": "開始",
+      "german": "Einstieg",
+      "korean": "시작하기",
+      "spanish": "Empezando",
+      "mandarin": "开始",
+      "portuguese": "Começando"
+    },
+    "share-approval-support": {
+      "english": "Contact Support",
+      "japanese": "サポート問い合わせ先",
+      "german": "Kontaktieren Sie Support",
+      "korean": "연락처 지원",
+      "spanish": "Soporte de contacto",
+      "mandarin": "联系支持人员",
+      "portuguese": "Entre em contato com o suporte"
+    },
+    "link-apps-type": {
+      "english": "apps",
+      "japanese": "アプリ",
+      "german": "apps",
+      "korean": "앱",
+      "spanish": "aplicaciones",
+      "mandarin": "应用",
+      "portuguese": "aplicativos"
+    },
+    "share-approval-secure": {
+      "english": "Secure Torus sign in",
+      "japanese": "セキュアトーラスサインイン",
+      "german": "Sichere Torus-Anmeldung",
+      "korean": "보안 토러스 로그인",
+      "spanish": "Iniciar sesión Secure Torus",
+      "mandarin": "安全Torus登录",
+      "portuguese": "Login seguro da Torus"
+    },
+    "share-approval-title": {
+      "english": "New login detected",
+      "japanese": "新しいログインが検出されました",
+      "german": "Neues Login erkannt",
+      "korean": "새 로그인 감지",
+      "spanish": "Nuevo inicio de sesión detectado",
+      "mandarin": "检测到新登录",
+      "portuguese": "Novo login detectado"
+    },
+    "link-account-type": {
+      "english": "account",
+      "japanese": "アカウント",
+      "german": "konto",
+      "korean": "계정",
+      "spanish": "cuenta",
+      "mandarin": "帐户",
+      "portuguese": "conta"
+    },
+    "link-account-name": {
+      "english": "Manage account",
+      "japanese": "アカウントを管理する",
+      "german": "Konto verwalten",
+      "korean": "계정 관리",
+      "spanish": "Administrar cuenta",
+      "mandarin": "管理帐户",
+      "portuguese": "Gerenciar conta"
+    },
+    "learn-more-desc": {
+      "english": "Take charge of your digital presence with OpenLogin.",
+      "japanese": "OpenLoginでデジタルプレゼンスを管理します。",
+      "german": "Übernehmen Sie mit OpenLogin die Kontrolle über Ihre digitale Präsenz.",
+      "korean": "OpenLogin으로 디지털 존재를 관리하십시오.",
+      "spanish": "Hágase cargo de su presencia digital con OpenLogin.",
+      "mandarin": "使用OpenLogin来管理您的数字业务。",
+      "portuguese": "Assuma o controle de sua presença digital com OpenLogin."
+    },
+    "share-approval-not-me": {
+      "english": "This is not me,",
+      "japanese": "これは私ではない、",
+      "german": "Das bin nicht ich,",
+      "korean": "이건 내가 아니다",
+      "spanish": "Este no soy yo,",
+      "mandarin": "这不是我，",
+      "portuguese": "Este não sou eu,"
+    }
+  }
 }

--- a/Openlogin-locale/locales-webauthn.json
+++ b/Openlogin-locale/locales-webauthn.json
@@ -1,172 +1,193 @@
 {
-	"webauthn": {
-		"webauthn-not-supported": {
-			"mandarin": "此设备不支持 Webauthn",
-			"german": "Webauthn wird auf diesem Gerät nicht unterstützt",
-			"japanese": "このデバイスではWeb認証はサポートされていません",
-			"korean": "Webauthn은 이 기기에서 지원되지 않습니다.",
-			"spanish": "Webauthn no es compatible con este dispositivo",
-			"english": "Webauthn is not supported on this device"
-		},
-		"action-sign-in": {
-			"mandarin": "登入",
-			"german": "Einloggen",
-			"japanese": "ログイン",
-			"korean": "로그인",
-			"spanish": "Registrarse",
-			"english": "Sign In"
-		},
-		"improve-experience": {
-			"mandarin": "改善您的体验",
-			"german": "Verbessern Sie Ihre Erfahrung",
-			"japanese": "あなたの経験を向上させる",
-			"korean": "경험 향상",
-			"spanish": "Mejora tu experiencia",
-			"english": "Improve your experience"
-		},
-		"something-wrong-note": {
-			"mandarin": "出问题了",
-			"german": "Etwas ist schief gelaufen",
-			"japanese": "何かがうまくいかなかった",
-			"korean": "문제가 발생했습니다.",
-			"spanish": "Algo salió mal",
-			"english": "Something went wrong"
-		},
-		"status-registered": {
-			"mandarin": "设备注册",
-			"german": "Gerät registriert",
-			"japanese": "登録済みのデバイス",
-			"korean": "등록된 기기",
-			"spanish": "Dispositivo registrado",
-			"english": "Device registered"
-		},
-		"browser-not-supported-note": {
-			"mandarin": "您正在使用我们不支持的浏览器。 尝试这些选项之一以获得在此应用程序上的更好体验。 如果您已经在使用以下列表中的浏览器，请更新到最新版本",
-			"german": "Sie verwenden einen von uns nicht unterstützten Browser. Probieren Sie eine dieser Optionen aus, um eine bessere Erfahrung mit dieser Anwendung zu erzielen. Wenn Sie bereits einen Browser aus der folgenden Liste verwenden, aktualisieren Sie bitte auf die neueste Version",
-			"japanese": "サポートされていないブラウザを使用しています。 これらのオプションのいずれかを試して、このアプリケーションのエクスペリエンスを向上させてください。 以下のリストのブラウザをすでに使用している場合は、最新バージョンに更新してください",
-			"korean": "지원하지 않는 브라우저를 사용하고 있습니다. 이 응용 프로그램에서 더 나은 경험을 얻으려면 다음 옵션 중 하나를 시도하십시오. 아래 목록의 브라우저를 이미 사용 중이라면 최신 버전으로 업데이트하십시오.",
-			"spanish": "Está utilizando un navegador que no admitimos. Pruebe una de estas opciones para tener una mejor experiencia en esta aplicación. Si ya está utilizando un navegador de la siguiente lista, actualice a la última versión",
-			"english": "You are using a browser we do not support. Try one of these options to have a better experience on this application. If you're already using a browser from the below list, Please update to the latest version"
-		},
-		"required-params-note": {
-			"mandarin": "缺少以下一项或多项必需参数",
-			"german": "Einer oder mehrere der folgenden erforderlichen Parameter fehlen",
-			"japanese": "次の必須パラメーターの1つ以上が欠落しています",
-			"korean": "다음 필수 매개변수 중 하나 이상이 누락되었습니다.",
-			"spanish": "Falta uno o más de los siguientes parámetros obligatorios",
-			"english": "One or more of the following required parameters is missing"
-		},
-		"status-loading": {
-			"mandarin": "加载中",
-			"german": "Wird geladen",
-			"japanese": "読み込み中",
-			"korean": "로딩 중",
-			"spanish": "Cargando",
-			"english": "Loading"
-		},
-		"operation-timeout": {
-			"mandarin": "操作超时或不允许",
-			"german": "Der Vorgang ist entweder abgelaufen oder nicht zulässig",
-			"japanese": "操作がタイムアウトしたか、許可されなかった",
-			"korean": "작업 시간이 초과되었거나 허용되지 않았습니다.",
-			"spanish": "La operación agotó el tiempo de espera o no se permitió",
-			"english": "The operation either timed out or was not allowed"
-		},
-		"action-yes": {
-			"mandarin": "是的",
-			"german": "Jawohl",
-			"japanese": "はい",
-			"korean": "예",
-			"spanish": "sí",
-			"english": "Yes"
-		},
-		"learn-more": {
-			"mandarin": "了解更多",
-			"german": "Mehr erfahren",
-			"japanese": "もっと詳しく知る",
-			"korean": "더 알아보기",
-			"spanish": "Aprende más",
-			"english": "Learn more"
-		},
-		"action-cancel": {
-			"mandarin": "取消",
-			"german": "Stornieren",
-			"japanese": "キャンセル",
-			"korean": "취소",
-			"spanish": "Cancelar",
-			"english": "Cancel"
-		},
-		"browser-not-supported": {
-			"mandarin": "浏览器不支持",
-			"german": "Browser nicht unterstützt",
-			"japanese": "ブラウザはサポートされていません",
-			"korean": "지원되지 않는 브라우저",
-			"spanish": "Navegador no compatible",
-			"english": "Browser not supported"
-		},
-		"action-no": {
-			"mandarin": "不",
-			"german": "Nein",
-			"japanese": "番号",
-			"korean": "아니요",
-			"spanish": "No",
-			"english": "No"
-		},
-		"registering-device": {
-			"mandarin": "注册您的设备",
-			"german": "Registrieren Ihres Geräts",
-			"japanese": "デバイスの登録",
-			"korean": "장치 등록",
-			"spanish": "Registro de su dispositivo",
-			"english": "Registering your device"
-		},
-		"sign-in": {
-			"mandarin": "通过 Touch ID / Face ID 登录？",
-			"german": "Über Touch ID / Face ID anmelden?",
-			"japanese": "Touch ID / Face IDでサインインしますか？",
-			"korean": "Touch ID/Face ID로 로그인하시겠습니까?",
-			"spanish": "¿Iniciar sesión a través de Touch ID / Face ID?",
-			"english": "Sign in via Touch ID / Face ID?"
-		},
-		"missing-params": {
-			"mandarin": "缺少参数",
-			"german": "Fehlende Parameter",
-			"japanese": "欠落しているパラメータ",
-			"korean": "누락된 매개변수",
-			"spanish": "Parámetros faltantes",
-			"english": "Missing params"
-		},
-		"user-denied": {
-			"mandarin": "用户已拒绝授权",
-			"german": "Benutzer hat die Autorisierung verweigert",
-			"japanese": "ユーザーが承認を拒否しました",
-			"korean": "사용자가 승인을 거부했습니다.",
-			"spanish": "El usuario ha denegado la autorización",
-			"english": "User has denied authorization"
-		},
-		"invalid-url": {
-			"mandarin": "重定向 URI 无效",
-			"german": "Ungültiger Weiterleitungs-URI",
-			"japanese": "リダイレクトURIが無効です",
-			"korean": "잘못된 리디렉션 URI",
-			"spanish": "URI de redireccionamiento no válido",
-			"english": "Invalid redirect URI"
-		},
-		"status-done": {
-			"mandarin": "完毕",
-			"german": "Erledigt",
-			"japanese": "終わり",
-			"korean": "완료",
-			"spanish": "Hecho",
-			"english": "Done"
-		},
-		"register-device": {
-			"mandarin": "您要注册此设备吗？",
-			"german": "Möchten Sie dieses Gerät registrieren?",
-			"japanese": "このデバイスを登録しますか？",
-			"korean": "이 장치를 등록하시겠습니까?",
-			"spanish": "¿Le gustaría registrar este dispositivo?",
-			"english": "Would you like to register this device?"
-		}
-	}
+  "webauthn": {
+    "webauthn-not-supported": {
+      "mandarin": "此设备不支持 Webauthn",
+      "german": "Webauthn wird auf diesem Gerät nicht unterstützt",
+      "japanese": "このデバイスではWeb認証はサポートされていません",
+      "korean": "Webauthn은 이 기기에서 지원되지 않습니다.",
+      "spanish": "Webauthn no es compatible con este dispositivo",
+      "english": "Webauthn is not supported on this device",
+      "portuguese": "Webauthn não é compatível com este dispositivo"
+    },
+    "action-sign-in": {
+      "mandarin": "登入",
+      "german": "Einloggen",
+      "japanese": "ログイン",
+      "korean": "로그인",
+      "spanish": "Registrarse",
+      "english": "Sign In",
+      "portuguese": "Entrar"
+    },
+    "improve-experience": {
+      "mandarin": "改善您的体验",
+      "german": "Verbessern Sie Ihre Erfahrung",
+      "japanese": "あなたの経験を向上させる",
+      "korean": "경험 향상",
+      "spanish": "Mejora tu experiencia",
+      "english": "Improve your experience",
+      "portuguese": "Melhore sua experiência"
+    },
+    "something-wrong-note": {
+      "mandarin": "出问题了",
+      "german": "Etwas ist schief gelaufen",
+      "japanese": "何かがうまくいかなかった",
+      "korean": "문제가 발생했습니다.",
+      "spanish": "Algo salió mal",
+      "english": "Something went wrong",
+      "portuguese": "Algo deu errado"
+    },
+    "status-registered": {
+      "mandarin": "设备注册",
+      "german": "Gerät registriert",
+      "japanese": "登録済みのデバイス",
+      "korean": "등록된 기기",
+      "spanish": "Dispositivo registrado",
+      "english": "Device registered",
+      "portuguese": "Dispositivo registrado"
+    },
+    "browser-not-supported-note": {
+      "mandarin": "您正在使用我们不支持的浏览器。 尝试这些选项之一以获得在此应用程序上的更好体验。 如果您已经在使用以下列表中的浏览器，请更新到最新版本",
+      "german": "Sie verwenden einen von uns nicht unterstützten Browser. Probieren Sie eine dieser Optionen aus, um eine bessere Erfahrung mit dieser Anwendung zu erzielen. Wenn Sie bereits einen Browser aus der folgenden Liste verwenden, aktualisieren Sie bitte auf die neueste Version",
+      "japanese": "サポートされていないブラウザを使用しています。 これらのオプションのいずれかを試して、このアプリケーションのエクスペリエンスを向上させてください。 以下のリストのブラウザをすでに使用している場合は、最新バージョンに更新してください",
+      "korean": "지원하지 않는 브라우저를 사용하고 있습니다. 이 응용 프로그램에서 더 나은 경험을 얻으려면 다음 옵션 중 하나를 시도하십시오. 아래 목록의 브라우저를 이미 사용 중이라면 최신 버전으로 업데이트하십시오.",
+      "spanish": "Está utilizando un navegador que no admitimos. Pruebe una de estas opciones para tener una mejor experiencia en esta aplicación. Si ya está utilizando un navegador de la siguiente lista, actualice a la última versión",
+      "english": "You are using a browser we do not support. Try one of these options to have a better experience on this application. If you're already using a browser from the below list, Please update to the latest version",
+      "portuguese": "Você está usando um navegador que não suportamos. Experimente uma dessas opções para ter uma melhor experiência neste aplicativo. Se você já estiver usando um navegador da lista abaixo, atualize para a versão mais recente"
+    },
+    "required-params-note": {
+      "mandarin": "缺少以下一项或多项必需参数",
+      "german": "Einer oder mehrere der folgenden erforderlichen Parameter fehlen",
+      "japanese": "次の必須パラメーターの1つ以上が欠落しています",
+      "korean": "다음 필수 매개변수 중 하나 이상이 누락되었습니다.",
+      "spanish": "Falta uno o más de los siguientes parámetros obligatorios",
+      "english": "One or more of the following required parameters is missing",
+      "portuguese": "Um ou mais dos seguintes parâmetros obrigatórios estão ausentes"
+    },
+    "status-loading": {
+      "mandarin": "加载中",
+      "german": "Wird geladen",
+      "japanese": "読み込み中",
+      "korean": "로딩 중",
+      "spanish": "Cargando",
+      "english": "Loading",
+      "portuguese": "Carregando"
+    },
+    "operation-timeout": {
+      "mandarin": "操作超时或不允许",
+      "german": "Der Vorgang ist entweder abgelaufen oder nicht zulässig",
+      "japanese": "操作がタイムアウトしたか、許可されなかった",
+      "korean": "작업 시간이 초과되었거나 허용되지 않았습니다.",
+      "spanish": "La operación agotó el tiempo de espera o no se permitió",
+      "english": "The operation either timed out or was not allowed",
+      "portuguese": "A operação expirou ou não foi permitida"
+    },
+    "action-yes": {
+      "mandarin": "是的",
+      "german": "Jawohl",
+      "japanese": "はい",
+      "korean": "예",
+      "spanish": "sí",
+      "english": "Yes",
+      "portuguese": "Sim"
+    },
+    "learn-more": {
+      "mandarin": "了解更多",
+      "german": "Mehr erfahren",
+      "japanese": "もっと詳しく知る",
+      "korean": "더 알아보기",
+      "spanish": "Aprende más",
+      "english": "Learn more",
+      "portuguese": "Saber mais"
+    },
+    "action-cancel": {
+      "mandarin": "取消",
+      "german": "Stornieren",
+      "japanese": "キャンセル",
+      "korean": "취소",
+      "spanish": "Cancelar",
+      "english": "Cancel",
+      "portuguese": "Cancelar"
+    },
+    "browser-not-supported": {
+      "mandarin": "浏览器不支持",
+      "german": "Browser nicht unterstützt",
+      "japanese": "ブラウザはサポートされていません",
+      "korean": "지원되지 않는 브라우저",
+      "spanish": "Navegador no compatible",
+      "english": "Browser not supported",
+      "portuguese": "Navegador não suportado"
+    },
+    "action-no": {
+      "mandarin": "不",
+      "german": "Nein",
+      "japanese": "番号",
+      "korean": "아니요",
+      "spanish": "No",
+      "english": "No",
+      "portuguese": "Não"
+    },
+    "registering-device": {
+      "mandarin": "注册您的设备",
+      "german": "Registrieren Ihres Geräts",
+      "japanese": "デバイスの登録",
+      "korean": "장치 등록",
+      "spanish": "Registro de su dispositivo",
+      "english": "Registering your device",
+      "portuguese": "Registrando seu dispositivo"
+    },
+    "sign-in": {
+      "mandarin": "通过 Touch ID / Face ID 登录？",
+      "german": "Über Touch ID / Face ID anmelden?",
+      "japanese": "Touch ID / Face IDでサインインしますか？",
+      "korean": "Touch ID/Face ID로 로그인하시겠습니까?",
+      "spanish": "¿Iniciar sesión a través de Touch ID / Face ID?",
+      "english": "Sign in via Touch ID / Face ID?",
+      "portuguese": "Entrar via Touch ID / Face ID?"
+    },
+    "missing-params": {
+      "mandarin": "缺少参数",
+      "german": "Fehlende Parameter",
+      "japanese": "欠落しているパラメータ",
+      "korean": "누락된 매개변수",
+      "spanish": "Parámetros faltantes",
+      "english": "Missing params",
+      "portuguese": "Parâmetros ausentes"
+    },
+    "user-denied": {
+      "mandarin": "用户已拒绝授权",
+      "german": "Benutzer hat die Autorisierung verweigert",
+      "japanese": "ユーザーが承認を拒否しました",
+      "korean": "사용자가 승인을 거부했습니다.",
+      "spanish": "El usuario ha denegado la autorización",
+      "english": "User has denied authorization",
+      "portuguese": "O usuário negou a autorização"
+    },
+    "invalid-url": {
+      "mandarin": "重定向 URI 无效",
+      "german": "Ungültiger Weiterleitungs-URI",
+      "japanese": "リダイレクトURIが無効です",
+      "korean": "잘못된 리디렉션 URI",
+      "spanish": "URI de redireccionamiento no válido",
+      "english": "Invalid redirect URI",
+      "portuguese": "URI de redirecionamento inválido"
+    },
+    "status-done": {
+      "mandarin": "完毕",
+      "german": "Erledigt",
+      "japanese": "終わり",
+      "korean": "완료",
+      "spanish": "Hecho",
+      "english": "Done",
+      "portuguese": "Feito"
+    },
+    "register-device": {
+      "mandarin": "您要注册此设备吗？",
+      "german": "Möchten Sie dieses Gerät registrieren?",
+      "japanese": "このデバイスを登録しますか？",
+      "korean": "이 장치를 등록하시겠습니까?",
+      "spanish": "¿Le gustaría registrar este dispositivo?",
+      "english": "Would you like to register this device?",
+      "portuguese": "Deseja registrar este dispositivo?"
+    }
+  }
 }

--- a/Web3Auth-locale/locale-common.json
+++ b/Web3Auth-locale/locale-common.json
@@ -7,7 +7,8 @@
 			"korean": "계속하려면 {{adapter}} 계정에서 인증하세요.",
 			"japanese": "続行するには、{{adapter}} アカウントで確認してください",
 			"spanish": "Verifica tu cuenta de {{adapter}} para continuar",
-			"french": "Vérifiez votre compte sur {{adapter}} pour continuer"
+			"french": "Vérifiez votre compte sur {{adapter}} pour continuer",
+			"portuguese": "Verifique a sua conta do {{adapter}} para continuar"
 		},
 		"external.title": {
 			"english": "External wallet",
@@ -16,7 +17,8 @@
 			"korean": "외부 지갑",
 			"japanese": "外部ウォレット",
 			"spanish": "Monedero externo",
-			"french": "Portefeuille externe"
+			"french": "Portefeuille externe",
+			"portuguese": "Carteira externa"
 		},
 		"social.view-less-new": {
 			"english": "View less",
@@ -25,7 +27,8 @@
 			"korean": "적게 보기",
 			"japanese": "表示を減らす",
 			"spanish": "ver menos",
-			"french": "Voir moins"
+			"french": "Voir moins",
+			"portuguese": "Ver menos"
 		},
 		"footer.message": {
 			"english": "Self-custodial login by",
@@ -34,7 +37,8 @@
 			"korean": "자가 관리 로그인",
 			"japanese": "による自己管理ログイン",
 			"spanish": "Inicio de sesión con autocustodia por",
-			"french": "Portefeuille hébergé par"
+			"french": "Portefeuille hébergé par",
+			"portuguese": "Início de sessão com autocustódia por"
 		},
 		"network.switch-request": {
 			"english": "This site is requesting to switch Network",
@@ -43,7 +47,8 @@
 			"korean": "이 사이트는 네트워크 전환을 요청하고 있습니다",
 			"japanese": "このサイトはネットワークの切り替えを要求しています",
 			"spanish": "Este sitio está solicitando cambiar de red",
-			"french": "Ce site vous demande de changer de réseau"
+			"french": "Ce site vous demande de changer de réseau",
+			"portuguese": "Este site está solicitando que troque a rede"
 		},
 		"footer.terms": {
 			"english": "Terms of use",
@@ -52,7 +57,8 @@
 			"korean": "이용약관",
 			"japanese": "利用規約",
 			"spanish": "Términos de Uso",
-			"french": "CGU"
+			"french": "CGU",
+			"portuguese": "Termos de uso"
 		},
 		"footer.message-new": {
 			"english": "Self-custodial login by Web3Auth",
@@ -61,7 +67,8 @@
 			"korean": "Web3Auth를 통한 자가 관리 로그인",
 			"japanese": "Web3Authによる自己管理ログイン",
 			"spanish": "Inicio de sesión con autocustodia por Web3Auth",
-			"french": "Connexion autonome par Web3Auth"
+			"french": "Connexion autonome par Web3Auth",
+			"portuguese": "Início de sessão com autocustódia por Web3Auth"
 		},
 		"network.to": {
 			"english": "To",
@@ -70,7 +77,8 @@
 			"korean": "에게",
 			"japanese": "に",
 			"spanish": "A",
-			"french": "A"
+			"french": "A",
+			"portuguese": "Para"
 		},
 		"external.walletconnect-subtitle": {
 			"english": "Scan QR code with a WalletConnect-compatible wallet",
@@ -79,7 +87,8 @@
 			"korean": "WalletConnect 호환 지갑으로 QR 코드 스캔",
 			"japanese": "WalletConnect対応ウォレットでQRコードをスキャン",
 			"spanish": "Escanea el código QR con una billetera compatible con WalletConnect",
-			"french": "Scannez le QR code avec un portefeuille compatible WalletConnect"
+			"french": "Scannez le QR code avec un portefeuille compatible WalletConnect",
+			"portuguese": "Escaneia o QR code com uma carteira compatível com WalletConnect"
 		},
 		"external.walletconnect-copy": {
 			"english": "Click on the QR Code to copy to clipboard",
@@ -88,7 +97,8 @@
 			"korean": "클립보드에 복사하려면 QR 코드를 클릭하세요.",
 			"japanese": "QRコードをクリックしてクリップボードにコピー",
 			"spanish": "Haga clic en el código QR para copiar al portapapeles",
-			"french": "Cliquez sur le code QR pour le copier dans le presse-papiers"
+			"french": "Cliquez sur le code QR pour le copier dans le presse-papiers",
+			"portuguese": "Clique aqui para copiar o código do QR Code"
 		},
 		"social.policy": {
 			"english": "We do not store any data related to your social logins.",
@@ -97,7 +107,8 @@
 			"korean": "우리는 귀하의 소셜 로그인과 관련된 데이터를 저장하지 않습니다.",
 			"japanese": "ソーシャル ログインに関連するデータは保存されません。",
 			"spanish": "No almacenamos ningún dato relacionado con sus inicios de sesión sociales.",
-			"french": "Nous ne stockons aucune donnée liée à vos connexions sociales."
+			"french": "Nous ne stockons aucune donnée liée à vos connexions sociales.",
+			"portuguese": "Não armazenamos nenhum dado relacionado ao seu login por rede social."
 		},
 		"external.walletconnect-connect": {
 			"english": "Connect",
@@ -106,7 +117,8 @@
 			"korean": "연결하다",
 			"japanese": "接続",
 			"spanish": "Conectar",
-			"french": "Se connecter"
+			"french": "Se connecter",
+			"portuguese": "Conectar"
 		},
 		"network.cancel": {
 			"english": "Cancel",
@@ -115,7 +127,8 @@
 			"korean": "취소",
 			"japanese": "キャンセル",
 			"spanish": "Cancelar",
-			"french": "Annuler"
+			"french": "Annuler",
+			"portuguese": "Cancelar"
 		},
 		"social.view-more-new": {
 			"english": "View more",
@@ -124,7 +137,8 @@
 			"korean": "더보기",
 			"japanese": "もっと見る",
 			"spanish": "Ver más",
-			"french": "Voir plus"
+			"french": "Voir plus",
+			"portuguese": "Ver mais"
 		},
 		"social.email": {
 			"english": "Email",
@@ -133,7 +147,8 @@
 			"korean": "이메일",
 			"japanese": "Eメール",
 			"spanish": "Correo electrónico",
-			"french": "Email"
+			"french": "Email",
+			"portuguese": "Email"
 		},
 		"external.connect": {
 			"english": "Connect with Wallet",
@@ -142,7 +157,8 @@
 			"korean": "지갑과 연결",
 			"japanese": "ウォレットと接続",
 			"spanish": "Conectar con Monedero",
-			"french": "Se connecter avec un portefeuille"
+			"french": "Se connecter avec un portefeuille",
+			"portuguese": "Conectar com carteira"
 		},
 		"network.proceed": {
 			"english": "Proceed",
@@ -151,7 +167,8 @@
 			"korean": "진행하다",
 			"japanese": "続行",
 			"spanish": "Proceder",
-			"french": "Procéder"
+			"french": "Procéder",
+			"portuguese": "Proceder"
 		},
 		"header-subtitle": {
 			"english": "Select one of the following to continue",
@@ -160,7 +177,8 @@
 			"korean": "계속하려면 다음 중 하나를 선택하세요.",
 			"japanese": "次のいずれかを選択して続行します",
 			"spanish": "Seleccione uno de los siguientes para continuar",
-			"french": "Sélectionnez une option suivante :"
+			"french": "Sélectionnez une option suivante :",
+			"portuguese": "Selecione um dos seguintes para continuar"
 		},
 		"adapter-loader.message1": {
 			"english": "Verify on your {{adapter}}",
@@ -169,7 +187,8 @@
 			"korean": "{{adapter}}에서 확인",
 			"japanese": "{{adapter}} で確認する",
 			"spanish": "Verifique en su {{adaptador}}",
-			"french": "Vérifiez sur votre {{adaptateur}}"
+			"french": "Vérifiez sur votre {{adaptateur}}",
+			"portuguese": "Verifique no seu {{adapter}}"
 		},
 		"footer.version": {
 			"english": "Version",
@@ -178,7 +197,8 @@
 			"korean": "버전",
 			"japanese": "バージョン",
 			"spanish": "Versión",
-			"french": "Version"
+			"french": "Version",
+			"portuguese": "Versão"
 		},
 		"social.view-more": {
 			"english": "View more options",
@@ -187,7 +207,8 @@
 			"korean": "더 많은 옵션 보기",
 			"japanese": "その他のオプションを表示",
 			"spanish": "Ver más opciones",
-			"french": "Voir plus d'options"
+			"french": "Voir plus d'options",
+			"portuguese": "Ver mais opções"
 		},
 		"header-title": {
 			"english": "Sign in",
@@ -196,7 +217,8 @@
 			"korean": "로그인",
 			"japanese": "ログイン",
 			"spanish": "Iniciar sesión",
-			"french": "Se connecter"
+			"french": "Se connecter",
+			"portuguese": "Iniciar sessão"
 		},
 		"header-subtitle-new": {
 			"english": "Your blockchain wallet in one-click",
@@ -205,7 +227,8 @@
 			"korean": "클릭 한 번으로 블록체인 지갑",
 			"japanese": "ワンクリックであなたのブロックチェーンウォレット",
 			"spanish": "Su billetera blockchain en un clic",
-			"french": "Votre portefeuille blockchain en un clic"
+			"french": "Votre portefeuille blockchain en un clic",
+			"portuguese": "A sua carteira de blockchain num clique"
 		},
 		"footer.terms-service": {
 			"english": "Terms of Service",
@@ -214,7 +237,8 @@
 			"korean": "서비스 약관",
 			"japanese": "利用規約",
 			"spanish": "Términos de servicio",
-			"french": "Conditions d'utilisation"
+			"french": "Conditions d'utilisation",
+			"portuguese": "Termos de serviço"
 		},
 		"social.email-continue": {
 			"english": "Continue with Email",
@@ -223,7 +247,8 @@
 			"korean": "이메일로 계속",
 			"japanese": "メールで続行",
 			"spanish": "Continuar con correo electrónico",
-			"french": "Continuer avec l'email"
+			"french": "Continuer avec l'email",
+			"portuguese": "Continuar com email"
 		},
 		"social.continue": {
 			"english": " Continue with ",
@@ -232,7 +257,8 @@
 			"korean": "계속",
 			"japanese": "続ける",
 			"spanish": "Continua con",
-			"french": "  Continue avec"
+			"french": "  Continue avec",
+			"portuguese": "Continuar com"
 		},
 		"external.back": {
 			"english": "Back",
@@ -241,7 +267,8 @@
 			"korean": "뒤",
 			"japanese": "戻る",
 			"spanish": "atrás",
-			"french": "Retour"
+			"french": "Retour",
+			"portuguese": "Voltar"
 		},
 		"network.add-request": {
 			"english": "This site is requesting to add Network",
@@ -250,7 +277,8 @@
 			"korean": "이 사이트는 네트워크 추가를 요청하고 있습니다",
 			"japanese": "このサイトはネットワークの追加をリクエストしています",
 			"spanish": "Este sitio está solicitando agregar Red",
-			"french": "Ce site vous demande de rajouter un réseau"
+			"french": "Ce site vous demande de rajouter un réseau",
+			"portuguese": "Este site está solicitando adicionar uma rede"
 		},
 		"social.email-new": {
 			"english": "name@example.com",
@@ -259,7 +287,8 @@
 			"korean": "name@example.com",
 			"japanese": "name@example.com",
 			"spanish": "nombre@ejemplo.com",
-			"french": "nom@exemple.com"
+			"french": "nom@exemple.com",
+			"portuguese": "nome@exemplo.com"
 		},
 		"footer.policy": {
 			"english": "Privacy Policy",
@@ -268,7 +297,8 @@
 			"korean": "개인 정보 정책",
 			"japanese": "プライバシーポリシー",
 			"spanish": "Política de privacidad",
-			"french": "Politique de confidentialité"
+			"french": "Politique de confidentialité",
+			"portuguese": "Política de privacidade"
 		},
 		"adapter-loader.message2": {
 			"english": "account to continue",
@@ -277,7 +307,8 @@
 			"korean": "계속할 계정",
 			"japanese": "継続するアカウント",
 			"spanish": "cuenta para continuar",
-			"french": "compte pour continuer"
+			"french": "compte pour continuer",
+			"portuguese": "conta para continuar"
 		},
 		"network.from": {
 			"english": "From",
@@ -286,7 +317,8 @@
 			"korean": "에서",
 			"japanese": "から",
 			"spanish": "De",
-			"french": "De"
+			"french": "De",
+			"portuguese": "De"
 		},
 		"social.view-less": {
 			"english": "View less options",
@@ -295,7 +327,8 @@
 			"korean": "더 적은 옵션 보기",
 			"japanese": "オプションを少なく表示",
 			"spanish": "Ver menos opciones",
-			"french": "Voir moins d'options"
+			"french": "Voir moins d'options",
+			"portuguese": "Ver menos opções"
 		}
 	}
 }


### PR DESCRIPTION
I just created a new translation based on `pt-BR` using `portuguese` as the language identifier, based on the other identifiers. 

We're building a solution based on Web3Auth at [Picnic](https://usepicnic.com) and it's quite important for us to have 100% of the user interaction on his/her chosen language.