### PR TITLE
Correct the expressions that are uncomfortable in Japanese.

### DIFF
--- a/Casper-locale/locales-wallet-dapp.json
+++ b/Casper-locale/locales-wallet-dapp.json
@@ -567,7 +567,7 @@
             "english": "Sign in"
         },
         "selfCustodial": {
-            "japanese": "による自己管理ログイン",
+            "japanese": "自己管理ログイン by",
             "korean": "자가 관리 로그인",
             "spanish": "Inicio de sesión con autocustodia por",
             "german": "Selbstverwahrungs-Login durch",

--- a/Openlogin-locale/locales-common.json
+++ b/Openlogin-locale/locales-common.json
@@ -348,7 +348,7 @@
       "english": "Self-custodial login by",
       "korean": "자가 관리 로그인",
       "spanish": "Inicio de sesión con autocustodia por",
-      "japanese": "による自己管理ログイン",
+      "japanese": "自己管理ログイン by",
       "portuguese": "Login autocustodial por"
     },
     "advanced-options": {

--- a/Solana-locale/locales-wallet-dapp.json
+++ b/Solana-locale/locales-wallet-dapp.json
@@ -554,7 +554,7 @@
 		"selfCustodial": {
 			"mandarin": "自托管登录由",
 			"spanish": "Inicio de sesión con autocustodia por",
-			"japanese": "による自己管理ログイン",
+			"japanese": "自己管理ログイン by",
 			"korean": "자가 관리 로그인",
 			"german": "Selbstverwahrungs-Login durch",
 			"english": "Self-custodial login by"

--- a/Torus-locale/locales-login.json
+++ b/Torus-locale/locales-login.json
@@ -1187,7 +1187,7 @@
       "german": "Selbstverwahrungs-Login durch",
       "english": "Self-custodial login by",
       "mandarin": "自托管登录由",
-      "japanese": "による自己管理ログイン",
+      "japanese": "自己管理ログイン by",
       "spanish": "Inicio de sesión con autocustodia por"
     },
     "your": {

--- a/Torus-locale/locales-wallet-dapp.json
+++ b/Torus-locale/locales-wallet-dapp.json
@@ -529,7 +529,7 @@
 			"spanish": "Inicio de sesión con autocustodia por",
 			"german": "Selbstverwahrungs-Login durch",
 			"mandarin": "自托管登录由",
-			"japanese": "による自己管理ログイン",
+			"japanese": "自己管理ログイン by",
 			"korean": "자가 관리 로그인"
 		},
 		"yourDigital": {

--- a/Web3Auth-locale/locale-common.json
+++ b/Web3Auth-locale/locale-common.json
@@ -35,7 +35,7 @@
 			"german": "Selbstverwahrungs-Login durch",
 			"mandarin": "自托管登录由",
 			"korean": "자가 관리 로그인",
-			"japanese": "による自己管理ログイン",
+			"japanese": "自己管理ログイン by",
 			"spanish": "Inicio de sesión con autocustodia por",
 			"french": "Portefeuille hébergé par",
 			"portuguese": "Início de sessão com autocustódia por"


### PR DESCRIPTION
I corrected the expressions that are uncomfortable in Japanese.

- "selfCustodial"
- "footer.message"

In Japanese, the expression "による" never comes at the beginning of a sentence.
Therefore, I have modified it to use "by" instead of "による".