### PR TITLE
Replace dot notation in passwordless error locales and escape curly brace characters using literal interpolation for compatibility with Vue-18n

### DIFF
--- a/Openlogin-locale/locales-passwordless.json
+++ b/Openlogin-locale/locales-passwordless.json
@@ -205,16 +205,16 @@
       "turkish": "Hatalı telefon numarası."
     },
     "invalid-phone-number-sub": {
-      "dutch": "Voer het telefoonnummer in het volgende formaat in, bijvoorbeeld: +'{cc}'-'{number}'",
-      "english": "Please enter the phone number in the following format eg: +'{cc}'-'{number}'",
-      "french": "Veuillez saisir le numéro de téléphone dans le format suivant par exemple: +'{cc}'-'{number}'",
-      "german": "Bitte geben Sie die Telefonnummer im folgenden Format ein z.b: +'{cc}'-'{number}'",
-      "japanese": "次の形式で電話番号を入力してください 例えば： +'{cc}'-'{number}'",
-      "korean": "다음 형식으로 전화 번호를 입력하십시오 예 : +'{cc}'-'{number}'",
-      "mandarin": "请以以下格式输入电话号码 例如： +'{cc}'-'{number}'",
-      "portuguese": "Por favor, insira o número de telefone no seguinte formato Por exemplo: +'{cc}'-'{number}'",
-      "spanish": "Ingrese el número de teléfono en el siguiente formato P.ej: +'{cc}'-'{number}'",
-      "turkish": "Lütfen telefon numaranızı şu formatta yazın: +'{cc}'-'{numara}'"
+      "dutch": "Voer het telefoonnummer in het volgende formaat in, bijvoorbeeld: +{'{cc}'}-{'{number}'}",
+      "english": "Please enter the phone number in the following format eg: +{'{cc}'}-{'{number}'}",
+      "french": "Veuillez saisir le numéro de téléphone dans le format suivant par exemple: +{'{cc}'}-{'{number}'}",
+      "german": "Bitte geben Sie die Telefonnummer im folgenden Format ein z.b: +{'{cc}'}-{'{number}'}",
+      "japanese": "次の形式で電話番号を入力してください 例えば： +{'{cc}'}-{'{number}'}",
+      "korean": "다음 형식으로 전화 번호를 입력하십시오 예 : +{'{cc}'}-{'{number}'}",
+      "mandarin": "请以以下格式输入电话号码 例如： +{'{cc}'}-{'{number}'}",
+      "portuguese": "Por favor, insira o número de telefone no seguinte formato Por exemplo: +{'{cc}'}-{'{number}'}",
+      "spanish": "Ingrese el número de teléfono en el siguiente formato P.ej: +{'{cc}'}-{'{number}'}",
+      "turkish": "Lütfen telefon numaranızı şu formatta yazın: +{'{cc}'}-{'{numara}'}"
     },
     "loader-done": {
       "dutch": "Klaar",

--- a/Openlogin-locale/locales-passwordless.json
+++ b/Openlogin-locale/locales-passwordless.json
@@ -48,7 +48,7 @@
       "spanish": "Algo salió mal",
       "turkish": "Bir şeyler ters gitti"
     },
