### PR TITLE
PD-4186 missing resend locale

### DIFF
--- a/Auth-dashboard-locale/locales-login.json
+++ b/Auth-dashboard-locale/locales-login.json
@@ -1,5 +1,17 @@
 {
   "login": {
+    "2fa-setup-step4-check-time": {
+      "dutch": "Niet ontvangen? Opnieuw versturen. Controleer opnieuw in {0}",
+      "english": "Did not receive it? Resent. Check again in {0}",
+      "french": "Vous ne l'avez pas reçu ? Renvoyez. Vérifiez à nouveau dans {0}",
+      "german": "Nicht erhalten? Übelnehmen. Erneut einchecken in {0}",
+      "japanese": "受け取れませんでしたか？再送します。{0}で再度確認してください",
+      "korean": "받지 못하셨나요? 화내다. {0}에서 다시 확인",
+      "mandarin": "没有收到吗？ 反感。 再次签入{0}",
+      "portuguese": "Não recebeu? Reenviar. Verifique novamente em {0}",
+      "spanish": "¿No lo recibiste? Reenviar. Vuelve a comprobar en {0}",
+      "turkish": "Almadınız mı? Tekrar gönder. {0} süre sonra bir daha kontrol edin"
+    },
     "connect-email": {
       "dutch": "Verbinden met e-mail",
       "english": "Connect with Email",

--- a/Auth-dashboard-locale/locales-wallet-account.json
+++ b/Auth-dashboard-locale/locales-wallet-account.json
@@ -999,15 +999,15 @@
     },
     "password-requirement-char": {
       "dutch": "Bevat 1 speciaal teken ({'!@#?'})",
-      "english": "Contain 1 special character ({'!@#?'})",
-      "french": "Contient 1 caractère spécial ({'!@#?'})",
-      "german": "Enthält 1 Sonderzeichen ({'!@#?'})",
+      "english": "Include one of these characters ({'!@#?'})",
+      "french": "Inclure un de ces caractères ({'!@#?'})",
+      "german": "Enthält eines dieser Zeichen ({'!@#?'})",
       "japanese": "特殊文字 ({'!@#?'}) を 1 つ含む",
       "korean": "특수문자({'!@#?'}) 1개 포함",
-      "mandarin": "包含 1 个特殊字符 ({'!@#?'})",
-      "portuguese": "Contém 1 caractere especial ({'!@#?'})",
-      "spanish": "Contiene 1 carácter especial ({'!@#?'})",
-      "turkish": "1 özel karakter içerir ({'!@#?'})"
+      "mandarin": "包含这些字符之一 ({'!@#?'})",
+      "portuguese": "Contém um desses caracteres ({'!@#?'})",
+      "spanish": "Contiene uno de estos caracteres ({'!@#?'})",
+      "turkish": "Bu karakterlerden birini içerir ({'!@#?'})"
     },
     "password-requirement-desc": {
       "dutch": "Zorg ervoor dat aan deze vereisten wordt voldaan:",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Motivation and Context
Added missing locale when resending recovery phrase to email

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Jira Link:
https://toruslabs.atlassian.net/browse/PD-4186

## Description
<!--- Describe your changes in detail -->


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code requires a db migration.
