### PR TITLE
Update social login string on modal

### DIFF
--- a/Web3Auth-locale/locale-common.json
+++ b/Web3Auth-locale/locale-common.json
@@ -332,13 +332,13 @@
 		},
 		"social.continue": {
 			"english": " Continue with ",
-			"german": "Weitermachen mit",
+			"german": " Weitermachen mit ",
 			"mandarin": "继续",
 			"korean": "계속",
 			"japanese": "続ける",
-			"spanish": "Continua con",
-			"french": "  Continue avec",
-			"portuguese": "Continuar com"
+			"spanish": " Continua con ",
+			"french": "  Continue avec ",
+			"portuguese": " Continuar com "
 		},
 		"external.back": {
 			"english": "Back",


### PR DESCRIPTION
There's not space between the `social.continue` tag and the provide name. So we need to adjust the tag to the same way that english is built. I updated all latin-based languages. @lionellbriones 