-    "errors.invalid-link": {
+    "error-invalid-link": {
       "dutch": "Ongeldige verificatielink of link verlopen",
       "english": "Invalid verification link or link expired",
       "french": "Lien de vérification invalide ou lien expiré",
@@ -60,7 +60,7 @@
       "spanish": "El enlace o el enlace de verificación no válido expirado",
       "turkish": "Hatalı ya da süresi geçmiş doğrulama linki"
     },
-    "errors.invalid-otp": {
+    "error-invalid-otp": {
       "english": "Invalid OTP, please try again",
       "german": "Ungültiges OTP, bitte versuchen Sie es erneut",
       "japanese": "無効なOTP、もう一度やり直してください",
@@ -72,7 +72,7 @@
       "french": "OTP non valide, veuillez réessayer",
       "turkish": "Hatalı OTP, lütfen tekrar deneyin."
     },
-    "errors.invalid-params": {
+    "error-invalid-params": {
       "dutch": "Ontbrekende of ongeldige parameters",
       "english": "Missing or Invalid Parameters.",
       "french": "Paramètres manquants ou invalides.",
@@ -84,7 +84,7 @@
       "spanish": "Parámetros faltantes o no válidos",
       "turkish": "Eksik ya da hatalı parametreler var."
     },
-    "errors.max-retry-limit-reached": {
+    "error-max-retry-limit-reached": {
       "dutch": "U heeft de limiet voor verkeerde pogingen bereikt. Start de stroom opnieuw om de verificatie te voltooien.",
       "english": "You have reached the limit for wrong attempts. Please restart the flow again to complete verification.",
       "french": "Vous avez atteint la limite pour les tentatives erronées. Veuillez redémarrer le flux pour terminer la vérification.",
@@ -96,7 +96,7 @@
       "spanish": "Has alcanzado el límite para intentos incorrectos. Reinicie el flujo nuevamente para completar la verificación.",
       "turkish": "Hatalı deneme limitine ulaştınız. Doğrulamayı tamamlamak için lütfen akışı baştan başlatın."
     },
-    "errors.new-link-generated-heading": {
+    "error-new-link-generated-heading": {
       "dutch": "Nieuwe verificatielink gegenereerd",
       "english": "New verification link generated",
       "french": "Nouveau lien de vérification généré",
@@ -108,7 +108,7 @@
       "spanish": "Nuevo enlace de verificación generado",
       "turkish": "Yeni doğrulama linki oluşturuldu."
     },
-    "errors.new-link-generated-info": {
+    "error-new-link-generated-info": {
       "dutch": "Verifieer met behulp van de laatste e-mail die u heeft ontvangen.",
       "english": "Please verify using the latest mail received on your email.",
       "french": "Veuillez vérifier en utilisant le dernier courrier reçu sur votre courrier électronique.",
@@ -120,7 +120,7 @@
       "spanish": "Verifique el uso del último correo recibido en su correo electrónico.",
       "turkish": "Lütfen e-postanıza gelen son e-posta ile doğrulama yapın."
     },
-    "errors.no-mail-generated": {
+    "error-no-mail-generated": {
       "dutch": "Geen e-mail gegenereerd. Start eerst de wachtwoordloze flow.",
       "english": "No mail generated. Please initiate the passwordless flow first.",
       "french": "Aucun courrier généré. Veuillez d'abord lancer le flux sans mot de passe.",
@@ -132,7 +132,7 @@
       "spanish": "No se genera correo. Inicie primero el flujo sin contraseña.",
       "turkish": "E-posta oluşturulmadı. Lütfen önce şifresiz akışı başlatın."
     },
-    "errors.no-sms-generated": {
+    "error-no-sms-generated": {
       "dutch": "Geen OTP gegenereerd. Start eerst de wachtwoordloze flow.",
       "english": "No OTP generated. Please initiate the passwordless flow first.",
       "french": "Aucun OTP généré. Veuillez d'abord lancer le flux sans mot de passe.",
@@ -144,7 +144,7 @@
       "spanish": "No se generó OTP. Inicie primero el flujo sin contraseña.",
       "turkish": "OTP oluşturulmadı. Lütfen önce şifresiz akışı başlatın."
     },
-    "errors.otp-expired": {
+    "error-otp-expired": {
       "dutch": "OTP verlopen",
       "english": "OTP Expired",
       "french": "OTP expiré",
@@ -156,7 +156,7 @@
       "spanish": "OTP expiró",
       "turkish": "OTP'nin süresi geçti."
     },
-    "errors.sending-sms-failed": {
+    "error-sending-sms-failed": {
       "dutch": "Er is een fout opgetreden bij het verzenden van een sms. Probeer het opnieuw.",
       "english": "There was an error sending an sms. Please try again.",
       "french": "Une erreur s'est produite lors de l'envoi d'un SMS. Veuillez réessayer.",
@@ -168,7 +168,7 @@
       "spanish": "Hubo un error de enviar un SMS. Inténtalo de nuevo.",
       "turkish": "SMS gönderilirken bir hata oldu. Lütfen tekrar deneyin."
     },
-    "errors.too-many-requests": {
+    "error-too-many-requests": {
       "english": "Too many requests received",
       "german": "Zu viele Anfragen erhalten",
       "japanese": "受け取ったリクエストが多すぎます",
@@ -180,7 +180,7 @@
       "french": "Trop de demandes reçues",
       "turkish": "Çok fazla talep alındı."
     },
-    "errors.too-many-requests-info": {
+    "error-too-many-requests-info": {
       "english": "You’ve sent too many requests. Please wait for moment before trying again.",
       "german": "Sie haben zu viele Anfragen gesendet. Bitte warten Sie auf einen Moment, bevor Sie es erneut versuchen.",
       "japanese": "あなたはあまりにも多くのリクエストを送信しました。もう一度試してみる前に、ちょっと待ってください。",

--- a/Openlogin-locale/locales-passwordless.json
+++ b/Openlogin-locale/locales-passwordless.json
@@ -205,16 +205,16 @@
       "turkish": "Hatalı telefon numarası."
     },
     "invalid-phone-number-sub": {
-      "dutch": "Voer het telefoonnummer in het volgende formaat in, bijvoorbeeld: +{'cc'}-{'number'}",
-      "english": "Please enter the phone number in the following format eg: +{'cc'}-{'number'}",
-      "french": "Veuillez saisir le numéro de téléphone dans le format suivant par exemple: +{'cc'}-{'number'}",
-      "german": "Bitte geben Sie die Telefonnummer im folgenden Format ein z.b: +{'cc'}-{'number'}",
-      "japanese": "次の形式で電話番号を入力してください 例えば： +{'cc'}-{'number'}",
-      "korean": "다음 형식으로 전화 번호를 입력하십시오 예 : +{'cc'}-{'number'}",
-      "mandarin": "请以以下格式输入电话号码 例如： +{'cc'}-{'number'}",
-      "portuguese": "Por favor, insira o número de telefone no seguinte formato Por exemplo: +{'cc'}-{'number'}",
-      "spanish": "Ingrese el número de teléfono en el siguiente formato P.ej: +{'cc'}-{'number'}",
-      "turkish": "Lütfen telefon numaranızı şu formatta yazın: +{'cc'}-{'numara'}"
+      "dutch": "Voer het telefoonnummer in het volgende formaat in, bijvoorbeeld: +'{cc}'-'{number}'",
+      "english": "Please enter the phone number in the following format eg: +'{cc}'-'{number}'",
+      "french": "Veuillez saisir le numéro de téléphone dans le format suivant par exemple: +'{cc}'-'{number}'",
+      "german": "Bitte geben Sie die Telefonnummer im folgenden Format ein z.b: +'{cc}'-'{number}'",
+      "japanese": "次の形式で電話番号を入力してください 例えば： +'{cc}'-'{number}'",
+      "korean": "다음 형식으로 전화 번호를 입력하십시오 예 : +'{cc}'-'{number}'",
+      "mandarin": "请以以下格式输入电话号码 例如： +'{cc}'-'{number}'",
+      "portuguese": "Por favor, insira o número de telefone no seguinte formato Por exemplo: +'{cc}'-'{number}'",
+      "spanish": "Ingrese el número de teléfono en el siguiente formato P.ej: +'{cc}'-'{number}'",
+      "turkish": "Lütfen telefon numaranızı şu formatta yazın: +'{cc}'-'{numara}'"
     },
     "loader-done": {
       "dutch": "Klaar",

--- a/Openlogin-locale/locales-passwordless.json
+++ b/Openlogin-locale/locales-passwordless.json
@@ -205,16 +205,16 @@
       "turkish": "Hatalı telefon numarası."
     },
     "invalid-phone-number-sub": {
-      "dutch": "Voer het telefoonnummer in het volgende formaat in, bijvoorbeeld: +{cc}-{number}",
-      "english": "Please enter the phone number in the following format eg: +{cc}-{number}",
-      "french": "Veuillez saisir le numéro de téléphone dans le format suivant par exemple: +{cc}-{number}",
-      "german": "Bitte geben Sie die Telefonnummer im folgenden Format ein z.b: +{cc}-{number}",
-      "japanese": "次の形式で電話番号を入力してください 例えば： +{cc}-{number}",
-      "korean": "다음 형식으로 전화 번호를 입력하십시오 예 : +{cc}-{number}",
-      "mandarin": "请以以下格式输入电话号码 例如： +{cc}-{number}",
-      "portuguese": "Por favor, insira o número de telefone no seguinte formato Por exemplo: +{cc}-{number}",
-      "spanish": "Ingrese el número de teléfono en el siguiente formato P.ej: +{cc}-{number}",
-      "turkish": "Lütfen telefon numaranızı şu formatta yazın: +{cc}-{numara}"
+      "dutch": "Voer het telefoonnummer in het volgende formaat in, bijvoorbeeld: +{'cc'}-{'number'}",
+      "english": "Please enter the phone number in the following format eg: +{'cc'}-{'number'}",
+      "french": "Veuillez saisir le numéro de téléphone dans le format suivant par exemple: +{'cc'}-{'number'}",
+      "german": "Bitte geben Sie die Telefonnummer im folgenden Format ein z.b: +{'cc'}-{'number'}",
+      "japanese": "次の形式で電話番号を入力してください 例えば： +{'cc'}-{'number'}",
+      "korean": "다음 형식으로 전화 번호를 입력하십시오 예 : +{'cc'}-{'number'}",
+      "mandarin": "请以以下格式输入电话号码 例如： +{'cc'}-{'number'}",
+      "portuguese": "Por favor, insira o número de telefone no seguinte formato Por exemplo: +{'cc'}-{'number'}",
+      "spanish": "Ingrese el número de teléfono en el siguiente formato P.ej: +{'cc'}-{'number'}",
+      "turkish": "Lütfen telefon numaranızı şu formatta yazın: +{'cc'}-{'numara'}"
     },
     "loader-done": {
       "dutch": "Klaar",


### PR DESCRIPTION
## Ticket Link
https://toruslabs.atlassian.net/browse/PD-3211
## What does this PR do?
Dot notation in locales doesn't seem to be working for vue i18n.
Refer to this issue https://github.com/kazupon/vue-i18n/issues/63
Changes it to use the standard hyphen separated keys.

Also, for special characters like `{` we need to use [link interpolation](https://vue-i18n.intlify.dev/guide/essentials/syntax#literal-interpolation)