### PR TITLE
add russian language to wallet-serivce,openLogin and web3auth locales

### DIFF
--- a/Openlogin-locale/locales-authenticator.json
+++ b/Openlogin-locale/locales-authenticator.json
@@ -114,7 +114,7 @@
       "portuguese": "Digitalizar código QR",
       "spanish": "Escanear código QR",
       "turkish": "QR kodunu tarayın",
-      "russian": "Сканировать QR-код"
+      "russian": "Сканируй QR-код"
     },
     "setup-complete-desc": {
       "dutch": "Als u geen toegang meer heeft tot uw tweede factor, gebruikt u uw authenticatie-app om uw account terug te krijgen.",
@@ -179,7 +179,7 @@
       "portuguese": "Digite o código de verificação de 6 dígitos do seu aplicativo de autenticação",
       "spanish": "Introduzca el código de verificación de 6 dígitos de su aplicación de autenticación",
       "turkish": "Kimlik doğrulama uygulamanızdan 6 basamaklı doğrulama kodunu girin",
-      "russian": "Введите 6-значный код подтверждения из приложения-аутентификатор"
+      "russian": "Введите 6-значный код подтверждения из приложения-аутентификатора"
     },
     "verify-title": {
       "dutch": "Verifieer uw Authenticator App",

--- a/Openlogin-locale/locales-authenticator.json
+++ b/Openlogin-locale/locales-authenticator.json
@@ -10,7 +10,8 @@
       "mandarin": "取消",
       "portuguese": "Cancelar",
       "spanish": "Cancelar",
-      "turkish": "İptal etmek"
+      "turkish": "İptal etmek",
+      "russian": "Отменить"
     },
     "complete-desc": {
       "dutch": "Als u geen toegang meer heeft tot uw tweede factor, gebruikt u uw authenticatie-app om uw account terug te krijgen.",
@@ -22,7 +23,8 @@
       "mandarin": "如果您无法访问第二个因素，请使用您的身份验证应用程序恢复您的帐户。",
       "portuguese": "Se você perder o acesso ao seu segundo fator, use seu aplicativo de autenticação para recuperar sua conta.",
       "spanish": "Si pierde el acceso a su segundo factor, use su aplicación de autenticación para recuperar su cuenta.",
-      "turkish": "İkinci faktöre erişiminizi kaybederseniz, hesabınızı kurtarmak için kimlik doğrulama uygulamanızı kullanın."
+      "turkish": "İkinci faktöre erişiminizi kaybederseniz, hesabınızı kurtarmak için kimlik doğrulama uygulamanızı kullanın.",
+      "russian": "Если вы потеряете доступ ко второму фактору, используйте приложение-аутентификатор, чтобы восстановить доступ к аккаунту."
     },
     "done": {
       "dutch": "Klaar",
@@ -34,7 +36,8 @@
       "mandarin": "完成",
       "portuguese": "Concluído",
       "spanish": "Hecho",
-      "turkish": "Bitti"
+      "turkish": "Bitti",
+      "russian": "Готово"
     },
     "error-invalid-otp": {
       "english": "Invalid OTP, please try again",
@@ -45,7 +48,8 @@
       "mandarin": "无效的 OTP，请重试",
       "portuguese": "OTP inválido, tente novamente",
       "spanish": "OTP no válido, inténtelo de nuevo",
-      "turkish": "Geçersiz OTP, lütfen tekrar deneyin"
+      "turkish": "Geçersiz OTP, lütfen tekrar deneyin",
+      "russian": "Неверный одноразовый код, попробуйте ещё раз"
     },
     "error-something-wrong-error": {
       "dutch": "Er is iets misgegaan",
@@ -57,7 +61,8 @@
       "mandarin": "出问题了",
       "portuguese": "Algo deu errado",
       "spanish": "Algo salió mal",
-      "turkish": "Bir şeyler ters gitti"
+      "turkish": "Bir şeyler ters gitti",
+      "russian": "Что-то пошло не так"
     },
     "error-too-many-attempts": {
       "dutch": "Je hebt te veel pogingen gedaan. Wacht 60 seconden voordat u het opnieuw probeert",
@@ -69,7 +74,8 @@
       "mandarin": "你已经做了太多的尝试。请等待 60 秒，然后重试",
       "portuguese": "Você fez muitas tentativas. Aguarde 60 segundos antes de tentar novamente",
       "spanish": "Has hecho demasiados intentos. Espere 60 segundos antes de volver a intentarlo.",
-      "turkish": "Çok fazla deneme yaptınız. Tekrar denemeden önce lütfen 60 saniye bekleyin"
+      "turkish": "Çok fazla deneme yaptınız. Tekrar denemeden önce lütfen 60 saniye bekleyin",
+      "russian": "Слишком много попыток. Пожалуйста, подождите 60 секунд перед повторной попыткой"
     },
     "manual-entry": {
       "dutch": "Voer de code handmatig in",
@@ -81,7 +87,8 @@
       "mandarin": "手动输入代码",
       "portuguese": "Digite o código manualmente",
       "spanish": "Introduzca el código manualmente",
-      "turkish": "Kodu manuel olarak girin"
+      "turkish": "Kodu manuel olarak girin",
+      "russian": "Введите код вручную"
     },
     "next": {
       "dutch": "Volgende",
@@ -93,7 +100,8 @@
       "mandarin": "下一个",
       "portuguese": "Próximo",
       "spanish": "Próximo",
-      "turkish": "Sonraki"
+      "turkish": "Sonraki",
+      "russian": "Далее"
     },
     "scan-qr-code": {
       "dutch": "Scan QR-code",
@@ -105,7 +113,8 @@
       "mandarin": "扫描 QR 码",
       "portuguese": "Digitalizar código QR",
       "spanish": "Escanear código QR",
-      "turkish": "QR kodunu tarayın"
+      "turkish": "QR kodunu tarayın",
+      "russian": "Сканировать QR-код"
     },
     "setup-complete-desc": {
       "dutch": "Als u geen toegang meer heeft tot uw tweede factor, gebruikt u uw authenticatie-app om uw account terug te krijgen.",
@@ -117,7 +126,8 @@
       "mandarin": "如果您无法访问第二个因素，请使用您的身份验证应用程序恢复您的帐户。",
       "portuguese": "Se você perder o acesso ao seu segundo fator, use seu aplicativo de autenticação para recuperar sua conta.",
       "spanish": "Si pierde el acceso a su segundo factor, use su aplicación de autenticación para recuperar su cuenta.",
-      "turkish": "İkinci faktöre erişiminizi kaybederseniz, hesabınızı geri almak için kimlik doğrulama uygulamanızı kullanın."
+      "turkish": "İkinci faktöre erişiminizi kaybederseniz, hesabınızı geri almak için kimlik doğrulama uygulamanızı kullanın.",
+      "russian": "Если вы потеряете доступ ко второму фактору, используйте приложение-аутентификатор, чтобы вернуть доступ к аккаунту."
     },
     "setup-complete-title": {
       "dutch": "Authenticator App als herstelfactor is succesvol toegevoegd",
@@ -129,7 +139,8 @@
       "mandarin": "已成功将 Authenticator 应用程序添加为恢复因素。",
       "portuguese": "O aplicativo Authenticator como fator de recuperação foi adicionado com sucesso",
       "spanish": "La aplicación Authenticator como factor de recuperación se añadio correctamente",
-      "turkish": "Authenticator Uygulaması Kurtarma Faktörü olarak başarıyla eklendi"
+      "turkish": "Authenticator Uygulaması Kurtarma Faktörü olarak başarıyla eklendi",
+      "russian": "Приложение-аутентификатор успешно добавлено в качестве фактора восстановления"
     },
     "setup-desc": {
       "dutch": "Gebruik uw authenticatie-app (bijv. Google Authenticator of Authy) om deze QR-code te scannen.",
@@ -141,7 +152,8 @@
       "mandarin": "使用您的身份验证应用程序（例如 Google Authenticator 或 Authy）扫描此 QR 码。",
       "portuguese": "Use seu aplicativo de autenticação (por exemplo, Google Authenticator ou Authy) para escanear este código QR.",
       "spanish": "Use su aplicación de autenticación (por ejemplo, Google Authenticator o Authy) para escanear este código QR.",
-      "turkish": "Bu QR kodunu tarayarak kimlik doğrulama uygulamanızı (ör. Google Authenticator veya Authy) kullanın."
+      "turkish": "Bu QR kodunu tarayarak kimlik doğrulama uygulamanızı (ör. Google Authenticator veya Authy) kullanın.",
+      "russian": "Используйте приложение-аутентификатор (например, Google Authenticator или Authy), чтобы сканировать этот QR-код."
     },
     "setup-title": {
       "dutch": "Authenticator App instellen",
@@ -153,7 +165,8 @@
       "mandarin": "设置 Authenticator 应用程序",
       "portuguese": "Configuração do aplicativo Authenticator",
       "spanish": "Configuración de la aplicación Authenticator",
-      "turkish": "Authenticator Uygulamasını ayarla"
+      "turkish": "Authenticator Uygulamasını ayarla",
+      "russian": "Настройка приложения-аутентификатор"
     },
     "verify-desc": {
       "dutch": "Voer de 6-cijferige verificatiecode in van uw authenticatie-app",
@@ -165,7 +178,8 @@
       "mandarin": "从您的身份验证应用程序输入 6 位数验证码",
       "portuguese": "Digite o código de verificação de 6 dígitos do seu aplicativo de autenticação",
       "spanish": "Introduzca el código de verificación de 6 dígitos de su aplicación de autenticación",
-      "turkish": "Kimlik doğrulama uygulamanızdan 6 basamaklı doğrulama kodunu girin"
+      "turkish": "Kimlik doğrulama uygulamanızdan 6 basamaklı doğrulama kodunu girin",
+      "russian": "Введите 6-значный код подтверждения из приложения-аутентификатор"
     },
     "verify-title": {
       "dutch": "Verifieer uw Authenticator App",
@@ -177,7 +191,8 @@
       "mandarin": "验证您的 Authenticator 应用程序",
       "portuguese": "Verifique seu aplicativo Authenticator",
       "spanish": "Verifique su aplicación Authenticator",
-      "turkish": "Authenticator Uygulamanızı doğrulayın"
+      "turkish": "Authenticator Uygulamanızı doğrulayın",
+      "russian": "Подтвердите приложение-аутентификатор"
     }
   }
 }

--- a/Openlogin-locale/locales-common.json
+++ b/Openlogin-locale/locales-common.json
@@ -10,9 +10,10 @@
       "mandarin": "高级选项",
       "portuguese": "Opções avançadas",
       "spanish": "Opciones avanzadas",
-      "turkish": "Gelişmiş Seçenekler"
+      "turkish": "Gelişmiş Seçenekler",
+      "russian": "Расширенные параметры"
     },
-   "back-to-download": {
+    "back-to-download": {
       "dutch": "Terug naar download herstelfactor",
       "english": "Back to download Recovery Factor",
       "french": "Retour au téléchargement du facteur de récupération",
@@ -22,7 +23,8 @@
       "mandarin": "返回下载恢复系数",
       "portuguese": "Voltar para baixar o fator de recuperação",
       "spanish": "Volver a descargar el factor de recuperación",
-      "turkish": "Kurtarma faktörünü indirmeye geri dön"
+      "turkish": "Kurtarma faktörünü indirmeye geri dön",
+      "russian": "Назад к загрузке фактора восстановления"
     },
     "backup-phrase-copied": {
       "dutch": "Herstelzin gekopieerd",
@@ -34,7 +36,8 @@
       "mandarin": "备份短语已复制",
       "portuguese": "Frase de backup copiada",
       "spanish": "Frase de respaldo copiada",
-      "turkish": "Yedekleme ifadesi kopyalandı"
+      "turkish": "Yedekleme ifadesi kopyalandı",
+      "russian": "Фраза для резервного копирования скопирована"
     },
     "cancel": {
       "dutch": "Annuleren",
@@ -46,7 +49,8 @@
       "mandarin": "取消",
       "portuguese": "Cancelar",
       "spanish": "Cancelar",
-      "turkish": "İptal"
+      "turkish": "İptal",
+      "russian": "Отмена"
     },
     "close": {
       "dutch": "Sluiten",
@@ -58,7 +62,8 @@
       "mandarin": "关闭",
       "portuguese": "Fechar",
       "spanish": "Cerrar",
-      "turkish": "Kapat"
+      "turkish": "Kapat",
+      "russian": "Закрыть"
     },
     "confirm": {
       "dutch": "Bevestigen",
@@ -70,7 +75,8 @@
       "mandarin": "确认",
       "portuguese": "Confirmar",
       "spanish": "Confirmar",
-      "turkish": "Onayla"
+      "turkish": "Onayla",
+      "russian": "Подтвердить"
     },
     "copier-copied": {
       "dutch": "Gekopieerd!",
@@ -82,7 +88,8 @@
       "mandarin": "复制！",
       "portuguese": "Copiado!",
       "spanish": "Copiado!",
-      "turkish": "Kopyalandı!"
+      "turkish": "Kopyalandı!",
+      "russian": "Скопировано!"
     },
     "copier-copy": {
       "dutch": "Kopiëren naar klembord",
@@ -94,7 +101,8 @@
       "mandarin": "复制到剪贴板",
       "portuguese": "Copiar para área de transferência",
       "spanish": "Copiar al portapapeles",
-      "turkish": "Panoya kopyala"
+      "turkish": "Panoya kopyala",
+      "russian": "Копировать в буфер обмена"
     },
     "copier-manage-account": {
       "dutch": "Account beheren",
@@ -106,7 +114,8 @@
       "mandarin": "管理帐户",
       "portuguese": "Gerenciar conta",
       "spanish": "Administrar cuenta",
-      "turkish": "Hesabı yönet"
+      "turkish": "Hesabı yönet",
+      "russian": "Управлять аккаунтом"
     },
     "copier-privacy-policy": {
       "dutch": "Privacybeleid",
@@ -118,7 +127,8 @@
       "mandarin": "隐私政策",
       "portuguese": "Política de privacidade",
       "spanish": "Política de privacidad",
-      "turkish": "Gizlilik Politikası"
+      "turkish": "Gizlilik Politikası",
+      "russian": "Политика конфиденциальности"
     },
     "copier-terms-of-use": {
       "dutch": "Gebruiksvoorwaarden",
@@ -130,7 +140,8 @@
       "mandarin": "使用条款",
       "portuguese": "Termos de uso",
       "spanish": "Condiciones de uso",
-      "turkish": "Kullanım Şartları"
+      "turkey": "Kullanım Şartları",
+      "russian": "Условия использования"
     },
     "copy-backup-phrase": {
       "dutch": "Herstelzin kopiëren",
@@ -142,7 +153,8 @@
       "mandarin": "复制备份短语",
       "portuguese": "Copiar Frase de Backup",
       "spanish": "Copiar frase de respaldo",
-      "turkish": "Yedekleme İfadesini Kopyala"
+      "turkish": "Yedekleme İfadesini Kopyala",
+      "russian": "Копировать фразу для резервного копирования"
     },
     "copy-paste": {
       "dutch": "Kopiëren en plakken",
@@ -154,7 +166,8 @@
       "mandarin": "复制和粘贴",
       "portuguese": "Copiar e colar",
       "spanish": "Copiar y pegar",
-      "turkish": "Kopyala ve yapıştır"
+      "turkish": "Kopyala ve yapıştır",
+      "russian": "Копировать и вставить"
     },
     "copy-recovery-phrase": {
       "dutch": "Herstelzin kopiëren",
@@ -166,7 +179,8 @@
       "mandarin": "复制助记词",
       "portuguese": "Copiar frase de recuperação",
       "spanish": "Copiar frase de respaldo",
-      "turkish": "Kurtarma ifadesini kopyala"
+      "turkish": "Kurtarma ifadesini kopyala",
+      "russian": "Копировать восстановительную фразу"
     },
     "device": {
       "dutch": "Apparaat",
@@ -178,7 +192,8 @@
       "mandarin": "设备",
       "portuguese": "Dispositivo",
       "spanish": "Dispositivo",
-      "turkish": "Cihaz"
+      "turkish": "Cihaz",
+      "russian": "Устройство"
     },
     "devices": {
       "dutch": "Apparaten",
@@ -190,7 +205,8 @@
       "mandarin": "设备",
       "portuguese": "Dispositivo (s)",
       "spanish": "Dispositivo (s)",
-      "turkish": "Cihaz(lar)"
+      "turkish": "Cihaz(lar)",
+      "russian": "Устройства"
     },
     "edit-email": {
       "dutch": "Wijzig email",
@@ -202,7 +218,8 @@
       "mandarin": "编辑电子邮件",
       "portuguese": "Editar e-mail",
       "spanish": "Editar correo electrónico",
-      "turkish": "E-postayı düzenle"
+      "turkish": "E-postayı düzenle",
+      "russian": "Редактировать email"
     },
     "errors-incorrect-mnemonic": {
       "dutch": "Onjuiste gedeelde mnemonische code",
@@ -214,7 +231,8 @@
       "mandarin": "不正确的共享助记符",
       "portuguese": "Mnemônico de compartilhamento incorreto",
       "spanish": "Mnemónico compartido incorrecto",
-      "turkish": "Hatalı mnemonic parçası"
+      "turkish": "Hatalı mnemonic parçası",
+      "russian": "Неверная мнемоническая фраза"
     },
     "errors-incorrect-password": {
       "dutch": "Onjuist wachtwoord",
@@ -226,7 +244,8 @@
       "mandarin": "密码错误",
       "portuguese": "Senha incorreta",
       "spanish": "Contraseña incorrecta",
-      "turkish": "Hatalı parola"
+      "turkish": "Hatalı parola",
+      "russian": "Неверный пароль"
     },
     "errors-invalid-email": {
       "dutch": "Ongeldig e-mailadres",
@@ -238,7 +257,8 @@
       "mandarin": "不合规电邮",
       "portuguese": "E-mail inválido",
       "spanish": "Email inválido",
-      "turkish": "Hatalı e-posta"
+      "turkish": "Hatalı e-posta",
+      "russian": "Неверный адрес электронной почты"
     },
     "errors-invalid-mnemonic": {
       "dutch": "Ongeldige mnemonische zin",
@@ -250,7 +270,8 @@
       "mandarin": "助记词短语无效",
       "portuguese": "Frase mnemônica inválida",
       "spanish": "Frase mnemotécnica no válida",
-      "turkish": "Geçersiz mnemonic"
+      "turkish": "Geçersiz mnemonic",
+      "russian": "Неверная мнемоническая фраза"
     },
     "errors-invalid-password": {
       "dutch": "Moet minimaal 10 tekens bevatten. Minimaal één hoofdletter, één kleine letter, één cijfer",
@@ -262,7 +283,8 @@
       "mandarin": "必须至少包含10个字符。 至少一个大写字母，一个小写字母，一个数字",
       "portuguese": "Deve conter pelo menos 10 caracteres. Pelo menos uma letra maiúscula, uma letra minúscula, um número",
       "spanish": "Debe contener al menos 10 caracteres. Al menos una letra mayúscula, una letra minúscula, un número",
-      "turkish": "En az 10 karakter içermelidir. En az bir büyük harf, bir küçük harf, bir rakam."
+      "turkish": "En az 10 karakter içermelidir. En az bir büyük harf, bir küçük harf, bir rakam.",
+      "russian": "Пароль должен содержать минимум 10 символов. Как минимум одну заглавную букву, одну строчную букву и одну цифру"
     },
     "errors-mismatch-password": {
       "dutch": "Wachtwoord moet overeenkomen",
@@ -274,7 +296,8 @@
       "mandarin": "密码必须匹配",
       "portuguese": "A senha deve ser igual",
       "spanish": "Contraseña debe coincidir con",
-      "turkish": "Şifre eşleşmelidir"
+      "turkish": "Şifre eşleşmelidir",
+      "russian": "Пароли должны совпадать"
     },
     "errors-required": {
       "dutch": "Verplicht",
@@ -286,7 +309,8 @@
       "mandarin": "必需的",
       "portuguese": "Requerido",
       "spanish": "Requerido",
-      "turkish": "Zorunlu"
+      "turkish": "Zorunlu",
+      "russian": "Обязательно"
     },
     "errors-same-email-verifier": {
       "dutch": "E-mail kan niet hetzelfde zijn als de sociale login-ID",
@@ -298,7 +322,8 @@
       "mandarin": "电子邮件不能与社交登录ID相同",
       "portuguese": "O email não pode ser o mesmo que o ID de login social",
       "spanish": "El correo electrónico no puede ser el mismo que la identificación de inicio de sesión social",
-      "turkish": "E-posta sosyal medya giriş kimliğiyle aynı olamaz"
+      "turkish": "E-posta sosyal medya giriş kimliğiyle aynı olamaz",
+      "russian": "Email не может совпадать с идентификатором социальной авторизации"
     },
     "factor1-social-login": {
       "dutch": "Factor 1: Sociale login",
@@ -310,7 +335,8 @@
       "mandarin": "因素 1：社交登录",
       "portuguese": "Fator 1: Login social",
       "spanish": "Factor 1: inicio de sesión social",
-      "turkish": "1. Faktör: Sosyal Medya Girişi"
+      "turkish": "1. Faktör: Sosyal Medya Girişi",
+      "russian": "Фактор 1: Социальный вход"
     },
     "factor2-devices": {
       "dutch": "Factor 2: Apparaat (en)",
@@ -322,7 +348,8 @@
       "mandarin": "因素 2：设备",
       "portuguese": "Fator 2: Dispositivo(s)",
       "spanish": "Factor 2: Dispositivo(s)",
-      "turkish": "2. Faktör: Cihaz(lar)"
+      "turkish": "2. Faktör: Cihaz(lar)",
+      "russian": "Фактор 2: Устройство(а)"
     },
     "factor3-social-recovery": {
       "dutch": "Factor 3: Sociaal herstel",
@@ -334,7 +361,8 @@
       "mandarin": "因素 3：社会恢复",
       "portuguese": "Fator 3: Recuperação Social",
       "spanish": "Factor 3: Recuperación Social",
-      "turkish": "3. Faktör: Sosyal Medya ile Kurtar"
+      "turkish": "3. Faktör: Sosyal Medya ile Kurtar",
+      "russian": "Фактор 3: Социальное восстановление"
     },
     "hide-options": {
       "dutch": "Opties verbergen",
@@ -346,7 +374,8 @@
       "mandarin": "隐藏选项",
       "portuguese": "Ocultar opções",
       "spanish": "Ocultar opciones",
-      "turkish": "Seçenekleri Gizle"
+      "turkish": "Seçenekleri Gizle",
+      "russian": "Скрыть параметры"
     },
     "last-accessed-on": {
       "dutch": "Laatst bezocht op:",
@@ -358,7 +387,8 @@
       "mandarin": "最后访问时间：",
       "portuguese": "Último acesso em:",
       "spanish": "Último acceso el:",
-      "turkish": "Son Giriş:"
+      "turkish": "Son Giriş:",
+      "russian": "Последний доступ:"
     },
     "learn-more": {
       "dutch": "Meer informatie",
@@ -370,7 +400,8 @@
       "mandarin": "更多详情",
       "portuguese": "Saber mais",
       "spanish": "Aprende más",
-      "turkish": "Daha fazla bilgi edinin"
+      "turkish": "Daha fazla bilgi edinin",
+      "russian": "Узнать больше"
     },
     "loader-device-detecting": {
       "dutch": "Uw apparaat word gedetecteerd",
@@ -382,7 +413,8 @@
       "mandarin": "检测您的设备",
       "portuguese": "Detectando seu dispositivo",
       "spanish": "Detectando su dispositivo",
-      "turkish": "Cihazınız algılanıyor"
+      "turkish": "Cihazınız algılanıyor",
+      "russian": "Идет определение устройства"
     },
     "loader-secure-login": {
       "dutch": "Inloggen beveiligen met tKey",
@@ -394,7 +426,8 @@
       "mandarin": "使用tKey保护登录",
       "portuguese": "Protegendo o login com tKey",
       "spanish": "Asegurar el inicio de sesión con tKey",
-      "turkish": "tKey ile giriş güvenliği sağlanıyor"
+      "turkish": "tKey ile giriş güvenliği sağlanıyor",
+      "russian": "Защита входа с помощью tKey"
     },
     "new-device-detected": {
       "dutch": "Nieuw apparaat gedetecteerd",
@@ -406,7 +439,8 @@
       "mandarin": "检测到新设备",
       "portuguese": "Novo dispositivo detectado",
       "spanish": "Nuevo dispositivo detectado",
-      "turkish": "Yeni cihaz algılandı"
+      "turkish": "Yeni cihaz algılandı",
+      "russian": "Обнаружено новое устройство"
     },
     "or": {
       "dutch": "of",
@@ -418,7 +452,8 @@
       "mandarin": "或者",
       "portuguese": "ou",
       "spanish": "o",
-      "turkish": "veya"
+      "turkish": "veya",
+      "russian": "или"
     },
     "other-factor-pwd": {
       "dutch": "Andere factoren: wachtwoord",
@@ -429,7 +464,8 @@
       "mandarin": "其他因素：密码",
       "portuguese": "Outros fatores: senha",
       "spanish": "Otros factores: contraseña",
-      "turkish": "Diğer Faktörler : Şifre"
+      "turkish": "Diğer Faktörler : Şifre",
+      "russian": "Другие факторы: пароль"
     },
     "password": {
       "dutch": "Wachtwoord",
@@ -441,7 +477,8 @@
       "mandarin": "密码",
       "portuguese": "Senha",
       "spanish": "Password",
-      "turkish": "Şifre"
+      "turkish": "Şifre",
+      "russian": "Пароль"
     },
     "password-label": {
       "dutch": "Voer wachtwoord in",
@@ -453,7 +490,8 @@
       "mandarin": "输入密码",
       "portuguese": "Digite a senha",
       "spanish": "Ingresa tu password",
-      "turkish": "Şifrenizi girin"
+      "turkish": "Şifrenizi girin",
+      "russian": "Введите пароль"
     },
     "phone": {
       "dutch": "Telefoon",
@@ -465,7 +503,8 @@
       "mandarin": "电话",
       "portuguese": "Telefone",
       "spanish": "Teléfono",
-      "turkish": "Telefon"
+      "turkish": "Telefon",
+      "russian": "Телефон"
     },
     "powered-by": {
       "dutch": "Mogelijk gemaakt door",
@@ -477,7 +516,8 @@
       "mandarin": "通过",
       "portuguese": "Provido por",
       "spanish": "por",
-      "turkish": "Powered by"
+      "turkish": "Powered by",
+      "russian": "Предоставлено"
     },
     "recovery-phrase-copied": {
       "dutch": "Herstelzin gekopieerd",
@@ -489,7 +529,8 @@
       "mandarin": "助记词已复制",
       "portuguese": "Frase de Recuperação Copiada",
       "spanish": "Frase de respaldo copiada",
-      "turkish": "Kurtarma İfadesi Kopyalandı"
+      "turkish": "Kurtarma İfadesi Kopyalandı",
+      "russian": "Фраза восстановления скопирована"
     },
     "recoveryFactor": {
       "dutch": "Herstelfactor",
@@ -501,7 +542,8 @@
       "mandarin": "恢复因子",
       "portuguese": "Fator de recuperação",
       "spanish": "Factor de respaldo",
-      "turkish": "Kurtarma Faktörü"
+      "turkish": "Kurtarma Faktörü",
+      "russian": "Фактор восстановления"
     },
     "referenceId": {
       "dutch": "Referentie-ID:",
@@ -513,7 +555,8 @@
       "mandarin": "参考编号：",
       "portuguese": "ID de referência:",
       "spanish": "Identificación de referencia:",
-      "turkish": "Referans Kimliği:"
+      "turkish": "Referans Kimliği:",
+      "russian": "Идентификатор ссылки:"
     },
     "resend-recovery": {
       "dutch": "Herstelfactor opnieuw verzenden",
@@ -525,7 +568,8 @@
       "mandarin": "重新发送恢复因子",
       "portuguese": "Reenviar Fator de Recuperação",
       "spanish": "Factor de respaldo de reenvío",
-      "turkish": "Kurtarma Faktörünü Yeniden Gönder"
+      "turkish": "Kurtarma Faktörünü Yeniden Gönder",
+      "russian": "Отправить фактор восстановления повторно"
     },
     "secured-by": {
       "dutch": "Beveiligd door",
@@ -537,7 +581,8 @@
       "mandarin": "担保人",
       "portuguese": "Assegurado por",
       "spanish": "Asegurado por",
-      "turkish": "Secured by"
+      "turkish": "Secured by",
+      "russian": "Защищено"
     },
     "selfCustodial": {
       "dutch": "Zelfbewarend inloggen door",
@@ -549,7 +594,8 @@
       "mandarin": "自托管登录由",
       "portuguese": "Login autocustodial por",
       "spanish": "Inicio de sesión con autocustodia por",
-      "turkish": "Öz-yönetimli giriş yapan:"
+      "turkish": "Öz-yönetimli giriş yapan:",
+      "russian": "Самостоятельная авторизация от"
     },
     "social": {
       "dutch": "Sociaal",
@@ -561,7 +607,8 @@
       "mandarin": "社会的",
       "portuguese": "Social",
       "spanish": "Social",
-      "turkish": "Sosyal"
+      "turkish": "Sosyal",
+      "russian": "Социальный"
     },
     "socialFactor": {
       "dutch": "Sociale factor",
@@ -573,7 +620,8 @@
       "mandarin": "社会因素",
       "portuguese": "Fator Social",
       "spanish": "Factor social",
-      "turkish": "Sosyal Medya Faktörü"
+      "turkish": "Sosyal Medya Faktörü",
+      "russian": "Социальный фактор"
     },
     "socialLogin": {
       "dutch": "Sociale login",
@@ -585,7 +633,8 @@
       "mandarin": "社交登录",
       "portuguese": "Login social",
       "spanish": "Inicio de sesión social",
-      "turkish": "Sosyal medya girişi"
+      "turkish": "Sosyal medya girişi",
+      "russian": "Социальный вход"
     },
     "toast-backup-phase-email-send-success": {
       "dutch": "Back-upzin verzonden naar uw e-mail",
@@ -597,7 +646,8 @@
       "mandarin": "备用词组已发送到您的电子邮件",
       "portuguese": "Frase de segurança enviada para o seu e-mail",
       "spanish": "Frase de seguridad enviada a su correo electrónico",
-      "turkish": "Yedekleme ifadesi e-postanıza gönderildi"
+      "turkish": "Yedekleme ifadesi e-postanıza gönderildi",
+      "russian": "Фраза резервного копирования отправлена на вашу электронную почту"
     },
     "toast-backup-phase-email-send-timeout": {
       "dutch": "Time-out bij het verzenden van de back-upzin naar uw e-mail. Download in plaats daarvan de back-upzin",
@@ -609,7 +659,8 @@
       "mandarin": "将备份短语发送到您的电子邮件时超时。 请改为下载备份短语",
       "portuguese": "Tempo limite ao enviar a frase de backup para o seu e-mail. Em vez disso, baixe a frase de backup",
       "spanish": "Tiempo de espera al enviar la frase de respaldo a su correo electrónico. Descargue la frase de respaldo en su lugar",
-      "turkish": "E-postanıza yedekleme ifadesi gönderilirken zaman aşımına uğradı. Lütfen yedekleme ifadesini indirin."
+      "turkish": "E-postanıza yedekleme ifadesi gönderilirken zaman aşımına uğradı. Lütfen yedekleme ifadesini indirin.",
+      "russian": "Время ожидания при отправке фразы резервного копирования на почту истекло. Пожалуйста, скачайте ее вместо этого"
     },
     "toast-backup-phase-send-fail": {
       "dutch": "Kan back-upzin niet verzenden",
@@ -621,7 +672,8 @@
       "mandarin": "无法发送备份短语",
       "portuguese": "Não foi possível enviar a frase de backup",
       "spanish": "No se pudo enviar la frase de respaldo",
-      "turkish": "Yedekleme ifadesi gönderilemiyor"
+      "turkish": "Yedekleme ifadesi gönderilemiyor",
+      "russian": "Не удалось отправить фразу резервного копирования"
     },
     "toast-backup-phase-send-success": {
       "dutch": "Back-upzin succesvol verzonden",
@@ -633,7 +685,8 @@
       "mandarin": "备份词组已成功发送",
       "portuguese": "Frase de backup enviada com sucesso",
       "spanish": "Frase de seguridad enviada con éxito",
-      "turkish": "Yedekleme ifadesi başarıyla gönderildi"
+      "turkish": "Yedekleme ifadesi başarıyla gönderildi",
+      "russian": "Фраза резервного копирования успешно отправлена"
     },
     "toast-backup-share-verification-fail": {
       "dutch": "Verificatie van gedeelde back-up is mislukt",
@@ -645,7 +698,8 @@
       "mandarin": "备份共享验证失败",
       "portuguese": "Falha na verificação do compartilhamento de backup",
       "spanish": "Error en la verificación del fragmento de la copia de seguridad",
-      "turkish": "Yedekleme parçası doğrulanamadı"
+      "turkish": "Yedekleme parçası doğrulanamadı",
+      "russian": "Не удалось проверить долю резервного копирования"
     },
     "toast-device-share-delete-fail": {
       "dutch": "Verwijderen van gedeelde apparaat is mislukt",
@@ -657,7 +711,8 @@
       "mandarin": "设备共享删除失败",
       "portuguese": "Falha na exclusão do compartilhamento do dispositivo",
       "spanish": "No se pudo eliminar el fragmento del dispositivo",
-      "turkish": "Cihaz şifresi silinemedi"
+      "turkish": "Cihaz şifresi silinemedi",
+      "russian": "Удаление доли устройства не удалось"
     },
     "toast-device-share-delete-success": {
       "dutch": "Apparaat delen succesvol verwijderd",
@@ -669,7 +724,8 @@
       "mandarin": "设备共享已成功删除",
       "portuguese": "Compartilhamento de dispositivo excluído com sucesso",
       "spanish": "Fragmento del dispositivo eliminado correctamente",
-      "turkish": "Cihaz şifresi başarıyla silindi"
+      "turkish": "Cihaz şifresi başarıyla silindi",
+      "russian": "Доля устройства успешно удалена"
     },
     "toast-password-change-fail": {
       "dutch": "Wachtwoordwijziging mislukt",
@@ -681,7 +737,8 @@
       "mandarin": "密码更改失败",
       "portuguese": "Falha na alteração da senha",
       "spanish": "Cambio de contraseña fallido",
-      "turkish": "Şifre değiştirilemedi"
+      "turkish": "Şifre değiştirilemedi",
+      "russian": "Не удалось изменить пароль"
     },
     "toast-password-change-success": {
       "dutch": "Wachtwoord succesvol gewijzigd",
@@ -693,7 +750,8 @@
       "mandarin": "密码修改成功",
       "portuguese": "Senha alterada com sucesso",
       "spanish": "Contraseña cambiada correctamente",
-      "turkish": "Şifre başarıyla değiştirildi"
+      "turkish": "Şifre başarıyla değiştirildi",
+      "russian": "Пароль успешно изменён"
     },
     "toast-password-verification-fail": {
       "dutch": "Wachtwoordverificatie mislukt",
@@ -705,7 +763,8 @@
       "mandarin": "密码验证失败",
       "portuguese": "A verificação da senha falhou",
       "spanish": "Falló la verificación de la contraseña",
-      "turkish": "Şifre doğrulaması başarısız"
+      "turkish": "Şifre doğrulaması başarısız",
+      "russian": "Проверка пароля не удалась"
     },
     "toast-recovery-share-delete-fail": {
       "dutch": "Het verwijderen van de herstelshare is mislukt",
@@ -717,7 +776,8 @@
       "mandarin": "恢复共享删除失败",
       "portuguese": "A exclusão do compartilhamento de recuperação falhou",
       "spanish": "Error al eliminar el fragmento de respaldo",
-      "turkish": "Kurtarma ifadesi silinemedi"
+      "turkish": "Kurtarma ifadesi silinemedi",
+      "russian": "Не удалось удалить долю восстановления"
     },
     "toast-recovery-share-delete-success": {
       "dutch": "Herstelshare succesvol verwijderd",
@@ -729,7 +789,8 @@
       "mandarin": "恢复共享已成功删除",
       "portuguese": "Compartilhamento de recuperação excluído com sucesso",
       "spanish": "Fragmento de respaldo eliminado con éxito",
-      "turkish": "Kurtarma ifadesi başarıyla silindi"
+      "turkish": "Kurtarma ifadesi başarıyla silindi",
+      "russian": "Доля восстановления успешно удалена"
     },
     "toast-registration-failed": {
       "dutch": "Registratie mislukt",
@@ -741,7 +802,8 @@
       "mandarin": "注册失败",
       "portuguese": "Registro falhou",
       "spanish": "Registro fallido",
-      "turkish": "Kayıt başarısız"
+      "turkish": "Kayıt başarısız",
+      "russian": "Регистрация не удалась"
     },
     "toast-require-verification": {
       "dutch": "Vereis een andere verificatie-invoer",
@@ -753,7 +815,8 @@
       "mandarin": "需要其他验证输入",
       "portuguese": "Exigir outra entrada de verificação",
       "spanish": "Requerir otra entrada de verificación",
-      "turkish": "Başka bir doğrulama girişi iste"
+      "turkish": "Başka bir doğrulama girişi iste",
+      "russian": "Требуется другой способ проверки"
     },
     "toast-share-transfer-fail": {
       "dutch": "Delen mislukt",
@@ -765,7 +828,8 @@
       "mandarin": "股份转让失败",
       "portuguese": "Falha na transferência de compartilhamento",
       "spanish": "Error al transferir el fragmento",
-      "turkish": "Şifre parçası transfer edilemedi"
+      "turkish": "Şifre parçası transfer edilemedi",
+      "russian": "Передача доли не удалась"
     },
     "toast-something-went-wrong": {
       "dutch": "Er is iets misgegaan",
@@ -777,7 +841,8 @@
       "mandarin": "出问题了",
       "portuguese": "Algo deu errado",
       "spanish": "Algo salió mal",
-      "turkish": "Bir şeyler ters gitti"
+      "turkish": "Bir şeyler ters gitti",
+      "russian": "Что-то пошло не так"
     },
     "upload-recovery-factor": {
       "dutch": "Herstelfactor uploaden",
@@ -789,7 +854,8 @@
       "mandarin": "上传恢复因子",
       "portuguese": "Carregar Fator de Recuperação",
       "spanish": "Subir factor de respaldo",
-      "turkish": "Kurtarma Faktörü yükle"
+      "turkish": "Kurtarma Faktörü yükle",
+      "russian": "Загрузить фактор восстановления"
     },
     "verify": {
       "dutch": "Verifiëren",
@@ -801,7 +867,8 @@
       "mandarin": "核实",
       "portuguese": "Verificar",
       "spanish": "Verificar",
-      "turkish": "Doğrula"
+      "turkish": "Doğrula",
+      "russian": "Проверить"
     },
     "verify-with-other-factors": {
       "dutch": "Verifiëren met andere factoren",
@@ -813,7 +880,8 @@
       "mandarin": "与其他因素验证",
       "portuguese": "Verifique com outros fatores",
       "spanish": "Verificar con otros factores",
-      "turkish": "Diğer faktörler ile doğrula"
+      "turkish": "Diğer faktörler ile doğrula",
+      "russian": "Проверить другими способами"
     },
     "webAuthentication": {
       "dutch": "Webauthenticatie",
@@ -825,7 +893,8 @@
       "mandarin": "网络认证",
       "portuguese": "Autenticação Web",
       "spanish": "Autenticación web",
-      "turkish": "Web Kimlik Doğrulaması"
+      "turkish": "Web Kimlik Doğrulaması",
+      "russian": "Веб-аутентификация"
     }
   },
   "error-block": {
@@ -839,7 +908,8 @@
       "mandarin": "以下一个或多个必需参数缺失/无效",
       "portuguese": "Um ou mais dos seguintes parâmetros obrigatórios estão ausentes/inválidos",
       "spanish": "Uno o más de los siguientes parámetros obligatorios faltan o no son válidos",
-      "turkish": "Gerekli parametrelerden bir veya daha fazlası eksik/geçersiz"
+      "turkish": "Gerekli parametrelerden bir veya daha fazlası eksik/geçersiz",
+      "russian": "Один или несколько обязательных параметров отсутствуют/недействительны"
     }
   }
 }

--- a/Openlogin-locale/locales-common.json
+++ b/Openlogin-locale/locales-common.json
@@ -115,7 +115,7 @@
       "portuguese": "Gerenciar conta",
       "spanish": "Administrar cuenta",
       "turkish": "Hesabı yönet",
-      "russian": "Управлять аккаунтом"
+      "russian": "Управление аккаунтом"
     },
     "copier-privacy-policy": {
       "dutch": "Privacybeleid",
@@ -180,7 +180,7 @@
       "portuguese": "Copiar frase de recuperação",
       "spanish": "Copiar frase de respaldo",
       "turkish": "Kurtarma ifadesini kopyala",
-      "russian": "Копировать восстановительную фразу"
+      "russian": "Копировать фразу восстановления"
     },
     "device": {
       "dutch": "Apparaat",
@@ -323,7 +323,7 @@
       "portuguese": "O email não pode ser o mesmo que o ID de login social",
       "spanish": "El correo electrónico no puede ser el mismo que la identificación de inicio de sesión social",
       "turkish": "E-posta sosyal medya giriş kimliğiyle aynı olamaz",
-      "russian": "Email не может совпадать с идентификатором социальной авторизации"
+      "russian": "Email не может совпадать с адресом авторизации в соцсети"
     },
     "factor1-social-login": {
       "dutch": "Factor 1: Sociale login",
@@ -336,7 +336,7 @@
       "portuguese": "Fator 1: Login social",
       "spanish": "Factor 1: inicio de sesión social",
       "turkish": "1. Faktör: Sosyal Medya Girişi",
-      "russian": "Фактор 1: Социальный вход"
+      "russian": "Фактор 1: Вход через соцсети"
     },
     "factor2-devices": {
       "dutch": "Factor 2: Apparaat (en)",
@@ -362,7 +362,7 @@
       "portuguese": "Fator 3: Recuperação Social",
       "spanish": "Factor 3: Recuperación Social",
       "turkish": "3. Faktör: Sosyal Medya ile Kurtar",
-      "russian": "Фактор 3: Социальное восстановление"
+      "russian": "Фактор 3: Восстановление через соцсети"
     },
     "hide-options": {
       "dutch": "Opties verbergen",
@@ -388,7 +388,7 @@
       "portuguese": "Último acesso em:",
       "spanish": "Último acceso el:",
       "turkish": "Son Giriş:",
-      "russian": "Последний доступ:"
+      "russian": "Последний вход:"
     },
     "learn-more": {
       "dutch": "Meer informatie",
@@ -465,7 +465,7 @@
       "portuguese": "Outros fatores: senha",
       "spanish": "Otros factores: contraseña",
       "turkish": "Diğer Faktörler : Şifre",
-      "russian": "Другие факторы: пароль"
+      "russian": "Другие факторы: Пароль"
     },
     "password": {
       "dutch": "Wachtwoord",
@@ -517,7 +517,7 @@
       "portuguese": "Provido por",
       "spanish": "por",
       "turkish": "Powered by",
-      "russian": "Предоставлено"
+      "russian": "Сделано с помощью"
     },
     "recovery-phrase-copied": {
       "dutch": "Herstelzin gekopieerd",
@@ -608,7 +608,7 @@
       "portuguese": "Social",
       "spanish": "Social",
       "turkish": "Sosyal",
-      "russian": "Социальный"
+      "russian": "Соцсети"
     },
     "socialFactor": {
       "dutch": "Sociale factor",
@@ -621,7 +621,7 @@
       "portuguese": "Fator Social",
       "spanish": "Factor social",
       "turkish": "Sosyal Medya Faktörü",
-      "russian": "Социальный фактор"
+      "russian": "Фактор соцсети"
     },
     "socialLogin": {
       "dutch": "Sociale login",
@@ -634,7 +634,7 @@
       "portuguese": "Login social",
       "spanish": "Inicio de sesión social",
       "turkish": "Sosyal medya girişi",
-      "russian": "Социальный вход"
+      "russian": "Вход через соцсети"
     },
     "toast-backup-phase-email-send-success": {
       "dutch": "Back-upzin verzonden naar uw e-mail",
@@ -699,7 +699,7 @@
       "portuguese": "Falha na verificação do compartilhamento de backup",
       "spanish": "Error en la verificación del fragmento de la copia de seguridad",
       "turkish": "Yedekleme parçası doğrulanamadı",
-      "russian": "Не удалось проверить долю резервного копирования"
+      "russian": "Ошибка проверки резервной копии"
     },
     "toast-device-share-delete-fail": {
       "dutch": "Verwijderen van gedeelde apparaat is mislukt",
@@ -712,7 +712,7 @@
       "portuguese": "Falha na exclusão do compartilhamento do dispositivo",
       "spanish": "No se pudo eliminar el fragmento del dispositivo",
       "turkish": "Cihaz şifresi silinemedi",
-      "russian": "Удаление доли устройства не удалось"
+      "russian": "Не удалось удалить доступ к устройству"
     },
     "toast-device-share-delete-success": {
       "dutch": "Apparaat delen succesvol verwijderd",
@@ -725,7 +725,7 @@
       "portuguese": "Compartilhamento de dispositivo excluído com sucesso",
       "spanish": "Fragmento del dispositivo eliminado correctamente",
       "turkish": "Cihaz şifresi başarıyla silindi",
-      "russian": "Доля устройства успешно удалена"
+      "russian": "Доступ к устройству успешно удален"
     },
     "toast-password-change-fail": {
       "dutch": "Wachtwoordwijziging mislukt",
@@ -764,7 +764,7 @@
       "portuguese": "A verificação da senha falhou",
       "spanish": "Falló la verificación de la contraseña",
       "turkish": "Şifre doğrulaması başarısız",
-      "russian": "Проверка пароля не удалась"
+      "russian": "Ошибка проверки пароля"
     },
     "toast-recovery-share-delete-fail": {
       "dutch": "Het verwijderen van de herstelshare is mislukt",
@@ -777,7 +777,7 @@
       "portuguese": "A exclusão do compartilhamento de recuperação falhou",
       "spanish": "Error al eliminar el fragmento de respaldo",
       "turkish": "Kurtarma ifadesi silinemedi",
-      "russian": "Не удалось удалить долю восстановления"
+      "russian": "Не удалось удалить фрагмент восстановления"
     },
     "toast-recovery-share-delete-success": {
       "dutch": "Herstelshare succesvol verwijderd",
@@ -790,7 +790,7 @@
       "portuguese": "Compartilhamento de recuperação excluído com sucesso",
       "spanish": "Fragmento de respaldo eliminado con éxito",
       "turkish": "Kurtarma ifadesi başarıyla silindi",
-      "russian": "Доля восстановления успешно удалена"
+      "russian": "Фрагмент восстановления успешно удалён"
     },
     "toast-registration-failed": {
       "dutch": "Registratie mislukt",
@@ -829,7 +829,7 @@
       "portuguese": "Falha na transferência de compartilhamento",
       "spanish": "Error al transferir el fragmento",
       "turkish": "Şifre parçası transfer edilemedi",
-      "russian": "Передача доли не удалась"
+      "russian": "Передача фрагмента не удалась"
     },
     "toast-something-went-wrong": {
       "dutch": "Er is iets misgegaan",
@@ -868,7 +868,7 @@
       "portuguese": "Verificar",
       "spanish": "Verificar",
       "turkish": "Doğrula",
-      "russian": "Проверить"
+      "russian": "Подтвердить"
     },
     "verify-with-other-factors": {
       "dutch": "Verifiëren met andere factoren",
@@ -881,7 +881,7 @@
       "portuguese": "Verifique com outros fatores",
       "spanish": "Verificar con otros factores",
       "turkish": "Diğer faktörler ile doğrula",
-      "russian": "Проверить другими способами"
+      "russian": "Подтвердить с помощью других факторов"
     },
     "webAuthentication": {
       "dutch": "Webauthenticatie",

--- a/Openlogin-locale/locales-login.json
+++ b/Openlogin-locale/locales-login.json
@@ -10,7 +10,8 @@
       "mandarin": "我们只是想确保您知道如何恢复您的帐户。",
       "portuguese": "Queremos apenas ter certeza de que você sabe como recuperar sua conta.",
       "spanish": "Solo queremos asegurarnos de que sepas cómo recuperar tu cuenta.",
-      "turkish": "Hesabınızı nasıl kurtaracağınızı bildiğinizden emin olmak istiyoruz."
+      "turkish": "Hesabınızı nasıl kurtaracağınızı bildiğinizden emin olmak istiyoruz.",
+      "russian": "Мы просто хотим убедиться, что вы знаете, как восстановить свой аккаунт."
     },
     "2fa-device-save-desc": {
       "dutch": "Gebruik het huidige apparaat als tweede factor om uw portemonnee te verifiëren en te beveiligen",
@@ -22,7 +23,8 @@
       "mandarin": "使用当前设备作为第二个因素来验证和保护你的钱包",
       "portuguese": "Use o dispositivo atual como segundo fator para verificar e proteger sua carteira",
       "spanish": "Use el dispositivo actual como segundo factor para verificar y asegurar su billetera",
-      "turkish": "Cüzdanınızı doğrulamak ve güvenliğini sağlamak için mevcut cihazı 2. faktör olarak kullanın"
+      "turkish": "Cüzdanınızı doğrulamak ve güvenliğini sağlamak için mevcut cihazı 2. faktör olarak kullanın",
+      "russian": "Используйте текущее устройство как второй фактор для подтверждения и защиты вашего кошелька."
     },
     "2fa-device-save-input-label": {
       "dutch": "Dit apparaat opslaan als",
@@ -34,7 +36,8 @@
       "mandarin": "将此设备另存为",
       "portuguese": "Salve este dispositivo como",
       "spanish": "Guardar este dispositivo como",
-      "turkish": "Bu cihazı şu isimle kaydedin:"
+      "turkish": "Bu cihazı şu isimle kaydedin:",
+      "russian": "Сохранить это устройство как"
     },
     "2fa-device-save-success-cta": {
       "dutch": "Herstelfactor instellen",
@@ -46,7 +49,8 @@
       "mandarin": "设置回收率",
       "portuguese": "Fator de recuperação de configuração",
       "spanish": "Configuración del factor de recuperación",
-      "turkish": "Kurtarma Faktörünü ayarla"
+      "turkish": "Kurtarma Faktörünü ayarla",
+      "russian": "Настроить фактор восстановления"
     },
     "2fa-device-save-success-desc": {
       "dutch": "Stel nu uw herstelfactor in om uw account terug te krijgen als u geen toegang meer heeft tot uw tweede factor.",
@@ -58,7 +62,8 @@
       "mandarin": "现在，如果您无法访问第二个因素，请设置您的恢复因素以取回您的帐户。",
       "portuguese": "Agora, caso você perca o acesso ao seu 2º fator, defina seu fator de recuperação para recuperar sua conta.",
       "spanish": "Ahora, en caso de que pierda el acceso a su segundo factor, configure su factor de recuperación para recuperar su cuenta.",
-      "turkish": "2. faktörünüze erişiminizi kaybederseniz, hesabınızı geri almak için kurtarma faktörünüzü ayarlayın."
+      "turkish": "2. faktörünüze erişiminizi kaybederseniz, hesabınızı geri almak için kurtarma faktörünüzü ayarlayın.",
+      "russian": "Если вы потеряете доступ ко второму фактору, настройте фактор восстановления, чтобы вернуть доступ к аккаунту."
     },
     "2fa-device-save-success-title": {
       "dutch": "Uw huidige apparaat is succesvol ingesteld als tweede herstelfactor",
@@ -70,7 +75,8 @@
       "mandarin": "您当前的设备已成功设置为第二个恢复因素",
       "portuguese": "Seu dispositivo atual foi definido com sucesso como um segundo fator de recuperação",
       "spanish": "Su dispositivo actual se configuró correctamente como segundo factor de recuperación",
-      "turkish": "Mevcut cihazınız 2. kurtarma faktörü olarak başarıyla ayarlandı"
+      "turkish": "Mevcut cihazınız 2. kurtarma faktörü olarak başarıyla ayarlandı",
+      "russian": "Текущее устройство успешно установлено как второй фактор восстановления"
     },
     "2fa-device-save-title": {
       "dutch": "Sla uw apparaat op als 2e factor",
@@ -82,7 +88,8 @@
       "mandarin": "将您的设备保存为第二因素",
       "portuguese": "Salve seu dispositivo como 2º fator",
       "spanish": "Guarde su dispositivo como 2º factor",
-      "turkish": "Cihazınızı 2. Faktör olarak kaydedin"
+      "turkish": "Cihazınızı 2. Faktör olarak kaydedin",
+      "russian": "Сохраните устройство как второй фактор"
     },
     "2fa-dwnld-desc": {
       "dutch": "Upload uw herstelfactor om ervoor te zorgen dat het werkt.",
@@ -94,7 +101,8 @@
       "mandarin": "上传您的恢复因子以确保它有效。",
       "portuguese": "Carregue seu Fator de Recuperação para garantir que funcione.",
       "spanish": "Cargue su factor de recuperación para asegurarse de que funcione.",
-      "turkish": "Çalıştığından emin olmak için Kurtarma Faktörünüzü yükleyin."
+      "turkish": "Çalıştığından emin olmak için Kurtarma Faktörünüzü yükleyin.",
+      "russian": "Загрузите фактор восстановления, чтобы убедиться, что он работает."
     },
     "2fa-pwd-desc": {
       "dutch": "Stel een wachtwoord in dat wordt gebruikt om toegang te krijgen tot uw account en dient als herstelfactor.",
@@ -106,7 +114,8 @@
       "mandarin": "设置将用于访问您的帐户并用作恢复因素的密码。",
       "portuguese": "Defina uma senha que será usada para acessar sua conta e servir como Fator de Recuperação.",
       "spanish": "Establezca una contraseña que se utilizará para acceder a su cuenta y servirá como factor de recuperación.",
-      "turkish": "Hesabınıza erişmek için kullanılacak ve Kurtarma Faktörü görevi görecek bir şifre belirleyin."
+      "turkish": "Hesabınıza erişmek için kullanılacak ve Kurtarma Faktörü görevi görecek bir şifre belirleyin.",
+      "russian": "Установите пароль, который будет использоваться для доступа к вашему аккаунту и служить фактором восстановления."
     },
     "2fa-pwd-success-title": {
       "dutch": "Uw wachtwoord is succesvol ingesteld als tweede factor",
@@ -118,7 +127,8 @@
       "mandarin": "您的密码已成功设置为第二因素",
       "portuguese": "Sua senha foi definida com sucesso como 2º Fator",
       "spanish": "Su contraseña se estableció con éxito como un segundo factor",
-      "turkish": "Şifreniz 2. Faktör olarak başarıyla belirlendi"
+      "turkish": "Şifreniz 2. Faktör olarak başarıyla belirlendi",
+      "russian": "Ваш пароль успешно установлен как второй фактор"
     },
     "2fa-pwd-title": {
       "dutch": "Stel wachtwoord in als herstelfactor",
@@ -130,7 +140,8 @@
       "mandarin": "将密码设置为恢复因子",
       "portuguese": "Definir senha como fator de recuperação",
       "spanish": "Establecer contraseña como factor de recuperación",
-      "turkish": "Şifreyi Kurtarma Faktörü olarak ayarla"
+      "turkish": "Şifreyi Kurtarma Faktörü olarak ayarla",
+      "russian": "Установить пароль как фактор восстановления"
     },
     "2fa-recovery-copied-subDesc": {
       "dutch": "Voer de gekopieerde herstelfactor in",
@@ -142,7 +153,8 @@
       "mandarin": "输入复制的恢复因子",
       "portuguese": "Digite o fator de recuperação copiado",
       "spanish": "Introduzca el factor de recuperación copiado",
-      "turkish": "Kopyalanan Kurtarma faktörünü girin"
+      "turkish": "Kopyalanan Kurtarma faktörünü girin",
+      "russian": "Введите скопированный фактор восстановления"
     },
     "2fa-recovery-cpy-subDesc": {
       "dutch": "Voer de herstelzin in die naar {email} is verzonden",
@@ -154,7 +166,8 @@
       "mandarin": "输入发送到 {email} 的恢复短语",
       "portuguese": "Digite a frase de recuperação enviada para {email}",
       "spanish": "Ingrese la frase de recuperación enviada a {email}",
-      "turkish": "{email} adresine gönderilen Kurtarma İfadesini girin"
+      "turkish": "{email} adresine gönderilen Kurtarma İfadesini girin",
+      "russian": "Введите фразу восстановления, отправленную на {email}"
     },
     "2fa-recovery-cpy-subTitle": {
       "dutch": "Herstelfactor verificatie",
@@ -166,7 +179,8 @@
       "mandarin": "采收率验证",
       "portuguese": "Verificação do Fator de Recuperação",
       "spanish": "Verificación del factor de recuperación",
-      "turkish": "Kurtarma Faktörü doğrulaması"
+      "turkish": "Kurtarma Faktörü doğrulaması",
+      "russian": "Проверка фактора восстановления"
     },
     "2fa-recovery-cpy-textArea": {
       "dutch": "Plak uw herstelzin",
@@ -178,7 +192,8 @@
       "mandarin": "粘贴您的恢复短语",
       "portuguese": "Cole sua frase de recuperação",
       "spanish": "Pega tu frase de recuperación",
-      "turkish": "Kurtarma ifadenizi yapıştırın"
+      "turkish": "Kurtarma ifadenizi yapıştırın",
+      "russian": "Вставьте фразу восстановления"
     },
     "2fa-recovery-downloaded-subDesc": {
       "dutch": "Upload de gedownloade herstelfactor",
@@ -190,7 +205,8 @@
       "mandarin": "上传下载的恢复因子",
       "portuguese": "Carregue o fator de recuperação baixado",
       "spanish": "Cargue el factor de recuperación descargado",
-      "turkish": "İndirilen Kurtarma faktörünü yükleyin"
+      "turkish": "İndirilen Kurtarma faktörünü yükleyin",
+      "russian": "Загрузите скачанный фактор восстановления"
     },
     "2fa-recovery-factor-desc": {
       "dutch": "Voer uw e-mailadres in om een herstelfactor voor uw portemonnee te ontvangen. U heeft het nodig om uw portemonnee te herstellen.",
@@ -202,7 +218,8 @@
       "mandarin": "输入您的电子邮件以接收钱包恢复系数。你需要它来恢复你的钱包。",
       "portuguese": "Insira seu e-mail para receber um fator de recuperação da carteira. Você precisa dele para recuperar sua carteira.",
       "spanish": "Introduzca su correo electrónico para recibir el factor de recuperación de su billetera. Lo necesita para recuperar su billetera.",
-      "turkish": "Cüzdan Kurtarma Faktörü almak için e-posta adresinizi girin. Cüzdanınızı kurtarmak için buna ihtiyacınız var."
+      "turkish": "Cüzdan Kurtarma Faktörü almak için e-posta adresinizi girin. Cüzdanınızı kurtarmak için buna ihtiyacınız var.",
+      "russian": "Введите свою почту, чтобы получить фактор восстановления кошелька. Он необходим для восстановления доступа."
     },
     "2fa-recovery-factor-send-btn": {
       "dutch": "Stuur mij mijn herstelfactor",
@@ -214,7 +231,8 @@
       "mandarin": "给我我的恢复因子",
       "portuguese": "Envie-me meu fator de recuperação",
       "spanish": "Envíame mi factor de recuperación",
-      "turkish": "Bana kurtarma faktörümü gönder"
+      "turkish": "Bana kurtarma faktörümü gönder",
+      "russian": "Отправить мне мой фактор восстановления"
     },
     "2fa-recovery-factor-title": {
       "dutch": "Mijn herstelfactor ophalen",
@@ -226,7 +244,8 @@
       "mandarin": "获取我的恢复因子",
       "portuguese": "Obter meu Fator de Recuperação",
       "spanish": "Obtener mi factor de recuperación",
-      "turkish": "Kurtarma Faktörümü al"
+      "turkish": "Kurtarma Faktörümü al",
+      "russian": "Получить мой фактор восстановления"
     },
     "2fa-recovery-success-title": {
       "dutch": "U heeft uw herstelfactor opgeslagen.",
@@ -238,7 +257,8 @@
       "mandarin": "您已保存恢复因子。",
       "portuguese": "Você salvou seu Fator de Recuperação.",
       "spanish": "Ha guardado su factor de recuperación.",
-      "turkish": "Kurtarma Faktörünüzü kaydettiniz."
+      "turkish": "Kurtarma Faktörünüzü kaydettiniz.",
+      "russian": "Вы сохранили свой фактор восстановления"
     },
     "2fa-setup-done-sub1": {
       "dutch": "Ga nu door naar {0}",
@@ -250,7 +270,8 @@
       "mandarin": "立即继续{0}",
       "portuguese": "Prossiga para {0} agora",
       "spanish": "Proceda a {0} ahora",
-      "turkish": "Şimdi {0}'a ilerleyin"
+      "turkish": "Şimdi {0}'a ilerleyin",
+      "russian": "Перейти к {0} сейчас"
     },
     "2fa-setup-done-title1": {
       "dutch": "Uw herstelfactor is ingesteld",
@@ -262,7 +283,8 @@
       "mandarin": "您的恢复因子是设置",
       "portuguese": "Seu fator de recuperação está configurado",
       "spanish": "Su factor de recuperación está configurado",
-      "turkish": "Kurtarma faktörünüz ayarlandı"
+      "turkish": "Kurtarma faktörünüz ayarlandı",
+      "russian": "Фактор восстановления настроен"
     },
     "2fa-setup-step1-cancel": {
       "dutch": "Misschien de volgende keer",
@@ -274,7 +296,8 @@
       "mandarin": "下次吧",
       "portuguese": "Talvez na próxima vez",
       "spanish": "Quizás la próxima vez",
-      "turkish": "Belki başka zaman"
+      "turkish": "Belki başka zaman",
+      "russian": "Может быть, в следующий раз"
     },
     "2fa-setup-step1-desc1": {
       "dutch": "Elke login vereist 2 factoren voor authenticatie",
@@ -286,7 +309,8 @@
       "mandarin": "每次登录需要 2 个身份验证因素",
       "portuguese": "Cada login requer 2 fatores para autenticação",
       "spanish": "Cada inicio de sesión requiere 2 factores para la autenticación",
-      "turkish": "Her oturum açma, kimlik doğrulama için 2 faktör gerektirir"
+      "turkish": "Her oturum açma, kimlik doğrulama için 2 faktör gerektirir",
+      "russian": "Каждый вход требует два фактора для аутентификации"
     },
     "2fa-setup-step1-desc21": {
       "dutch": "We raden ten zeerste een 2FA-instelling aan voor een actieve gebruiker zoals uzelf.",
@@ -298,7 +322,8 @@
       "mandarin": "我们强烈建议为像您这样的活跃用户设置 2FA。",
       "portuguese": "Recomendamos fortemente uma configuração 2FA para um usuário ativo como você.",
       "spanish": "Recomendamos encarecidamente una configuración de 2 factores para un usuario activo como usted.",
-      "turkish": "Sizin gibi aktif bir kullanıcı için 2FA kurulumunu şiddetle tavsiye ediyoruz."
+      "turkish": "Sizin gibi aktif bir kullanıcı için 2FA kurulumunu şiddetle tavsiye ediyoruz.",
+      "russian": "Мы настоятельно рекомендуем настроить двухфакторную аутентификацию для активных пользователей, как вы."
     },
     "2fa-setup-step1-desc22": {
       "dutch": "Stel het in in 3 eenvoudige stappen!",
@@ -310,7 +335,8 @@
       "mandarin": "只需 3 个简单的步骤即可完成设置！",
       "portuguese": "Configure em 3 passos simples!",
       "spanish": "¡Configúrelo en 3 sencillos pasos!",
-      "turkish": "3 basit adımda kurun!"
+      "turkish": "3 basit adımda kurun!",
+      "russian": "Настройте всего за 3 простых шага!"
     },
     "2fa-setup-step1-next": {
       "dutch": "2FA instellen",
@@ -322,7 +348,8 @@
       "mandarin": "设置 2FA",
       "portuguese": "Configurar 2FA",
       "spanish": "Configurar autenticación de 2 factores",
-      "turkish": "2 Faktörlü doğrulamayı kurun"
+      "turkish": "2 Faktörlü doğrulamayı kurun",
+      "russian": "Установите двухфакторную аутентификацию"
     },
     "2fa-setup-step1-sub1": {
       "dutch": "Activeer 2-factor authenticatie (2FA)",
@@ -334,7 +361,8 @@
       "mandarin": "启用 2 因素身份验证 (2FA)",
       "portuguese": "Ativar autenticação de 2 fatores (2FA)",
       "spanish": "Habilitar la autenticación de 2 factores (2FA)",
-      "turkish": "2 Faktörlü Kimlik Doğrulamayı Etkinleştir (2FA)"
+      "turkish": "2 Faktörlü Kimlik Doğrulamayı Etkinleştir (2FA)",
+      "russian": "Включить двухфакторную аутентификацию (2FA)"
     },
     "2fa-setup-step1-sub1-desc": {
       "dutch": "Voeg een extra beveiligingslaag toe aan uw account. Elke login vereist 2 factoren voor authenticatie",
@@ -346,7 +374,8 @@
       "mandarin": "为您的帐户添加额外的安全层，每次登录都需要 2 个因素进行身份验证",
       "portuguese": "Adicione uma camada extra de segurança à sua conta. Cada login requer 2 fatores para autenticação",
       "spanish": "Agregue una capa adicional de seguridad a su cuenta. Cada inicio de sesión requiere 2 factores para la autenticación",
-      "turkish": "Hesabınıza ekstra bir güvenlik katmanı ekleyin. Her oturum açma, kimlik doğrulama için 2 faktör gerektirir"
+      "turkish": "Hesabınıza ekstra bir güvenlik katmanı ekleyin. Her oturum açma, kimlik doğrulama için 2 faktör gerektirir",
+      "russian": "Добавьте дополнительный уровень защиты для вашего аккаунта. Каждый вход требует два фактора для аутентификации"
     },
     "2fa-setup-step1-sub2": {
       "dutch": "Voeg een extra beveiligingslaag toe aan uw account",
@@ -358,7 +387,8 @@
       "mandarin": "为您的帐户添加额外的安全层",
       "portuguese": "Adicione uma camada extra de segurança à sua conta",
       "spanish": "Agregue una capa adicional de seguridad a su cuenta",
-      "turkish": "Hesabınıza ekstra bir güvenlik katmanı ekleyin"
+      "turkish": "Hesabınıza ekstra bir güvenlik katmanı ekleyin",
+      "russian": "Добавьте дополнительный уровень защиты для вашего аккаунта"
     },
     "2fa-setup-step1-sub3": {
       "dutch": "Voeg een extra beveiligingslaag toe aan uw account en bewaar uw activa veilig.",
@@ -370,7 +400,8 @@
       "mandarin": "为您的帐户添加额外的安全层并妥善保管您的资产。",
       "portuguese": "Adicione uma camada extra de segurança à sua conta e proteja seus ativos.",
       "spanish": "Agregue una capa adicional de seguridad a su cuenta y proteja sus activos.",
-      "turkish": "Hesabınıza ekstra bir güvenlik katmanı ekleyin ve varlıklarınızı koruyun."
+      "turkish": "Hesabınıza ekstra bir güvenlik katmanı ekleyin ve varlıklarınızı koruyun.",
+      "russian": "Добавьте дополнительный уровень защиты и сохраните свои активы в безопасности"
     },
     "2fa-setup-step2-cancel": {
       "dutch": "Terug",
@@ -382,7 +413,8 @@
       "mandarin": "后退",
       "portuguese": "Voltar",
       "spanish": "Atrás",
-      "turkish": "Geri"
+      "turkish": "Geri",
+      "russian": "Назад"
     },
     "2fa-setup-step2-confirm-note": {
       "dutch": "Ik begrijp dat het wissen van de browsergeschiedenis en cookies deze factor op mijn browser zal verwijderen.",
@@ -394,7 +426,8 @@
       "mandarin": "我了解清除浏览器历史记录和 cookie 将删除我浏览器上的这个因素。",
       "portuguese": "Entendo que limpar o histórico e os cookies do navegador excluirá esse fator do meu navegador.",
       "spanish": "Entiendo que borrar el historial del navegador y las cookies eliminará este factor en mi navegador.",
-      "turkish": "Tarayıcı geçmişini ve çerezleri temizlemenin tarayıcımdaki bu faktörü sileceğini anlıyorum."
+      "turkish": "Tarayıcı geçmişini ve çerezleri temizlemenin tarayıcımdaki bu faktörü sileceğini anlıyorum.",
+      "russian": "Я понимаю, что очистка истории браузера и файлов cookie приведет к удалению этого фактора в моем браузере."
     },
     "2fa-setup-step2-current-browser": {
       "dutch": "Huidige browser",
@@ -406,7 +439,8 @@
       "mandarin": "当前浏览器",
       "portuguese": "Navegador atual",
       "spanish": "Navegador actual",
-      "turkish": "Mevcut tarayıcı"
+      "turkish": "Mevcut tarayıcı",
+      "russian": "Текущий браузер"
     },
     "2fa-setup-step2-next": {
       "dutch": "Doorgaan",
@@ -418,7 +452,8 @@
       "mandarin": "继续",
       "portuguese": "Continuar",
       "spanish": "Continuar",
-      "turkish": "Devam et"
+      "turkish": "Devam et",
+      "russian": "Продолжить"
     },
     "2fa-setup-step2-save-device": {
       "dutch": "Huidige apparaat opslaan",
@@ -430,7 +465,8 @@
       "mandarin": "保存当前设备",
       "portuguese": "Salvar dispositivo atual",
       "spanish": "Guardar dispositivo actual",
-      "turkish": "Mevcut cihazı kaydet"
+      "turkish": "Mevcut cihazı kaydet",
+      "russian": "Сохранить текущее устройство"
     },
     "2fa-setup-step2-sub1": {
       "dutch": "Instellen met de huidige browser",
@@ -442,7 +478,8 @@
       "mandarin": "使用当前浏览器设置",
       "portuguese": "Configurar usando o navegador atual",
       "spanish": "Configurar usando el navegador actual",
-      "turkish": "Mevcut tarayıcıyı kullanarak kurulum yapın"
+      "turkish": "Mevcut tarayıcıyı kullanarak kurulum yapın",
+      "russian": "Настроить с использованием текущего браузера"
     },
     "2fa-setup-step2-sub2": {
       "dutch": "Gebruik de huidige browser om toegang vanaf nieuwe apparaten/browsers goed te keuren.",
@@ -454,7 +491,8 @@
       "mandarin": "使用当前浏览器批准来自新设备/浏览器的访问。",
       "portuguese": "Use o navegador atual para aprovar o acesso de novos dispositivos/navegadores.",
       "spanish": "Utilice el navegador actual para aprobar el acceso desde nuevos dispositivos / navegadores.",
-      "turkish": "Yeni cihazlardan/tarayıcılardan erişimi onaylamak için mevcut tarayıcıyı kullanın."
+      "turkish": "Yeni cihazlardan/tarayıcılardan erişimi onaylamak için mevcut tarayıcıyı kullanın.",
+      "russian": "Используйте текущий браузер, чтобы одобрить доступ с новых устройств или браузеров."
     },
     "2fa-setup-step3-cancel": {
       "dutch": "Terug",
@@ -466,7 +504,8 @@
       "mandarin": "后退",
       "portuguese": "Voltar",
       "spanish": "atrás",
-      "turkish": "Geri"
+      "turkish": "Geri",
+      "russian": "Назад"
     },
     "2fa-setup-step3-confirm-phrase": {
       "dutch": "Als gevorderde gebruiker weet ik dat als ik deze herstelfrase verlies, ik het risico loop mijn account te verliezen.",
@@ -478,7 +517,8 @@
       "mandarin": "作为高级用户，我知道如果我丢失了此恢复短语，我将承担丢失帐户的风险。",
       "portuguese": "Como usuário avançado, sei que, se perder esta frase de recuperação, corro o risco de perder minha conta.",
       "spanish": "Como usuario avanzado, sé que si pierdo esta frase de recuperación, corro el riesgo de perder mi cuenta.",
-      "turkish": "İleri düzey bir kullanıcı olarak, bu kurtarma ifadesini kaybedersem hesabımı kaybetme riskiyle karşı karşıya olduğumu biliyorum."
+      "turkish": "İleri düzey bir kullanıcı olarak, bu kurtarma ifadesini kaybedersem hesabımı kaybetme riskiyle karşı karşıya olduğumu biliyorum.",
+      "russian": "Как продвинутый пользователь, я понимаю, что потеря фразы восстановления может привести к потере доступа к аккаунту."
     },
     "2fa-setup-step3-copy-phrase": {
       "dutch": "Frase kopiëren",
@@ -490,7 +530,8 @@
       "mandarin": "复制短语",
       "portuguese": "Copiar frase",
       "spanish": "Copiar frase",
-      "turkish": "İfadeyi kopyala"
+      "turkish": "İfadeyi kopyala",
+      "russian": "Скопировать фразу"
     },
     "2fa-setup-step3-download": {
       "dutch": "Download mijn herstelfrase",
@@ -502,7 +543,8 @@
       "mandarin": "下载我的恢复短语",
       "portuguese": "Baixar minha frase de recuperação",
       "spanish": "Descarga mi frase de recuperación",
-      "turkish": "Kurtarma ifademi indir"
+      "turkish": "Kurtarma ifademi indir",
+      "russian": "Скачать фразу восстановления"
     },
     "2fa-setup-step3-download-phrase": {
       "dutch": "Frase downloaden",
@@ -514,7 +556,8 @@
       "mandarin": "下载短语",
       "portuguese": "Baixar frase",
       "spanish": "Descargar frase",
-      "turkish": "İfadeyi indir"
+      "turkish": "İfadeyi indir",
+      "russian": "Скачать фразу"
     },
     "2fa-setup-step3-email": {
       "dutch": "E-mail",
@@ -526,7 +569,8 @@
       "mandarin": "电子邮件",
       "portuguese": "E-mail",
       "spanish": "Correo electrónico",
-      "turkish": "E-posta"
+      "turkish": "E-posta",
+      "russian": "Электронная почта"
     },
     "2fa-setup-step3-enter-email": {
       "dutch": "Voer uw e-mailadres in",
@@ -538,7 +582,8 @@
       "mandarin": "输入你的电子邮箱地址",
       "portuguese": "Insira o seu endereço de email",
       "spanish": "Ingrese su dirección de correo electrónico",
-      "turkish": "E-posta adresinizi girin"
+      "turkish": "E-posta adresinizi girin",
+      "russian": "Введите свой адрес электронной почты"
     },
     "2fa-setup-step3-enter-recovery": {
       "dutch": "Voer uw herstelfrase in",
@@ -550,7 +595,8 @@
       "mandarin": "输入您的辅助短语",
       "portuguese": "Digite sua frase de recuperação",
       "spanish": "Introduce tu frase de recuperación",
-      "turkish": "Kurtarma ifadenizi girin"
+      "turkish": "Kurtarma ifadenizi girin",
+      "russian": "Введите фразу восстановления"
     },
     "2fa-setup-step3-hide-adv": {
       "dutch": "Verberg geavanceerde optie",
@@ -562,7 +608,8 @@
       "mandarin": "隐藏高级选项",
       "portuguese": "Ocultar opção avançada",
       "spanish": "Ocultar opción avanzada",
-      "turkish": "Gelişmiş seçenekleri gizle"
+      "turkish": "Gelişmiş seçenekleri gizle",
+      "russian": "Скрыть расширенные настройки"
     },
     "2fa-setup-step3-manual-save": {
       "dutch": "Sla uw zin handmatig op",
@@ -574,7 +621,8 @@
       "mandarin": "手动保存您的短语",
       "portuguese": "Salve manualmente sua frase",
       "spanish": "Guarde manualmente su frase",
-      "turkish": "İfadenizi manuel olarak kaydedin"
+      "turkish": "İfadenizi manuel olarak kaydedin",
+      "russian": "Сохранить фразу вручную"
     },
     "2fa-setup-step3-next": {
       "dutch": "Doorgaan",
@@ -586,7 +634,8 @@
       "mandarin": "继续",
       "portuguese": "Continuar",
       "spanish": "Continuar",
-      "turkish": "Devam et"
+      "turkish": "Devam et",
+      "russian": "Продолжить"
     },
     "2fa-setup-step3-next1": {
       "dutch": "Voltooi instellingen",
@@ -598,7 +647,8 @@
       "mandarin": "完成设置",
       "portuguese": "Concluir a configuração",
       "spanish": "Terminar de configurar",
-      "turkish": "Kurulumu bitir"
+      "turkish": "Kurulumu bitir",
+      "russian": "Завершить настройку"
     },
     "2fa-setup-step3-next2": {
       "dutch": "Verifiëren",
@@ -610,7 +660,8 @@
       "mandarin": "核实",
       "portuguese": "Verificar",
       "spanish": "Verificar",
-      "turkish": "Doğrula"
+      "turkish": "Doğrula",
+      "russian": "Подтвердить"
     },
     "2fa-setup-step3-next3": {
       "dutch": "Herstelzin verzenden",
@@ -622,7 +673,8 @@
       "mandarin": "发送恢复短语",
       "portuguese": "Enviar frase de recuperação",
       "spanish": "Enviar frase de recuperación",
-      "turkish": "Kurtarma ifadesini gönder"
+      "turkish": "Kurtarma ifadesini gönder",
+      "russian": "Отправить фразу восстановления"
     },
     "2fa-setup-step3-next4": {
       "dutch": "Ik heb mijn herstelfrase opgeslagen",
@@ -634,7 +686,8 @@
       "mandarin": "我已经保存了我的恢复短语",
       "portuguese": "Salvei minha frase de recuperação",
       "spanish": "He guardado mi frase de recuperación",
-      "turkish": "Kurtarma ifademi kaydettim"
+      "turkish": "Kurtarma ifademi kaydettim",
+      "russian": "Я сохранил свою фразу восстановления"
     },
     "2fa-setup-step3-note11": {
       "dutch": "Opmerking:",
@@ -646,7 +699,8 @@
       "mandarin": "笔记：",
       "portuguese": "Observação:",
       "spanish": "Nota:",
-      "turkish": "Not:"
+      "turkish": "Not:",
+      "russian": "Примечание:"
     },
     "2fa-setup-step3-note12": {
       "dutch": "U moet deze zin bevestigen op het volgende scherm",
@@ -658,7 +712,8 @@
       "mandarin": "您需要在下一个屏幕上确认此短语",
       "portuguese": "Você precisará confirmar esta frase na próxima tela",
       "spanish": "Deberá confirmar esta frase en la siguiente pantalla",
-      "turkish": "Bir sonraki ekranda bu ifadeyi onaylamanız gerekecek"
+      "turkish": "Bir sonraki ekranda bu ifadeyi onaylamanız gerekecek",
+      "russian": "Вам нужно будет подтвердить эту фразу на следующем экране"
     },
     "2fa-setup-step3-show-adv": {
       "dutch": "Bekijk geavanceerde optie",
@@ -670,7 +725,8 @@
       "mandarin": "查看高级选项",
       "portuguese": "Ver opção avançada",
       "spanish": "Ver opción avanzada",
-      "turkish": "Gelişmiş seçeneği görüntüle"
+      "turkish": "Gelişmiş seçeneği görüntüle",
+      "russian": "Показать расширенные настройки"
     },
     "2fa-setup-step3-sub1": {
       "dutch": "Geef een e-mailadres op om de herstelfrase te ontvangen",
@@ -682,7 +738,8 @@
       "mandarin": "提供电子邮件以接收恢复短语",
       "portuguese": "Forneça um e-mail para receber a frase de recuperação",
       "spanish": "Proporcione un correo electrónico para recibir la frase de recuperación",
-      "turkish": "Kurtarma ifadenizi almak için bir e-posta girin"
+      "turkish": "Kurtarma ifadenizi almak için bir e-posta girin",
+      "russian": "Укажите адрес электронной почты для получения фразы восстановления"
     },
     "2fa-setup-step3-sub2": {
       "dutch": "Als u geen toegang meer heeft tot uw opgeslagen browser, kunt u zich authenticeren met uw herstelfrase.",
@@ -694,7 +751,8 @@
       "mandarin": "如果您无法访问保存的浏览器，您可以使用恢复短语进行身份验证。",
       "portuguese": "Caso perca o acesso ao seu navegador salvo, você pode autenticar com sua frase de recuperação.",
       "spanish": "En caso de que pierda el acceso a su navegador guardado, puede autenticarse con su frase de recuperación.",
-      "turkish": "Kayıtlı tarayıcınıza erişiminizi kaybetmeniz durumunda, kurtarma ifadenizle kimlik doğrulaması yapabilirsiniz."
+      "turkish": "Kayıtlı tarayıcınıza erişiminizi kaybetmeniz durumunda, kurtarma ifadenizle kimlik doğrulaması yapabilirsiniz.",
+      "russian": "Если вы потеряете доступ к сохранённому браузеру, вы сможете пройти аутентификацию с помощью фразы восстановления."
     },
     "2fa-setup-step3-sub21": {
       "dutch": "Plak uw herstelfrase die naar {0} is verzonden",
@@ -706,7 +764,8 @@
       "mandarin": "粘贴您发送到 {0} 的辅助短语",
       "portuguese": "Cole sua frase de recuperação enviada para {0}",
       "spanish": "Pegue su frase de recuperación enviada a {0}",
-      "turkish": "{0} adresine gönderilen kurtarma ifadenizi yapıştırın"
+      "turkish": "{0} adresine gönderilen kurtarma ifadenizi yapıştırın",
+      "russian": "Вставьте фразу восстановления, отправленную на {0}"
     },
     "2fa-setup-step3-sub22": {
       "dutch": "Ik weet dat als ik deze herstelfrase verlies, ik het risico loop mijn account te verliezen.",
@@ -718,7 +777,8 @@
       "mandarin": "我知道如果我丢失了这个恢复短语，我将承担丢失帐户的风险。",
       "portuguese": "Sei que se eu perder esta frase de recuperação, correrei o risco de perder minha conta.",
       "spanish": "Sé que si pierdo esta frase de recuperación, correré el riesgo de perder mi cuenta.",
-      "turkish": "Bu kurtarma ifadesini kaybedersem hesabımı kaybetme riskini üstleneceğimi biliyorum."
+      "turkish": "Bu kurtarma ifadesini kaybedersem hesabımı kaybetme riskini üstleneceğimi biliyorum.",
+      "russian": "Я понимаю, что если потеряю эту фразу восстановления, то рискую потерять доступ к аккаунту."
     },
     "2fa-setup-step3-toggle1": {
       "dutch": "Mijn herstelfrase opslaan zonder e-mail",
@@ -730,7 +790,8 @@
       "mandarin": "无需电子邮件即可保存我的恢复短语",
       "portuguese": "Salvar minha frase de recuperação sem e-mail",
       "spanish": "Guardar mi frase de recuperación sin correo electrónico",
-      "turkish": "Kurtarma ifademi e-posta olmadan kaydet"
+      "turkish": "Kurtarma ifademi e-posta olmadan kaydet",
+      "russian": "Сохранить мою фразу восстановления без электронной почты"
     },
     "2fa-setup-step3-toggle2": {
       "dutch": "Stuur mijn herstelfrase per e-mail",
@@ -738,11 +799,12 @@
       "french": "Envoyez-moi ma phrase de récupération par e-mail",
       "german": "Senden Sie mir meinen Wiederherstellungssatz per E-Mail",
       "japanese": "私の回復フレーズを私にメールしてください",
-      "korean":  "내 복구 구문을 이메일로 보내기",
+      "korean": "내 복구 구문을 이메일로 보내기",
       "mandarin": "通过电子邮件向我发送恢复短语",
       "portuguese": "Envie-me um e-mail com minha frase de recuperação",
       "spanish": "Envíame mi frase de recuperación por correo electrónico",
-      "turkish": "Kurtarma ifademi bana e-postayla gönder"
+      "turkish": "Kurtarma ifademi bana e-postayla gönder",
+      "russian": "Отправить мою фразу восстановления на почту"
     },
     "2fa-setup-step3-verified": {
       "dutch": "Geverifieerd",
@@ -754,7 +816,8 @@
       "mandarin": "已验证",
       "portuguese": "Verificado",
       "spanish": "Verificado",
-      "turkish": "Doğrulandı"
+      "turkish": "Doğrulandı",
+      "russian": "Подтверждено"
     },
     "2fa-setup-step4-cancel": {
       "dutch": "Terug",
@@ -766,7 +829,8 @@
       "mandarin": "后退",
       "portuguese": "Voltar",
       "spanish": "atrás",
-      "turkish": "Geri"
+      "turkish": "Geri",
+      "russian": "Назад"
     },
     "2fa-setup-step4-check-time": {
       "dutch": "Niet ontvangen? Opnieuw versturen. Controleer opnieuw in {0}",
@@ -778,7 +842,8 @@
       "mandarin": "没有收到吗？ 反感。 再次签入{0}",
       "portuguese": "Não recebeu? Reenviar. Verifique novamente em {0}",
       "spanish": "¿No lo recibiste? Resentirse de. Vuelve a comprobar en {0}",
-      "turkish": "Almadınız mı? Yeniden gönderildi. {0} saniye/dakika sonra tekrar kontrol edin"
+      "turkish": "Almadınız mı? Yeniden gönderildi. {0} saniye/dakika sonra tekrar kontrol edin",
+      "russian": "Не получили? Отправить повторно. Повторная проверка через {0}"
     },
     "2fa-setup-step4-contact-support": {
       "dutch": "Neem contact op met de ondersteuning",
@@ -790,7 +855,8 @@
       "mandarin": "联系支持",
       "portuguese": "Entre em contato com o suporte",
       "spanish": "Soporte de contacto",
-      "turkish": "Destek merkeziyle iletişime geçin"
+      "turkish": "Destek merkeziyle iletişime geçin",
+      "russian": "Связаться с поддержкой"
     },
     "2fa-setup-step4-next": {
       "dutch": "Verifiëren",
@@ -802,7 +868,8 @@
       "mandarin": "核实",
       "portuguese": "Verificar",
       "spanish": "Verificar",
-      "turkish": "Doğrula"
+      "turkish": "Doğrula",
+      "russian": "Подтвердить"
     },
     "2fa-setup-step4-not-received": {
       "dutch": "Niet ontvangen?",
@@ -814,7 +881,8 @@
       "mandarin": "没有收到吗？",
       "portuguese": "Não recebeu?",
       "spanish": "¿No lo recibiste?",
-      "turkish": "Almadınız mı?"
+      "turkish": "Almadınız mı?",
+      "russian": "Не получили?"
     },
     "2fa-setup-step4-recovery": {
       "dutch": "Herstelzin",
@@ -826,7 +894,8 @@
       "mandarin": "恢复短语",
       "portuguese": "Frase de recuperação",
       "spanish": "Frase de recuperación",
-      "turkish": "Kurtarma ifadesi"
+      "turkish": "Kurtarma ifadesi",
+      "russian": "Фраза восстановления"
     },
     "2fa-setup-step4-resend": {
       "dutch": "Opnieuw verzenden",
@@ -838,7 +907,8 @@
       "mandarin": "重发",
       "portuguese": "Reenviar",
       "spanish": "Reenviar",
-      "turkish": "Yeniden gönder"
+      "turkish": "Yeniden gönder",
+      "russian": "Отправить повторно"
     },
     "2fa-setup-step4-sub1": {
       "dutch": "Verifieer uw herstelfrase",
@@ -850,7 +920,8 @@
       "mandarin": "验证您的恢复短语",
       "portuguese": "Verifique sua frase de recuperação",
       "spanish": "Verifica tu frase de recuperación",
-      "turkish": "Kurtarma ifadenizi doğrulayın"
+      "turkish": "Kurtarma ifadenizi doğrulayın",
+      "russian": "Подтвердите свою фразу восстановления"
     },
     "2fa-setup-step4-sub21": {
       "dutch": "Plak de herstelfrase",
@@ -862,7 +933,8 @@
       "mandarin": "粘贴恢复短语",
       "portuguese": "Cole a frase de recuperação",
       "spanish": "Pega la frase de recuperación",
-      "turkish": "Kurtarma ifadesini yapıştırın"
+      "turkish": "Kurtarma ifadesini yapıştırın",
+      "russian": "Вставьте фразу восстановления"
     },
     "2fa-setup-step4-sub22": {
       "dutch": "Plak de herstelzin die naar uw e-mail is gestuurd {0}",
@@ -874,7 +946,8 @@
       "mandarin": "粘贴发送到您的电子邮件的恢复短语 {0}",
       "portuguese": "Cole a frase de recuperação enviada para seu e-mail {0}",
       "spanish": "Pega la frase de recuperación enviada a tu correo electrónico {0}",
-      "turkish": "{0} e-postanıza gönderilen kurtarma ifadesini yapıştırın"
+      "turkish": "{0} e-postanıza gönderilen kurtarma ifadesini yapıştırın",
+      "russian": "Вставьте фразу восстановления, отправленную на вашу почту {0}"
     },
     "2fa-setup-step5-next": {
       "dutch": "Klaar",
@@ -886,7 +959,8 @@
       "mandarin": "完毕",
       "portuguese": "Feito",
       "spanish": "Hecho",
-      "turkish": "Tamamlandı"
+      "turkish": "Tamamlandı",
+      "russian": "Готово"
     },
     "2fa-setup-step5-return-app": {
       "dutch": "Terug naar de applicatie",
@@ -898,7 +972,8 @@
       "mandarin": "返回申请",
       "portuguese": "Voltar ao aplicativo",
       "spanish": "Volver a la aplicación",
-      "turkish": "Uygulamaya geri dön"
+      "turkish": "Uygulamaya geri dön",
+      "russian": "Вернуться в приложение"
     },
     "2fa-setup-step5-sub1": {
       "dutch": "Uw 2FA is geactiveerd!",
@@ -910,7 +985,8 @@
       "mandarin": "您的 2FA 已激活！",
       "portuguese": "Seu 2FA foi ativado!",
       "spanish": "¡Su 2FA ha sido activado!",
-      "turkish": "2FA (Çift Faktörlü Doğrulama) aktive edildi!"
+      "turkish": "2FA (Çift Faktörlü Doğrulama) aktive edildi!",
+      "russian": "Двухфакторная аутентификация активирована!"
     },
     "2fa-setup-step5-sub2": {
       "dutch": "Beheer toekomstige accountinstellingen op app.openlogin.com",
@@ -922,7 +998,8 @@
       "mandarin": "在 app.openlogin.com 上管理未来的帐户设置",
       "portuguese": "Gerencie as configurações futuras da conta em app.openlogin.com",
       "spanish": "Administre la configuración de la cuenta futura en app.openlogin.com",
-      "turkish": "Gelecekteki hesap ayarlarını app.openlogin.com'da yönetin"
+      "turkish": "Gelecekteki hesap ayarlarını app.openlogin.com'da yönetin",
+      "russian": "Управляйте настройками будущего аккаунта на app.openlogin.com"
     },
     "2fa-setup-title1": {
       "dutch": "Beveilig uw account",
@@ -934,7 +1011,8 @@
       "mandarin": "保护您的帐户",
       "portuguese": "Proteja sua conta",
       "spanish": "Asegure su cuenta",
-      "turkish": "Hesabınızı güvence altına alın"
+      "turkish": "Hesabınızı güvence altına alın",
+      "russian": "Защитите свой аккаунт"
     },
     "2fa-setup-title12": {
       "dutch": "Stel 2-factor authenticatie in",
@@ -946,7 +1024,8 @@
       "mandarin": "设置 2 因素身份验证",
       "portuguese": "Configure a autenticação de 2 fatores",
       "spanish": "Configurar autenticación de 2 factores",
-      "turkish": "2 Faktörlü Kimlik doğrulamayı kurun"
+      "turkish": "2 Faktörlü Kimlik doğrulamayı kurun",
+      "russian": "Настройте двухфакторную аутентификацию"
     },
     "2fa-setup-title2": {
       "dutch": "2FA instellen",
@@ -958,7 +1037,8 @@
       "mandarin": "设置 2FA",
       "portuguese": "Configurar 2FA",
       "spanish": "Configurar 2FA",
-      "turkish": "2FA (2 Faktörlü Kimlik doğrulama) kurun"
+      "turkish": "2FA (2 Faktörlü Kimlik doğrulama) kurun",
+      "russian": "Установите двухфакторную аутентификацию"
     },
     "2fa-setup-title21": {
       "dutch": "Stap 1: Sla uw apparaat op",
@@ -970,7 +1050,8 @@
       "mandarin": "第 1 步：保存您的设备",
       "portuguese": "Etapa 1: salve seu dispositivo",
       "spanish": "Paso 1: Guarde su dispositivo",
-      "turkish": "1. Adım: Cihazınızı kaydedin"
+      "turkish": "1. Adım: Cihazınızı kaydedin",
+      "russian": "Шаг 1: Сохраните ваше устройство"
     },
     "2fa-setup-title3": {
       "dutch": "Herstelzin opslaan",
@@ -982,7 +1063,8 @@
       "mandarin": "保存恢复短语",
       "portuguese": "Salvar frase de recuperação",
       "spanish": "Guardar frase de recuperación",
-      "turkish": "Kurtarma ifadesini kaydet"
+      "turkish": "Kurtarma ifadesini kaydet",
+      "russian": "Сохранить фразу восстановления"
     },
     "2fa-setup-title31": {
       "dutch": "Stap 2: Bewaar herstelfrase",
@@ -994,7 +1076,8 @@
       "mandarin": "第 2 步：保存恢复短语",
       "portuguese": "Etapa 2: salvar a frase de recuperação",
       "spanish": "Paso 2: Guarda la frase de recuperación",
-      "turkish": "2. Adım: Kurtarma ifadesini kaydedin"
+      "turkish": "2. Adım: Kurtarma ifadesini kaydedin",
+      "russian": "Шаг 2: Сохраните фразу восстановления"
     },
     "2fa-setup-title32": {
       "dutch": "Stap 3: Verifieer herstelzin",
@@ -1006,7 +1089,8 @@
       "mandarin": "第 3 步：验证恢复短语",
       "portuguese": "Etapa 3: verificar a frase de recuperação",
       "spanish": "Paso 3: Verificar la frase de recuperación",
-      "turkish": "3. Adım: Kurtarma ifadesini doğrulayın"
+      "turkish": "3. Adım: Kurtarma ifadesini doğrulayın",
+      "russian": "Шаг 3: Подтвердите фразу восстановления"
     },
     "2fa-setup-title4": {
       "dutch": "Herstelverificatie",
@@ -1018,7 +1102,8 @@
       "mandarin": "恢复验证",
       "portuguese": "Verificação de recuperação",
       "spanish": "Verificación de recuperación",
-      "turkish": "Kurtarma doğrulaması"
+      "turkish": "Kurtarma doğrulaması",
+      "russian": "Проверка восстановления"
     },
     "2fa-setup-title5": {
       "dutch": "2FA geactiveerd",
@@ -1030,7 +1115,8 @@
       "mandarin": "2FA 激活",
       "portuguese": "2FA ativado",
       "spanish": "2FA activado",
-      "turkish": "2FA aktive edildi"
+      "turkish": "2FA aktive edildi",
+      "russian": "'2FA активирован'"
     },
     "2fa-social-desc": {
       "dutch": "Ga verder met een van de volgende stappen om het als uw herstelfactor in te stellen.",
@@ -1042,7 +1128,8 @@
       "mandarin": "继续执行以下操作之一，将其设置为您的恢复因素。",
       "portuguese": "Continue com um dos seguintes para defini-lo como seu fator de recuperação.",
       "spanish": "Continúe con uno de los siguientes para configurarlo como su factor de recuperación.",
-      "turkish": "Kurtarma faktörünüz olarak ayarlamak için aşağıdakilerden biriyle devam edin."
+      "turkish": "Kurtarma faktörünüz olarak ayarlamak için aşağıdakilerden biriyle devam edin.",
+      "russian": "Продолжите с одним из следующих вариантов, чтобы установить его в качестве фактора восстановления."
     },
     "2fa-social-success-title": {
       "dutch": "Uw sociale factor is succesvol ingesteld als tweede herstelfactor",
@@ -1054,7 +1141,8 @@
       "mandarin": "您的社交因素已成功设置为第二恢复因素",
       "portuguese": "Seu fator social foi configurado com sucesso como um segundo fator de recuperação",
       "spanish": "Su factor social se ha configurado con éxito como un segundo factor de recuperación",
-      "turkish": "Sosyal medya faktörünüz 2. kurtarma faktörü olarak başarıyla kuruldu."
+      "turkish": "Sosyal medya faktörünüz 2. kurtarma faktörü olarak başarıyla kuruldu.",
+      "russian": "Вы успешно настроили социальную сеть как второй способ восстановления"
     },
     "2fa-social-title": {
       "dutch": "Stel een sociaal herstelfactor in",
@@ -1066,7 +1154,8 @@
       "mandarin": "设置社会恢复因素",
       "portuguese": "Configure um fator de recuperação social",
       "spanish": "Configurar un factor de recuperación social",
-      "turkish": "Bir Sosyal Medya kurtarma faktörü oluşturun"
+      "turkish": "Bir Sosyal Medya kurtarma faktörü oluşturun",
+      "russian": "Настройте восстановление через социальную сеть"
     },
     "2fa-verify-multi-head": {
       "dutch": "Toegang toestaan vanuit uw opgeslagen browser",
@@ -1078,7 +1167,8 @@
       "mandarin": "允许从您保存的浏览器访问",
       "portuguese": "Permita o acesso do seu navegador salvo",
       "spanish": "Permitir el acceso desde su navegador guardado",
-      "turkish": "Kayıtlı tarayıcınızdan erişime izin verin"
+      "turkish": "Kayıtlı tarayıcınızdan erişime izin verin",
+      "russian": "Разрешите доступ из сохранённого браузера"
     },
     "2fa-verify-multi-subhead": {
       "dutch": "Log in op de volgende opgeslagen browser om toegang goed te keuren",
@@ -1090,7 +1180,8 @@
       "mandarin": "登录到以下已保存的浏览器以批准访问",
       "portuguese": "Faça login no seguinte navegador salvo para aprovar o acesso",
       "spanish": "Inicie sesión en el siguiente navegador guardado para aprobar el acceso",
-      "turkish": "Erişimi onaylamak için aşağıdaki kayıtlı tarayıcıya giriş yapın"
+      "turkish": "Erişimi onaylamak için aşağıdaki kayıtlı tarayıcıya giriş yapın",
+      "russian": "Войдите в указанный сохранённый браузер, чтобы подтвердить доступ"
     },
     "2fa-verify-multi-subhead2": {
       "dutch": "Een inlogverzoek wordt naar uw opgeslagen browser gestuurd",
@@ -1102,7 +1193,8 @@
       "mandarin": "登录请求将发送到您保存的浏览器",
       "portuguese": "Uma solicitação de login será enviada para o seu navegador salvo",
       "spanish": "Se enviará una solicitud de inicio de sesión a su navegador guardado",
-      "turkish": "Kayıtlı tarayıcınıza bir oturum açma isteği gönderilecektir"
+      "turkish": "Kayıtlı tarayıcınıza bir oturum açma isteği gönderilecektir",
+      "russian": "Запрос на вход будет отправлен в ваш сохранённый браузер"
     },
     "2fa-verify-multi-title": {
       "dutch": "{0} apparaten beschikbaar",
@@ -1114,7 +1206,8 @@
       "mandarin": "{0} 台设备可用",
       "portuguese": "{0} dispositivos disponíveis",
       "spanish": "{0} dispositivos disponibles",
-      "turkish": "{0} cihaz mevcut"
+      "turkish": "{0} cihaz mevcut",
+      "russian": "Доступно устройств: {0}"
     },
     "2fa-verify-recovery-label": {
       "dutch": "Voer herstelfrase in",
@@ -1126,7 +1219,8 @@
       "mandarin": "输入恢复短语",
       "portuguese": "Digite a frase de recuperação",
       "spanish": "Ingrese la frase de recuperación",
-      "turkish": "Kurtarma ifadesini girin"
+      "turkish": "Kurtarma ifadesini girin",
+      "russian": "Введите фразу восстановления"
     },
     "2fa-verify-recovery-note": {
       "dutch": "Als u geen van bovenstaande kunt verifiëren, kunt u niet inloggen op uw account.",
@@ -1138,7 +1232,8 @@
       "mandarin": "如果您无法验证上述任何一项，则无法登录您的帐户。",
       "portuguese": "Se você não conseguir verificar nenhum dos itens acima, não poderá fazer login na sua conta.",
       "spanish": "Si no puede verificar ninguno de los anteriores, no puede iniciar sesión en su cuenta.",
-      "turkish": "Yukarıdakilerden herhangi birini doğrulayamıyorsanız, hesabınıza giriş yapamazsınız."
+      "turkish": "Yukarıdakilerden herhangi birini doğrulayamıyorsanız, hesabınıza giriş yapamazsınız.",
+      "russian": "Если вы не можете подтвердить что-либо из вышеуказанного, вы не сможете войти в свой аккаунт."
     },
     "2fa-verify-recovery-placeholder": {
       "dutch": "Herstelzin",
@@ -1150,7 +1245,8 @@
       "mandarin": "恢复短语",
       "portuguese": "Frase de recuperação",
       "spanish": "Frase de recuperación",
-      "turkish": "Kurtarma ifadesi"
+      "turkish": "Kurtarma ifadesi",
+      "russian": "Фраза восстановления"
     },
     "2fa-verify-recovery-title": {
       "dutch": "Herstelcode",
@@ -1162,7 +1258,8 @@
       "mandarin": "恢复代码",
       "portuguese": "Código de recuperação",
       "spanish": "Código de recuperación",
-      "turkish": "Kurtarma kodu"
+      "turkish": "Kurtarma kodu",
+      "russian": "Код восстановления"
     },
     "2fa-verify-reference-id": {
       "dutch": "Referentie-ID",
@@ -1174,7 +1271,8 @@
       "mandarin": "参考编号",
       "portuguese": "Identificador de referência",
       "spanish": "Identificación de referencia",
-      "turkish": "Referans Kimliği"
+      "turkish": "Referans Kimliği",
+      "russian": "Идентификатор ссылки"
     },
     "2fa-verify-save-head": {
       "dutch": "Account hersteld",
@@ -1186,7 +1284,8 @@
       "mandarin": "帐户已恢复",
       "portuguese": "Conta recuperada",
       "spanish": "Cuenta recuperada",
-      "turkish": "Hesap kurtarıldı"
+      "turkish": "Hesap kurtarıldı",
+      "russian": "Аккаунт восстановлен"
     },
     "2fa-verify-save-nosave": {
       "dutch": "Misschien de volgende keer",
@@ -1198,7 +1297,8 @@
       "mandarin": "下次吧",
       "portuguese": "Talvez na próxima vez",
       "spanish": "Quizás la próxima vez",
-      "turkish": "Belki başka zaman"
+      "turkish": "Belki başka zaman",
+      "russian": "Возможно в следующий раз"
     },
     "2fa-verify-save-save": {
       "dutch": "Dit apparaat opslaan",
@@ -1210,7 +1310,8 @@
       "mandarin": "保存此设备",
       "portuguese": "Salvar este dispositivo",
       "spanish": "Guardar este dispositivo",
-      "turkish": "Bu cihazı kaydet"
+      "turkish": "Bu cihazı kaydet",
+      "russian": "Сохранить это устройство"
     },
     "2fa-verify-save-subhead": {
       "dutch": "Wilt u dit apparaat opslaan als een vertrouwd apparaat?",
@@ -1222,7 +1323,8 @@
       "mandarin": "您想将此设备保存为受信任的设备吗？",
       "portuguese": "Deseja salvar este dispositivo como um dispositivo confiável?",
       "spanish": "¿Le gustaría guardar este dispositivo como dispositivo de confianza?",
-      "turkish": "Bu cihazı güvenilir bir cihaz olarak kaydetmek ister misiniz?"
+      "turkish": "Bu cihazı güvenilir bir cihaz olarak kaydetmek ister misiniz?",
+      "russian": "Вы хотите сохранить это устройство как доверенное?"
     },
     "2fa-verify-share-browser": {
       "dutch": "Browser",
@@ -1234,7 +1336,8 @@
       "mandarin": "浏览器",
       "portuguese": "Navegador",
       "spanish": "Navegador",
-      "turkish": "Tarayıcı"
+      "turkish": "Tarayıcı",
+      "russian": "Браузер"
     },
     "2fa-verify-share-head": {
       "dutch": "Selecteer een van de volgende",
@@ -1246,7 +1349,8 @@
       "mandarin": "选择以下之一",
       "portuguese": "Selecione um dos seguintes",
       "spanish": "Selecciona uno de los siguientes",
-      "turkish": "Birini seçiniz"
+      "turkish": "Birini seçiniz",
+      "russian": "Выберите один из следующих"
     },
     "2fa-verify-share-resend": {
       "dutch": "Verzoek opnieuw verzenden",
@@ -1258,7 +1362,8 @@
       "mandarin": "重新发送请求",
       "portuguese": "Reenviar solicitação",
       "spanish": "Reenviar solicitud",
-      "turkish": "İsteği yeniden gönder"
+      "turkish": "İsteği yeniden gönder",
+      "russian": "Повторить запрос"
     },
     "2fa-verify-share-send": {
       "dutch": "Verzoek versturen",
@@ -1270,7 +1375,8 @@
       "mandarin": "发送请求",
       "portuguese": "Enviar pedido",
       "spanish": "Enviar petición",
-      "turkish": "İstek gönder"
+      "turkish": "İstek gönder",
+      "russian": "Отправить запрос"
     },
     "2fa-verify-share-subhead": {
       "dutch": "U heeft een van de volgende opties nodig om in te loggen",
@@ -1282,7 +1388,8 @@
       "mandarin": "您需要以下其中一项才能登录",
       "portuguese": "Você precisa de um dos seguintes para fazer login",
       "spanish": "Necesita uno de los siguientes para iniciar sesión",
-      "turkish": "Giriş yapmak için aşağıdakilerden birine ihtiyacınız vardır"
+      "turkish": "Giriş yapmak için aşağıdakilerden birine ihtiyacınız vardır",
+      "russian": "Вам нужно одно из следующего для входа в систему."
     },
     "2fa-verify-step1-do-not-save": {
       "dutch": "Sla deze browser/apparaat niet op.",
@@ -1294,7 +1401,8 @@
       "mandarin": "不要保存此浏览器/设备。",
       "portuguese": "Não salve este navegador/dispositivo.",
       "spanish": "No guarde este navegador / dispositivo.",
-      "turkish": "Bu tarayıcıyı/cihazı kaydetmeyin."
+      "turkish": "Bu tarayıcıyı/cihazı kaydetmeyin.",
+      "russian": "Не сохраняйте этот браузер/устройство."
     },
     "2fa-verify-step1-go-app": {
       "dutch": "Ga naar de app",
@@ -1306,7 +1414,8 @@
       "mandarin": "转到应用程序",
       "portuguese": "Vá para o aplicativo",
       "spanish": "Ir a la aplicación",
-      "turkish": "Uygulamaya git"
+      "turkish": "Uygulamaya git",
+      "russian": "Перейти в приложение"
     },
     "2fa-verify-step1-panel1": {
       "dutch": "Opgeslagen browser(s) / apparaten",
@@ -1318,7 +1427,8 @@
       "mandarin": "保存的浏览器/设备",
       "portuguese": "Navegadores/dispositivos salvos",
       "spanish": "Navegadores / dispositivos guardados",
-      "turkish": "Kaydedilen tarayıcı(lar) / cihazlar"
+      "turkish": "Kaydedilen tarayıcı(lar) / cihazlar",
+      "russian": "Сохраненные браузер(ы) / устройства"
     },
     "2fa-verify-step1-panel2": {
       "dutch": "Herstelzin",
@@ -1330,7 +1440,8 @@
       "mandarin": "恢复短语",
       "portuguese": "Frase de recuperação",
       "spanish": "Frase de recuperación",
-      "turkish": "Kurtarma ifadesi"
+      "turkish": "Kurtarma ifadesi",
+      "russian": "Фраза восстановления"
     },
     "2fa-verify-step1-rec-label": {
       "dutch": "Voer herstelfrase in",
@@ -1342,7 +1453,8 @@
       "mandarin": "输入恢复短语",
       "portuguese": "Digite a frase de recuperação",
       "spanish": "Ingrese la frase de recuperación",
-      "turkish": "Kurtarma ifadesini girin"
+      "turkish": "Kurtarma ifadesini girin",
+      "russian": "Введите фразу восстановления"
     },
     "2fa-verify-step1-rec-placeholder": {
       "dutch": "Herstelzin",
@@ -1354,7 +1466,8 @@
       "mandarin": "恢复短语",
       "portuguese": "Frase de recuperação",
       "spanish": "Frase de recuperación",
-      "turkish": "Kurtarma ifadesi"
+      "turkish": "Kurtarma ifadesi",
+      "russian": "Фраза восстановления"
     },
     "2fa-verify-step1-sub1": {
       "dutch": "Authenticeren met een van de volgende",
@@ -1366,7 +1479,8 @@
       "mandarin": "使用以下之一进行身份验证",
       "portuguese": "Autenticar com um dos seguintes",
       "spanish": "Autenticarse con uno de los siguientes",
-      "turkish": "Aşağıdakilerden biriyle kimlik doğrulaması yapın"
+      "turkish": "Aşağıdakilerden biriyle kimlik doğrulaması yapın",
+      "russian": "Авторизуйтесь с помощью одного из следующих"
     },
     "2fa-verify-step1-sub2": {
       "dutch": "U heeft een van de volgende opties nodig om in te loggen",
@@ -1378,7 +1492,8 @@
       "mandarin": "您需要以下其中一项才能登录",
       "portuguese": "Você precisa de um dos seguintes para fazer login",
       "spanish": "Necesita uno de los siguientes para iniciar sesión",
-      "turkish": "Giriş yapmak için aşağıdakilerden birine ihtiyacınız vardır"
+      "turkish": "Giriş yapmak için aşağıdakilerden birine ihtiyacınız vardır",
+      "russian": "Вам нужно одно из следующего для входа в систему."
     },
     "2fa-verify-step1-verify": {
       "dutch": "Verifiëren",
@@ -1390,7 +1505,8 @@
       "mandarin": "核实",
       "portuguese": "Verificar",
       "spanish": "Verificar",
-      "turkish": "Doğrula"
+      "turkish": "Doğrula",
+      "russian": "Проверить"
     },
     "2fa-verify-step2-sub1": {
       "dutch": "Verificatie succesvol",
@@ -1402,7 +1518,8 @@
       "mandarin": "验证成功",
       "portuguese": "Verificação bem-sucedida",
       "spanish": "Verificación exitosa",
-      "turkish": "Başarılı doğrulama"
+      "turkish": "Başarılı doğrulama",
+      "russian": "Успешная верификация"
     },
     "2fa-verify-success-head": {
       "dutch": "Succesvol",
@@ -1414,7 +1531,8 @@
       "mandarin": "成功的",
       "portuguese": "Bem sucedido",
       "spanish": "Exitoso",
-      "turkish": "Başarılı"
+      "turkish": "Başarılı",
+      "russian": "Успешно"
     },
     "2fa-verify-success-subtitle": {
       "dutch": "U wordt ingelogd",
@@ -1426,7 +1544,8 @@
       "mandarin": "登录",
       "portuguese": "Conectando você",
       "spanish": "iniciando sesión",
-      "turkish": "Giriş yapıyorsunuz"
+      "turkish": "Giriş yapıyorsunuz",
+      "russian": "Вход в систему"
     },
     "2fa-verify-success-title": {
       "dutch": "2FA geverifieerd",
@@ -1438,7 +1557,8 @@
       "mandarin": "2FA 验证",
       "portuguese": "2FA verificado",
       "spanish": "2FA verificado",
-      "turkish": "2FA doğrulandı"
+      "turkish": "2FA doğrulandı",
+      "russian": "'2FA подтверждена'"
     },
     "2fa-verify-title1": {
       "dutch": "Verifieer uw login",
@@ -1450,7 +1570,8 @@
       "mandarin": "验证您的登录信息",
       "portuguese": "Verifique seu login",
       "spanish": "Verifique su inicio de sesión",
-      "turkish": "Giriş bilgilerinizi doğrulayın"
+      "turkish": "Giriş bilgilerinizi doğrulayın",
+      "russian": "Проверьте ваш вход в систему"
     },
     "2fa-verify-title2": {
       "dutch": "2FA geactiveerd",
@@ -1458,11 +1579,12 @@
       "french": "2FA activé",
       "german": "2FA aktiviert",
       "japanese": "2FAがアクティブ化",
-      "korean":  "2단계 인증이 활성화되었습니다",
+      "korean": "2단계 인증이 활성화되었습니다",
       "mandarin": "2FA 激活",
       "portuguese": "2FA ativado",
       "spanish": "2FA activado",
-      "turkish": "2FA aktifleştirildi"
+      "turkish": "2FA aktifleştirildi",
+      "russian": "2FA активирован"
     },
     "2fa-verify-try-other": {
       "dutch": "Probeer andere methoden",
@@ -1474,7 +1596,8 @@
       "mandarin": "尝试其他方法",
       "portuguese": "Tente outros métodos",
       "spanish": "Pruebe otros métodos",
-      "turkish": "Diğer yöntemleri deneyin"
+      "turkish": "Diğer yöntemleri deneyin",
+      "russian": "Попробуйте другие методы"
     },
     "2fa-verify-verify": {
       "dutch": "Verifiëren",
@@ -1486,7 +1609,8 @@
       "mandarin": "核实",
       "portuguese": "Verificar",
       "spanish": "Verificar",
-      "turkish": "Doğrula"
+      "turkish": "Doğrula",
+      "russian": "Проверить"
     },
     "accountMismatchSocialFactor": {
       "dutch": "Account komt niet overeen, ga verder met degene die je hebt ingesteld als sociaal herstelfactor",
@@ -1498,7 +1622,8 @@
       "mandarin": "帐户不匹配，请继续将您设置为社会恢复因素",
       "portuguese": "Indatibilidade de conta, continue com um que você definiu como um fator de recuperação social",
       "spanish": "Desacuadado de la cuenta, continúe con uno que establezca como factor de recuperación social",
-      "turkish": "Hesap uyuşmazlığı, lütfen sosyal kurtarma faktörü olarak belirlediğiniz bir hesapla devam edin"
+      "turkish": "Hesap uyuşmazlığı, lütfen sosyal kurtarma faktörü olarak belirlediğiniz bir hesapla devam edin",
+      "russian": "Несоответствие аккаунта, продолжайте с тем, который вы установили как фактор восстановления через соцсети."
     },
     "connect-email": {
       "dutch": "Verbinden met e-mail",
@@ -1510,7 +1635,8 @@
       "mandarin": "连接电子邮件",
       "portuguese": "Conectar com e-mail",
       "spanish": "Conectar con correo electrónico",
-      "turkish": "E-posta ile Bağlanın"
+      "turkish": "E-posta ile Bağlanın",
+      "russian": "Подключиться через электронную почту"
     },
     "connect-phone": {
       "dutch": "Verbinden met telefoon",
@@ -1522,7 +1648,8 @@
       "mandarin": "连接手机",
       "portuguese": "Conectar com telefone",
       "spanish": "Conectar con el teléfono",
-      "turkish": "Telefon ile Bağlanın"
+      "turkish": "Telefon ile Bağlanın",
+      "russian": "Подключиться с телефоном"
     },
     "connect-phone-email": {
       "dutch": "Verbinden met telefoon of e-mail",
@@ -1534,7 +1661,8 @@
       "mandarin": "通过电话或电子邮件联系",
       "portuguese": "Conecte-se com telefone ou e-mail",
       "spanish": "Conectar con teléfono o correo electrónico",
-      "turkish": "Telefon veya E-posta ile Bağlanın"
+      "turkish": "Telefon veya E-posta ile Bağlanın",
+      "russian": "Подключиться с помощью телефона или электронной почты"
     },
     "connect-wallet": {
       "dutch": "Verbinden met portemonnee",
@@ -1546,7 +1674,8 @@
       "mandarin": "连接钱包",
       "portuguese": "Conecte-se com a Carteira",
       "spanish": "Conectar con Monedero",
-      "turkish": "Cüzdan ile Bağlanın"
+      "turkish": "Cüzdan ile Bağlanın",
+      "russian": "Подключиться к кошельку"
     },
     "constructYourKey": {
       "dutch": "Uw sleutel construeren op",
@@ -1558,7 +1687,8 @@
       "mandarin": "构建您的密钥",
       "portuguese": "Construindo sua chave em",
       "spanish": "Construyendo tu clave en",
-      "turkish": "Anahtarınız oluşturuluyor"
+      "turkish": "Anahtarınız oluşturuluyor",
+      "russian": "Создание вашего ключа на"
     },
     "constructYourKeyCustom": {
       "english": "Constructing your key on {0}",
@@ -1567,7 +1697,8 @@
       "korean": "{0}에서 키 생성 중입니다",
       "mandarin": "在{0}上构建密钥",
       "spanish": "Construyendo su clave en {0}",
-      "turkish": "Anahtarınız oluşturuluyor {0}"
+      "turkish": "Anahtarınız oluşturuluyor {0}",
+      "russian": "Создание вашего ключа на {0}"
     },
     "continue-with": {
       "dutch": "Doorgaan met",
@@ -1579,7 +1710,8 @@
       "mandarin": "继续",
       "portuguese": "Continuar com",
       "spanish": "Continua con",
-      "turkish": " Şununla devam et:"
+      "turkish": " Şununla devam et:",
+      "russian": "Продолжить с"
     },
     "edit-phone-number-text": {
       "dutch": "Telefoonnummer bewerken",
@@ -1591,7 +1723,8 @@
       "mandarin": "编辑电话号码",
       "portuguese": "Edite o número de telefone",
       "spanish": "Editar número de teléfono",
-      "turkish": "Telefon numarasını düzenle"
+      "turkish": "Telefon numarasını düzenle",
+      "russian": "Изменить номер телефона"
     },
     "external-wallet": {
       "dutch": "Externe portemonnee",
@@ -1603,7 +1736,8 @@
       "mandarin": "外部钱包",
       "portuguese": "Carteira externa",
       "spanish": "Monedero externo",
-      "turkish": "Harici cüzdan"
+      "turkish": "Harici cüzdan",
+      "russian": "Внешний кошелек"
     },
     "footer-message-login": {
       "dutch": "Zelf-custodial login door Web3Auth",
@@ -1615,7 +1749,8 @@
       "mandarin": "Web3Auth 的自我托管登录",
       "portuguese": "Início de sessão com autocustódia por Web3Auth",
       "spanish": "Inicio de sesión con autocustodia por Web3Auth",
-      "turkish": "Web3Auth tarafından öz-yönetimli giriş"
+      "turkish": "Web3Auth tarafından öz-yönetimli giriş",
+      "russian": "Некастодиальный вход через Web3Auth"
     },
     "incorrectBackupPhrase": {
       "dutch": "Onjuiste back-upzin",
@@ -1627,7 +1762,8 @@
       "mandarin": "备份短语不正确",
       "portuguese": "Frase de backup incorreta",
       "spanish": "Frase de respaldo incorrecta",
-      "turkish": "Hatalı yedekleme ifadesi"
+      "turkish": "Hatalı yedekleme ifadesi",
+      "russian": "Неверная фраза для восстановления"
     },
     "invalid-number-email": {
       "dutch": "Ongeldig e-mailadres of telefoonnummer",
@@ -1639,7 +1775,8 @@
       "mandarin": "无效的电子邮件或电话号码",
       "portuguese": "Email inválido ou número de telefone",
       "spanish": "Correo electrónico o número de teléfono no válido",
-      "turkish": "Geçersiz E-posta veya Telefon Numarası"
+      "turkish": "Geçersiz E-posta veya Telefon Numarası",
+      "russian": "Недействительный адрес электронной почты или номер телефона"
     },
     "invalid-number-error-message": {
       "dutch": "Ongeldig telefoonnummer",
@@ -1651,7 +1788,8 @@
       "mandarin": "无效的电话号码",
       "portuguese": "Número de telefone inválido",
       "spanish": "Numero de telefono invalido",
-      "turkish": "Geçersiz Telefon Numarası"
+      "turkish": "Geçersiz Telefon Numarası",
+      "russian": "Недействительный номер телефона"
     },
     "login-page-desc": {
       "dutch": "Beheer de toegangs- en beveiligingsinstellingen voor alle door Web3Auth ondersteunde toepassingen.",
@@ -1663,7 +1801,8 @@
       "mandarin": "管理 Web3Auth 支持的所有应用程序的访问和安全设置。",
       "portuguese": "Gerencie as configurações de acesso e segurança em todos os aplicativos suportados pelo Web3Auth.",
       "spanish": "Administre la configuración de acceso y seguridad en todas las aplicaciones compatibles con Web3Auth.",
-      "turkish": "Web3Auth tarafından desteklenen tüm uygulamalardaki erişim ve güvenlik ayarlarını yönetin."
+      "turkish": "Web3Auth tarafından desteklenen tüm uygulamalardaki erişim ve güvenlik ayarlarını yönetin.",
+      "russian": "Управляйте настройками доступа и безопасности во всех приложениях, поддерживаемых Web3Auth."
     },
     "login-page-title": {
       "dutch": "Twee-factor portemonnee accountbeheer",
@@ -1675,7 +1814,8 @@
       "mandarin": "两因素钱包账户管理",
       "portuguese": "Gerenciamento de conta de carteira de dois fatores",
       "spanish": "Gestión de cuenta de billetera de dos factores",
-      "turkish": "İki Faktörlü Cüzdan Hesap Yönetimi"
+      "turkish": "İki Faktörlü Cüzdan Hesap Yönetimi",
+      "russian": "Управление кошельком с двухфакторной аутентификацией"
     },
     "migrate-continue": {
       "dutch": "Doorgaan",
@@ -1687,7 +1827,8 @@
       "mandarin": "继续",
       "portuguese": "Continuar",
       "spanish": "Continuar",
-      "turkish": "Devam et"
+      "turkish": "Devam et",
+      "russian": "Продолжить"
     },
     "migrate-desc1": {
       "dutch": "De nieuwste versie van Torus Wallet wordt aangedreven door OpenLogin.",
@@ -1699,7 +1840,8 @@
       "mandarin": "最新版本的Torus Wallet由OpenLogin提供支持。",
       "portuguese": "A versão mais recente do Torus Wallet é fornecida pelo OpenLogin.",
       "spanish": "La última versión de Torus Wallet funciona con OpenLogin.",
-      "turkish": "Torus Wallet'ın en son sürümü OpenLogin tarafından desteklenmektedir."
+      "turkish": "Torus Wallet'ın en son sürümü OpenLogin tarafından desteklenmektedir.",
+      "russian": "Последняя версия кошелька Torus работает на OpenLogin."
     },
     "migrate-desc21": {
       "dutch": "Om te genieten van de nieuwste functies van de Torus Wallet",
@@ -1711,7 +1853,8 @@
       "mandarin": "享受Torus钱包的最新功能",
       "portuguese": "Para aproveitar os recursos mais recentes da Torus Wallet",
       "spanish": "Para disfrutar de las últimas funciones de Torus Wallet",
-      "turkish": "Torus Cüzdan'ın en son özelliklerinden yararlanmak için"
+      "turkish": "Torus Cüzdan'ın en son özelliklerinden yararlanmak için",
+      "russian": "Наслаждаться последними функциями кошелька Torus"
     },
     "migrate-desc22": {
       "dutch": "Verifieer vriendelijk uw identiteit op deze nieuwe versie",
@@ -1723,7 +1866,8 @@
       "mandarin": "请在此新版本上验证您的身份",
       "portuguese": "gentilmente verifique sua identidade nesta nova versão",
       "spanish": "por favor verifique su identidad en esta nueva versión",
-      "turkish": "lütfen bu yeni sürümde kimliğinizi doğrulayın"
+      "turkish": "lütfen bu yeni sürümde kimliğinizi doğrulayın",
+      "russian": "Пожалуйста, подтвердите свою личность в этой новой версии."
     },
     "migrate-list1": {
       "dutch": "Ondersteunt Face ID / Touch ID",
@@ -1735,7 +1879,8 @@
       "mandarin": "支持面部识别/触摸识别",
       "portuguese": "Suporta Face ID / Touch ID",
       "spanish": "Soporta Face ID / Touch ID",
-      "turkish": "Face ID / Touch ID'yi destekler"
+      "turkish": "Face ID / Touch ID'yi destekler",
+      "russian": "Поддерживает Face ID / Touch ID"
     },
     "migrate-list2": {
       "dutch": "Beveiligd door SSO en apparaat",
@@ -1747,7 +1892,8 @@
       "mandarin": "由SSO和设备保护",
       "portuguese": "Protegido por SSO e dispositivo",
       "spanish": "Asegurado por SSO y dispositivo",
-      "turkish": "SSO ve cihaz tarafından güvence altına alınmıştır"
+      "turkish": "SSO ve cihaz tarafından güvence altına alınmıştır",
+      "russian": "Защищено с помощью SSO и устройства"
     },
     "migrate-list3": {
       "dutch": "Beschermde gebruikersgegevens en privacy",
@@ -1759,7 +1905,8 @@
       "mandarin": "受保护的用户数据和隐私",
       "portuguese": "Dados e privacidade protegidos do usuário",
       "spanish": "Privacidad y datos de usuario protegidos",
-      "turkish": "Korunan Kullanıcı Verileri ve Gizlilik"
+      "turkish": "Korunan Kullanıcı Verileri ve Gizlilik",
+      "russian": "Защита данных пользователя и конфиденциальности"
     },
     "migrate-subtitle": {
       "dutch": "Uw tKey migreren",
@@ -1771,7 +1918,8 @@
       "mandarin": "迁移您的tKey",
       "portuguese": "Migrando sua tKey",
       "spanish": "Migrar su tKey",
-      "turkish": "tKey'inizi taşıma"
+      "turkish": "tKey'inizi taşıma",
+      "russian": "Перенос вашего tKey"
     },
     "migrate-title": {
       "dutch": "eenvoudig en veilig gemaakt met",
@@ -1783,7 +1931,8 @@
       "mandarin": "变得简单而安全",
       "portuguese": "simples e seguro com",
       "spanish": "hecho simple y seguro con",
-      "turkish": "Şununla basit ve güvenli hale getirildi: "
+      "turkish": "Şununla basit ve güvenli hale getirildi: ",
+      "russian": "сделано простым и безопасным с помощью"
     },
     "mpc-2fa-setup-step3-download": {
       "dutch": "Download mijn herstelfactor",
@@ -1795,7 +1944,8 @@
       "mandarin": "下载我的恢复因子",
       "portuguese": "Baixar meu fator de recuperação",
       "spanish": "Descargar mi factor de recuperación",
-      "turkish": "Kurtarma faktörümü indir"
+      "turkish": "Kurtarma faktörümü indir",
+      "russian": "Скачайте мой фактор восстановления"
     },
     "mpc-2fa-setup-step3-sub1": {
       "dutch": "Geef een e-mailadres op om het herstelfactor te ontvangen",
@@ -1807,7 +1957,8 @@
       "mandarin": "提供电子邮件以接收恢复短语",
       "portuguese": "Forneça um e-mail para receber o fator de recuperação",
       "spanish": "Proporcione un correo electrónico para recibir la frase de recuperación",
-      "turkish": "Kurtarma faktörünü almak için bir e-posta sağlayın"
+      "turkish": "Kurtarma faktörünü almak için bir e-posta sağlayın",
+      "russian": "Предоставьте электронную почту для получения средства восстановления"
     },
     "mpc-2fa-setup-step3-sub2": {
       "dutch": "Als u geen toegang meer heeft tot uw opgeslagen browser, kunt u zich authenticeren met uw herstelfactor.",
@@ -1819,7 +1970,8 @@
       "mandarin": "如果您无法访问保存的浏览器，您可以使用恢复短语进行身份验证。",
       "portuguese": "Caso perca o acesso ao seu navegador salvo, você pode autenticar com seu fator de recuperação.",
       "spanish": "En caso de que pierda el acceso a su navegador guardado, puede autenticarse con su frase de recuperación.",
-      "turkish": "Kayıtlı tarayıcınıza erişiminizi kaybetmeniz durumunda, kurtarma faktörünüzle kimlik doğrulaması yapabilirsiniz."
+      "turkish": "Kayıtlı tarayıcınıza erişiminizi kaybetmeniz durumunda, kurtarma faktörünüzle kimlik doğrulaması yapabilirsiniz.",
+      "russian": "В случае, если вы потеряете доступ к сохраненному браузеру, вы можете аутентифицироваться с помощью вашего восстановительного фактора."
     },
     "mpc-2fa-setup-step4-recovery": {
       "dutch": "Herstelfactor",
@@ -1831,7 +1983,8 @@
       "mandarin": "恢复系数",
       "portuguese": "Fator de recuperação",
       "spanish": "Factor de recuperación",
-      "turkish": "Kurtarma faktörü"
+      "turkish": "Kurtarma faktörü",
+      "russian": "Коэффициент восстановления"
     },
     "mpc-2fa-setup-step4-sub1": {
       "dutch": "Verifieer uw herstelfactor",
@@ -1843,7 +1996,8 @@
       "mandarin": "验证您的恢复系数",
       "portuguese": "Verifique seu fator de recuperação",
       "spanish": "Verifique su factor de recuperación",
-      "turkish": "Kurtarma faktörünüzü doğrulayın"
+      "turkish": "Kurtarma faktörünüzü doğrulayın",
+      "russian": "Проверьте ваш фактор восстановления"
     },
     "mpc-2fa-setup-step4-sub21": {
       "dutch": "Plak het herstelfactor",
@@ -1855,7 +2009,8 @@
       "mandarin": "粘贴恢复因子",
       "portuguese": "Cole o fator de recuperação",
       "spanish": "Pegar el factor de recuperación",
-      "turkish": "Kurtarma faktörünü yapıştır"
+      "turkish": "Kurtarma faktörünü yapıştır",
+      "russian": "Вставьте фактор восстановления"
     },
     "mpc-2fa-setup-step4-sub22": {
       "dutch": "Plak de herstelfactor die naar uw e-mail {0} is gestuurd",
@@ -1867,7 +2022,8 @@
       "mandarin": "粘贴发送到您的电子邮件 {0} 的恢复因素",
       "portuguese": "Cole o fator de recuperação enviado para seu e-mail {0}",
       "spanish": "Pegue el factor de recuperación enviado a su correo electrónico {0}",
-      "turkish": "{0} e-postanıza gönderilen kurtarma faktörünü yapıştırın"
+      "turkish": "{0} e-postanıza gönderilen kurtarma faktörünü yapıştırın",
+      "russian": "Вставьте восстановительный фактор, отправленный на вашу электронную почту {0}"
     },
     "mpc-2fa-setup-title3": {
       "dutch": "Herstelfactor opslaan",
@@ -1879,7 +2035,8 @@
       "mandarin": "保存恢复短语",
       "portuguese": "Salvar fator de recuperação",
       "spanish": "Guardar frase de recuperación",
-      "turkish": "Kurtarma faktörünü kaydet"
+      "turkish": "Kurtarma faktörünü kaydet",
+      "russian": "Сохранить фактор восстановления"
     },
     "mpc-2fa-verify-step1-panel2": {
       "dutch": "Herstelfactor",
@@ -1891,7 +2048,8 @@
       "mandarin": "恢复系数",
       "portuguese": "Fator de recuperação",
       "spanish": "Factor de recuperación",
-      "turkish": "Kurtarma faktörü"
+      "turkish": "Kurtarma faktörü",
+      "russian": "Фактор восстановления"
     },
     "mpc-2fa-verify-step1-rec-label": {
       "dutch": "Voer herstelfactor in",
@@ -1903,7 +2061,8 @@
       "mandarin": "输入恢复系数",
       "portuguese": "Insira o fator de recuperação",
       "spanish": "Ingrese el factor de recuperación",
-      "turkish": "Kurtarma faktörünü girin"
+      "turkish": "Kurtarma faktörünü girin",
+      "russian": "Введите фактор восстановления"
     },
     "mpc-2fa-verify-step1-rec-placeholder": {
       "dutch": "Herstelfactor",
@@ -1915,7 +2074,8 @@
       "mandarin": "恢复系数",
       "portuguese": "Fator de recuperação",
       "spanish": "Factor de recuperación",
-      "turkish": "Kurtarma faktörü"
+      "turkish": "Kurtarma faktörü",
+      "russian": "Фактор восстановления"
     },
     "otp-verification-response-expired": {
       "dutch": "OTP verlopen",
@@ -1927,7 +2087,8 @@
       "mandarin": "OTP过期",
       "portuguese": "OTP expirou",
       "spanish": "OTP expiró",
-      "turkish": "OTP Süresi Doldu"
+      "turkish": "OTP Süresi Doldu",
+      "russian": "Одноразовый пароль истек"
     },
     "otp-verification-response-invalid": {
       "dutch": "Ongeldige OTP",
@@ -1939,7 +2100,8 @@
       "mandarin": "无效的OTP",
       "portuguese": "OTP inválido",
       "spanish": "OTP no válido",
-      "turkish": "Geçersiz OTP"
+      "turkish": "Geçersiz OTP",
+      "russian": "Недействительный OTP"
     },
     "otp-verification-response-success": {
       "dutch": "OTP geverifieerd",
@@ -1951,7 +2113,8 @@
       "mandarin": "已验证OTP",
       "portuguese": "OTP Verificado",
       "spanish": "OTP verificado",
-      "turkish": "OTP doğrulandı"
+      "turkish": "OTP doğrulandı",
+      "russian": "OTP подтвержден"
     },
     "pageReloadWarning": {
       "dutch": "Gelieve de pagina niet opnieuw te laden.",
@@ -1963,7 +2126,8 @@
       "mandarin": "请不要重新加载页面",
       "portuguese": "Por favor, não recarregue a página.",
       "spanish": "Por favor, no vuelva a cargar la página.",
-      "turkish": "Lütfen sayfayı yenilemeyin."
+      "turkish": "Lütfen sayfayı yenilemeyin.",
+      "russian": "Пожалуйста, не перезагружайте страницу."
     },
     "password-verification": {
       "dutch": "Wachtwoordverificatie",
@@ -1975,7 +2139,8 @@
       "mandarin": "密码验证",
       "portuguese": "verificação de senha",
       "spanish": "Verificación de contraseña",
-      "turkish": "Şifre doğrulama"
+      "turkish": "Şifre doğrulama",
+      "russian": "Проверка пароля"
     },
     "password-verification-desc": {
       "dutch": "Voer uw herstelwachtwoord in om te verifiëren",
@@ -1987,7 +2152,8 @@
       "mandarin": "输入您的恢复密码进行验证",
       "portuguese": "Digite sua senha de recuperação para verificar",
       "spanish": "Ingrese su contraseña de recuperación para verificar",
-      "turkish": "Doğrulamak için kurtarma şifrenizi girin"
+      "turkish": "Doğrulamak için kurtarma şifrenizi girin",
+      "russian": "Введите ваш пароль восстановления для проверки"
     },
     "pasteRecoveryFactor": {
       "dutch": "Plak alsjeblieft je herstelfactor",
@@ -1999,7 +2165,8 @@
       "mandarin": "请粘贴您的恢复因素",
       "portuguese": "Cole o seu fator de recuperação",
       "spanish": "Pegue su factor de recuperación",
-      "turkish": "Lütfen kurtarma faktörünüzü yapıştırın"
+      "turkish": "Lütfen kurtarma faktörünüzü yapıştırın",
+      "russian": "Пожалуйста, вставьте ваш фактор восстановления."
     },
     "phone-email-label": {
       "dutch": "Telefoon of e-mail",
@@ -2011,7 +2178,8 @@
       "mandarin": "电话还是邮件",
       "portuguese": "Telefone ou email",
       "spanish": "Teléfono o correo electrónico",
-      "turkish": "Telefon veya E-posta"
+      "turkish": "Telefon veya E-posta",
+      "russian": "Телефон или Электронная почта"
     },
     "popup-already": {
       "dutch": "Heb je al een account?",
@@ -2023,7 +2191,8 @@
       "mandarin": "已经有账户？",
       "portuguese": "Já possui uma conta?",
       "spanish": "¿Ya tienes una cuenta?",
-      "turkish": "Zaten bir hesabınız var mı?"
+      "turkish": "Zaten bir hesabınız var mı?",
+      "russian": "Уже есть аккаунт?"
     },
     "popup-continue": {
       "dutch": "Doorgaan",
@@ -2035,7 +2204,8 @@
       "mandarin": "继续",
       "portuguese": "Continuar",
       "spanish": "Continuar",
-      "turkish": "Devam et"
+      "turkish": "Devam et",
+      "russian": "Продолжить"
     },
     "popup-continue-existing": {
       "dutch": "Doorgaan met bestaande {0}",
@@ -2047,7 +2217,8 @@
       "mandarin": "继续使用现有的{0}",
       "portuguese": "Continuar com {0} existente",
       "spanish": "Continuar con {0} existente",
-      "turkish": "Mevcut {0} ile devam edin"
+      "turkish": "Mevcut {0} ile devam edin",
+      "russian": "Продолжить с существующим {0}"
     },
     "popup-here": {
       "dutch": "hier",
@@ -2059,7 +2230,8 @@
       "mandarin": "这里",
       "portuguese": "aqui",
       "spanish": "aquí",
-      "turkish": "Burada"
+      "turkish": "Burada",
+      "russian": "здесь"
     },
     "popup-manage": {
       "dutch": "Account beheren",
@@ -2071,7 +2243,8 @@
       "mandarin": "管理帐户",
       "portuguese": "Gerenciar conta",
       "spanish": "Administrar cuenta",
-      "turkish": "Hesabı yönet"
+      "turkish": "Hesabı yönet",
+      "russian": "Управление аккаунтом"
     },
     "popup-privacy": {
       "dutch": "Privacybeleid",
@@ -2083,7 +2256,8 @@
       "mandarin": "隐私政策",
       "portuguese": "Política de Privacidade",
       "spanish": "Política de privacidad",
-      "turkish": "Gizlilik Politikası"
+      "turkish": "Gizlilik Politikası",
+      "russian": "Политика конфиденциальности"
     },
     "popup-subtitle": {
       "dutch": "Selecteer hoe u verder wilt gaan",
@@ -2095,7 +2269,8 @@
       "mandarin": "选择您想继续的方式",
       "portuguese": "Selecione como você gostaria de continuar",
       "spanish": "Seleccione cómo le gustaría continuar",
-      "turkish": "Nasıl devam etmek istediğinizi seçin"
+      "turkish": "Nasıl devam etmek istediğinizi seçin",
+      "russian": "Выберите, как вы хотели бы продолжить"
     },
     "popup-terms": {
       "dutch": "Gebruiksvoorwaarden",
@@ -2107,7 +2282,8 @@
       "mandarin": "使用条款",
       "portuguese": "Termos de uso",
       "spanish": "Condiciones de uso",
-      "turkish": "Kullanım Şartları"
+      "turkish": "Kullanım Şartları",
+      "russian": "Условия использования"
     },
     "popup-title": {
       "dutch": "Welkom aan boord",
@@ -2119,7 +2295,8 @@
       "mandarin": "欢迎登机",
       "portuguese": "Bem-vindo a bordo",
       "spanish": "La bienvenida a bordo",
-      "turkish": "Hoş geldiniz"
+      "turkish": "Hoş geldiniz",
+      "russian": "Добро пожаловать на борт"
     },
     "popup-view-less": {
       "dutch": "Minder opties bekijken",
@@ -2131,7 +2308,8 @@
       "mandarin": "查看较少的选项",
       "portuguese": "Ver menos opções",
       "spanish": "Ver menos opciones",
-      "turkish": "Daha az seçenek görüntüle"
+      "turkish": "Daha az seçenek görüntüle",
+      "russian": "Посмотреть меньше опций"
     },
     "popup-view-more": {
       "dutch": "Meer opties bekijken",
@@ -2143,7 +2321,8 @@
       "mandarin": "查看更多选项",
       "portuguese": "Ver mais opções",
       "spanish": "Ver más opciones",
-      "turkish": "Daha fazla seçenek görüntüle"
+      "turkish": "Daha fazla seçenek görüntüle",
+      "russian": "Посмотреть больше опций"
     },
     "reconstruct-always-skip": {
       "dutch": "Altijd overslaan",
@@ -2155,7 +2334,8 @@
       "mandarin": "总是跳过",
       "portuguese": "Sempre pular",
       "spanish": "Saltar siempre",
-      "turkish": "Her zaman atlayın"
+      "turkish": "Her zaman atlayın",
+      "russian": "Всегда пропускай"
     },
     "reconstruct-always-skip-note": {
       "dutch": "Door 'Altijd overslaan' te selecteren, wordt u niet gevraagd om opnieuw in te loggen op uw OpenLogin-account. Als u van gedachten verandert, kunt u deze voorkeur op elk moment wijzigen in 'Instellingen'.",
@@ -2167,7 +2347,8 @@
       "mandarin": "通过选择“始终跳过”，您将不会收到再次登录 OpenLogin 帐户的提示。 如果您改变主意，您可以随时在“设置”中更改此首选项。",
       "portuguese": "Ao selecionar 'Sempre pular', você não será solicitado a fazer login na sua conta OpenLogin novamente. Se mudar de ideia, você pode alterar essa preferência a qualquer momento em 'Configurações'.",
       "spanish": "Si selecciona 'Omitir siempre', no se le pedirá que vuelva a iniciar sesión en su cuenta de OpenLogin. Si cambia de opinión, puede cambiar esta preferencia en cualquier momento en 'Configuración'.",
-      "turkish": "'Her zaman atla' seçeneğini seçtiğinizde, OpenLogin hesabınıza tekrar giriş yapmanız istenmeyecektir. Fikrinizi değiştirirseniz, bu tercihi istediğiniz zaman 'Ayarlar'dan değiştirebilirsiniz."
+      "turkish": "'Her zaman atla' seçeneğini seçtiğinizde, OpenLogin hesabınıza tekrar giriş yapmanız istenmeyecektir. Fikrinizi değiştirirseniz, bu tercihi istediğiniz zaman 'Ayarlar'dan değiştirebilirsiniz.",
+      "russian": "Выбрав \"Всегда пропускать\", вы больше не будете получать запрос на вход в свой аккаунт OpenLogin. Если вы передумаете, вы можете изменить это предпочтение в любое время в разделе \"Настройки\"."
     },
     "reconstruct-backup-phrase-desc": {
       "dutch": "Voer de back-upzin in die eerder naar uw herstel-e-mail is verzonden.",
@@ -2179,7 +2360,8 @@
       "mandarin": "输入先前发送到您的辅助邮箱的备份短语。",
       "portuguese": "Digite a frase de backup enviada para seu e-mail de recuperação anteriormente.",
       "spanish": "Ingrese la frase de respaldo enviada a su correo electrónico de recuperación anteriormente.",
-      "turkish": "Daha önce kurtarma e-postanıza gönderilen yedekleme ifadesini girin."
+      "turkish": "Daha önce kurtarma e-postanıza gönderilen yedekleme ifadesini girin.",
+      "russian": "Введите фразу восстановления, которую ранее отправили на вашу почту для восстановления."
     },
     "reconstruct-backup-phrase-desc-2": {
       "dutch": "Verifieer met uw back-upzin die is ingesteld op",
@@ -2191,7 +2373,8 @@
       "mandarin": "确认已设置的备份集",
       "portuguese": "Verifique com sua frase de recuperação que foi configurada em",
       "spanish": "Compruebe el conjunto de copia de seguridad establecido",
-      "turkish": "Şunun üzerinde ayarlanmış olan yedekleme ifadenizle doğrulayın"
+      "turkish": "Şunun üzerinde ayarlanmış olan yedekleme ifadenizle doğrulayın",
+      "russian": "Проверьте с помощью вашей фразы врсстановления, которая была настроена на"
     },
     "reconstruct-backup-phrase-desc-3": {
       "dutch": "en verzonden naar e-mail:",
@@ -2203,7 +2386,8 @@
       "mandarin": "并发送到电子邮件：",
       "portuguese": "e enviado para o e-mail:",
       "spanish": "y enviado al correo electrónico:",
-      "turkish": "ve e-postaya gönderildi:"
+      "turkish": "ve e-postaya gönderildi:",
+      "russian": "и отправлено на электронную почту:"
     },
     "reconstruct-backup-phrase-placeholder": {
       "dutch": "Voer de back-upzin in",
@@ -2215,7 +2399,8 @@
       "mandarin": "输入备用词组",
       "portuguese": "Digite a frase de backup",
       "spanish": "Ingrese la frase de respaldo",
-      "turkish": "Yedekleme ifadesini girin"
+      "turkish": "Yedekleme ifadesini girin",
+      "russian": "Введите фразу восстановления"
     },
     "reconstruct-backup-phrase-title": {
       "dutch": "Back-up zin",
@@ -2227,7 +2412,8 @@
       "mandarin": "备用词组",
       "portuguese": "Frase de backup",
       "spanish": "Frase de respaldo",
-      "turkish": "Yedekleme ifadesi"
+      "turkish": "Yedekleme ifadesi",
+      "russian": "Фраза восстановления"
     },
     "reconstruct-biometrics-desc": {
       "dutch": "* Alleen voor Touch ID / Face ID die eerder zijn ingesteld op de volgende apparaat(s):",
@@ -2239,7 +2425,8 @@
       "mandarin": "*仅适用于先前在以下设备上设置的Touch ID / Face ID：",
       "portuguese": "* Apenas para Touch ID / Face ID previamente configurado no(s) seguinte(s) dispositivo(s):",
       "spanish": "* Solo para Touch ID / Face ID configurado previamente en los siguientes dispositivos:",
-      "turkish": "* Yalnızca aşağıdaki cihaz(lar)da önceden ayarlanmış Touch ID / Face ID için:"
+      "turkish": "* Yalnızca aşağıdaki cihaz(lar)da önceden ayarlanmış Touch ID / Face ID için:",
+      "russian": "* Только для Touch ID / Face ID, ранее настроенных на следующем(их) устройстве(ах):"
     },
     "reconstruct-biometrics-title": {
       "dutch": "Apparaat(en) met Face ID / Touch ID-ondersteuning*",
@@ -2251,7 +2438,8 @@
       "mandarin": "支持面部识别/触摸识别的设备*",
       "portuguese": "Dispositivo(s) habilitado(s) para Face ID / Touch ID*",
       "spanish": "Dispositivos habilitados con Face ID / Touch ID *",
-      "turkish": "Face ID / Touch ID özellikli cihaz(lar) *"
+      "turkish": "Face ID / Touch ID özellikli cihaz(lar) *",
+      "russian": "Устройство(а) с включенной функцией Face ID / Touch ID *"
     },
     "reconstruct-biometrics-verify": {
       "dutch": "Verifiëren met Touch ID / Face ID",
@@ -2263,7 +2451,8 @@
       "mandarin": "使用Touch ID / Face ID进行验证",
       "portuguese": "Verificar com Touch ID / Face ID",
       "spanish": "Verificar con Touch ID / Face ID",
-      "turkish": "Touch ID / Face ID ile doğrulama"
+      "turkish": "Touch ID / Face ID ile doğrulama",
+      "russian": "Подтвердите с помощью Touch ID / Face ID"
     },
     "reconstruct-device-desc": {
       "dutch": "Log in op {0} vanuit de opgeslagen browser hieronder om uw identiteit te verifiëren.",
@@ -2275,7 +2464,8 @@
       "mandarin": "从下面存储的浏览器登录到{0}以验证您的身份。",
       "portuguese": "Faça login em {0} no navegador armazenado abaixo para verificar sua identidade.",
       "spanish": "Inicie sesión en {0} desde el navegador almacenado a continuación para verificar su identidad.",
-      "turkish": "Kimliğinizi doğrulamak için aşağıdaki kayıtlı tarayıcıdan {0}'a giriş yapın."
+      "turkish": "Kimliğinizi doğrulamak için aşağıdaki kayıtlı tarayıcıdan {0}'a giriş yapın.",
+      "russian": "Войдите в {0} из сохраненного ниже браузера, чтобы подтвердить свою личность."
     },
     "reconstruct-device-desc1": {
       "dutch": "Inloggen op",
@@ -2287,7 +2477,8 @@
       "mandarin": "登录到",
       "portuguese": "Logar em",
       "spanish": "Iniciar sesión en",
-      "turkish": "Giriş yapmak için"
+      "turkish": "Giriş yapmak için",
+      "russian": "Войдите в"
     },
     "reconstruct-device-desc2": {
       "dutch": "van een van de volgende apparaten om de beveiligingsverificatie te voltooien.",
@@ -2299,7 +2490,8 @@
       "mandarin": "从以下任何设备中完成安全性验证。",
       "portuguese": "de qualquer um dos seguintes dispositivos para concluir a verificação de segurança.",
       "spanish": "desde cualquiera de los siguientes dispositivos para completar la verificación de seguridad.",
-      "turkish": "Güvenlik doğrulamasını tamamlamak için aşağıdaki cihazlardan herhangi birinden"
+      "turkish": "Güvenlik doğrulamasını tamamlamak için aşağıdaki cihazlardan herhangi birinden",
+      "russian": "с любого из следующих устройств для завершения проверки безопасности."
     },
     "reconstruct-device-prev1": {
       "dutch": "Log in op uw",
@@ -2311,7 +2503,8 @@
       "mandarin": "登录到您的",
       "portuguese": "Entre no seu",
       "spanish": "Inicie sesión en su",
-      "turkish": "Giriş yapın"
+      "turkish": "Giriş yapın",
+      "russian": "Войдите в ваш"
     },
     "reconstruct-device-prev2": {
       "dutch": "vorige versie van de Torus Wallet",
@@ -2323,7 +2516,8 @@
       "mandarin": "Torus钱包的先前版本",
       "portuguese": "versão anterior da Torus Wallet",
       "spanish": "versión anterior de Torus Wallet",
-      "turkish": "Torus Cüzdan'ın önceki sürümü"
+      "turkish": "Torus Cüzdan'ın önceki sürümü",
+      "russian": "предыдущая версия кошелька Torus"
     },
     "reconstruct-device-prev3": {
       "dutch": "van de opgeslagen browser hieronder om uw identiteit te verifiëren.",
@@ -2335,7 +2529,8 @@
       "mandarin": "从下面存储的浏览器中验证您的身份。",
       "portuguese": "do navegador armazenado abaixo para verificar sua identidade.",
       "spanish": "desde el navegador almacenado a continuación para verificar su identidad.",
-      "turkish": "kimliğinizi doğrulamak için aşağıdaki kayıtlı tarayıcıdan"
+      "turkish": "kimliğinizi doğrulamak için aşağıdaki kayıtlı tarayıcıdan",
+      "russian": "Из сохраненного браузера ниже для проверки вашей личности."
     },
     "reconstruct-device-title": {
       "dutch": "Appara(a)t(en)",
@@ -2347,7 +2542,8 @@
       "mandarin": "设备",
       "portuguese": "Dispositivo(s)",
       "spanish": "Dispositivos",
-      "turkish": "Cihaz(lar)"
+      "turkish": "Cihaz(lar)",
+      "russian": "Устройство(а)"
     },
     "reconstruct-fail": {
       "dutch": "Kan account niet herstellen?",
@@ -2359,7 +2555,8 @@
       "mandarin": "无法找回帐户？",
       "portuguese": "Não é possível recuperar a conta?",
       "spanish": "¿No puede recuperar la cuenta?",
-      "turkish": "Hesap kurtarılamıyor mu?"
+      "turkish": "Hesap kurtarılamıyor mu?",
+      "russian": "Не удается восстановить аккаунт?"
     },
     "reconstruct-multiple-transports-desc": {
       "dutch": "Alleen voor webauthenticatiemethoden die eerder zijn ingesteld op de volgende apparaat(s)",
@@ -2367,11 +2564,12 @@
       "french": "Uniquement pour les méthodes d'authentification Web qui ont été précédemment configurées sur le(s) appareil(s) suivant(s)",
       "german": "Nur für Webauthentifizierungsmethoden, die zuvor auf den folgenden Geräten eingerichtet wurden (en)",
       "japanese": "以前に次のデバイスに設定されたWeb認証方法のみ",
-      "korean":  "다음 기기에서 이전에 설정된 웹 인증 수단에만 해당됩니다",
+      "korean": "다음 기기에서 이전에 설정된 웹 인증 수단에만 해당됩니다",
       "mandarin": "仅对于以前在以下设备上设置的Web身份验证方法",
       "portuguese": "Apenas para métodos de autenticação da web que foram configurados anteriormente no(s) seguinte(s) dispositivo(s)",
       "spanish": "Solo para métodos de autenticación web que se configuraron previamente en los siguientes dispositivos",
-      "turkish": "Yalnızca aşağıdaki cihaz(lar)da daha önce ayarlanmış olan web kimlik doğrulama yöntemleri için"
+      "turkish": "Yalnızca aşağıdaki cihaz(lar)da daha önce ayarlanmış olan web kimlik doğrulama yöntemleri için",
+      "russian": "Только для методов веб-аутентификации, которые были ранее настроены на следующем(их) устройстве(ах)"
     },
     "reconstruct-multiple-transports-title": {
       "dutch": "Apparaten met webauthenticatie ingeschakeld",
@@ -2379,11 +2577,12 @@
       "french": "Appareil(s) habilité(s) pour l'authentification Web",
       "german": "Webauthentifizierung aktiviertes Geräte (en)",
       "japanese": "Web認証有効化デバイス",
-      "korean":  "웹 인증이 활성화된 기기",
+      "korean": "웹 인증이 활성화된 기기",
       "mandarin": "Web身份验证启用设备",
       "portuguese": "Dispositivo(s) habilitado(s) para utenticação da Web",
       "spanish": "Dispositivo (s) de autenticación web",
-      "turkish": "Web Kimlik Doğrulaması Etkin Cihaz(lar)"
+      "turkish": "Web Kimlik Doğrulaması Etkin Cihaz(lar)",
+      "russian": "Устройство(а) с включенной веб-аутентификацией"
     },
     "reconstruct-multiple-transports-verify": {
       "dutch": "Nu verifiëren",
@@ -2395,7 +2594,8 @@
       "mandarin": "立即验证",
       "portuguese": "Verifique agora",
       "spanish": "Verifica ahora",
-      "turkish": "Şimdi doğrula"
+      "turkish": "Şimdi doğrula",
+      "russian": "Подтвердите сейчас"
     },
     "reconstruct-password-desc": {
       "dutch": "Voer hier uw account herstel wachtwoord in",
@@ -2407,7 +2607,8 @@
       "mandarin": "在此处输入您的帐户恢复密码",
       "portuguese": "Digite sua senha de recuperação de conta aqui",
       "spanish": "Ingrese la contraseña de recuperación de su cuenta aquí",
-      "turkish": "Hesap kurtarma şifrenizi buraya girin"
+      "turkish": "Hesap kurtarma şifrenizi buraya girin",
+      "russian": "Введите пароль для восстановления вашего аккаунта"
     },
     "reconstruct-password-placeholder": {
       "dutch": "Account wachtwoord",
@@ -2419,7 +2620,8 @@
       "mandarin": "户口密码",
       "portuguese": "Senha da conta",
       "spanish": "Contraseña de la cuenta",
-      "turkish": "Hesap şifresi"
+      "turkish": "Hesap şifresi",
+      "russian": "Пароль учетной записи"
     },
     "reconstruct-password-title": {
       "dutch": "Herstel wachtwoord",
@@ -2431,7 +2633,8 @@
       "mandarin": "找回密码",
       "portuguese": "Senha de recuperação",
       "spanish": "Contraseña de recuperación",
-      "turkish": "Kurtarma şifresi"
+      "turkish": "Kurtarma şifresi",
+      "russian": "Восстановление пароля"
     },
     "reconstruct-subtitle": {
       "dutch": "Verifieer met een van de volgende om toegang te krijgen tot uw account",
@@ -2443,7 +2646,8 @@
       "mandarin": "验证以下内容之一以访问您的帐户",
       "portuguese": "Verifique com um dos seguintes para acessar sua conta",
       "spanish": "Verifique con uno de los siguientes para acceder a su cuenta",
-      "turkish": "Hesabınıza erişmek için aşağıdakilerden biriyle doğrulama yapın"
+      "turkish": "Hesabınıza erişmek için aşağıdakilerden biriyle doğrulama yapın",
+      "russian": "Подтвердите с помощью одного из следующих методов для доступа к вашему аккаунту"
     },
     "reconstruct-support": {
       "dutch": "Neem contact op met de ondersteuning",
@@ -2455,7 +2659,8 @@
       "mandarin": "联系支持",
       "portuguese": "Entre em contato com o suporte",
       "spanish": "Soporte de contacto",
-      "turkish": "Destekle iletişime geçin"
+      "turkish": "Destekle iletişime geçin",
+      "russian": "Свяжитесь со службой поддержки"
     },
     "reconstruct-title": {
       "dutch": "Verifieer uw login",
@@ -2467,7 +2672,8 @@
       "mandarin": "验证您的登录名",
       "portuguese": "Verifique seu login",
       "spanish": "Verifique su inicio de sesión",
-      "turkish": "Giriş bilgilerinizi doğrulayın"
+      "turkish": "Giriş bilgilerinizi doğrulayın",
+      "russian": "Проверьте ваш вход в систему"
     },
     "recovery-factor-sent-to": {
       "dutch": "Voer de herstelzin in die is verzonden naar {email} op {date}, of als deze niet in uw e -mail staat, kunt u deze ophalen op {link}",
@@ -2479,7 +2685,8 @@
       "mandarin": "在{date}上输入发送到{email}的恢复短语，或者如果不在电子邮件中，则可以在{link}上检索它。",
       "portuguese": "Insira a frase de recuperação enviada para {email} em {date}, ou se não estiver em seu e -mail, você pode recuperá -lo em {link}",
       "spanish": "Ingrese la frase de recuperación enviada a {email} en {date}, o si no está en su correo electrónico, puede recuperarla en {link}",
-      "turkish": "{Date} tarihinde {email} adresine gönderilen kurtarma ifadesini girin veya e-postanızda yoksa {link} adresinden alabilirsiniz"
+      "turkish": "{Date} tarihinde {email} adresine gönderilen kurtarma ifadesini girin veya e-postanızda yoksa {link} adresinden alabilirsiniz",
+      "russian": "Введите код восстановления, отправленный на {email} {date}, или, если его нет в вашей почте, вы можете получить его по ссылке {link}"
     },
     "recovery-factor-sent-to-custom-verifier": {
       "dutch": "Voer de herstelzin in die is verzonden naar {email} op {date}",
@@ -2491,7 +2698,8 @@
       "mandarin": "在{date}上输入发送到{email}的恢复短语",
       "portuguese": "Insira a frase de recuperação enviada para {email} em {date}",
       "spanish": "Ingrese la frase de recuperación enviada a {email} en {date}",
-      "turkish": "{Date} tarihinde {email} adresine gönderilen kurtarma ifadesini girin"
+      "turkish": "{Date} tarihinde {email} adresine gönderilen kurtarma ifadesini girin",
+      "russian": "Введите фразу восстановления, отправленную на {email} {date}"
     },
     "register-backup-phrase-additional-security-desc1": {
       "dutch": "Er wordt een e-mail naar u verzonden met de back-upzin.",
@@ -2503,7 +2711,8 @@
       "mandarin": "将向您发送一封包含备份短语的电子邮件。",
       "portuguese": "Um e-mail será enviado para você contendo a frase de backup.",
       "spanish": "Se le enviará un correo electrónico con la frase de respaldo.",
-      "turkish": "Size yedekleme ifadesini içeren bir e-posta gönderilecektir."
+      "turkish": "Size yedekleme ifadesini içeren bir e-posta gönderilecektir.",
+      "russian": "На вашу почту будет отправлено письмо, содержащее резервную фразу."
     },
     "register-backup-phrase-additional-security-desc2": {
       "dutch": "Het helpt u bij het herstellen van uw account als u uw apparaat met Touch ID / Face ID verliest.",
@@ -2515,7 +2724,8 @@
       "mandarin": "如果您丢失带有 Touch ID / Face ID 的设备，它可以帮助您恢复帐户。",
       "portuguese": "Ele ajuda na recuperação da conta caso você perca seu dispositivo com Touch ID / Face ID。",
       "spanish": "Le ayuda con la recuperación de la cuenta en caso de que pierda su dispositivo con Touch ID / Face ID.",
-      "turkish": "Touch ID / Face ID ile cihazınızı kaybetmeniz durumunda hesap kurtarma konusunda size yardımcı olur."
+      "turkish": "Touch ID / Face ID ile cihazınızı kaybetmeniz durumunda hesap kurtarma konusunda size yardımcı olur.",
+      "russian": "Оно помогает вам восстановить доступ к аккаунту в случае потери устройства с Touch ID / Face ID."
     },
     "register-backup-phrase-confirm-desc1": {
       "dutch": "Ik bevestig dat ik de herstel-e-mail heb ontvangen.",
@@ -2523,11 +2733,12 @@
       "french": "Je confirme avoir reçu l'e-mail de récupération.",
       "german": "Ich bestätige, dass ich die Wiederherstellungs-E-Mail erhalten habe.",
       "japanese": "復旧メールを受信したことを確認しました。",
-      "korean":  "복구 메일을 전송 받았음을 확인했습니다.",
+      "korean": "복구 메일을 전송 받았음을 확인했습니다.",
       "mandarin": "我确认我已收到恢复电子邮件。",
       "portuguese": "Confirmo que recebi o e-mail de recuperação.",
       "spanish": "Confirmo que he recibido el correo de recuperación.",
-      "turkish": "Kurtarma e-postasını aldığımı onaylıyorum."
+      "turkish": "Kurtarma e-postasını aldığımı onaylıyorum.",
+      "russian": "Я подтверждаю, что получил письмо для восстановления."
     },
     "register-backup-phrase-confirm-desc2": {
       "dutch": "Indien niet,",
@@ -2539,7 +2750,8 @@
       "mandarin": "如果不，",
       "portuguese": "Se não,",
       "spanish": "Que no,",
-      "turkish": "Eğer değilse,"
+      "turkish": "Eğer değilse,",
+      "russian": "'Если нет,'"
     },
     "register-backup-phrase-confirm-desc3": {
       "dutch": "herstel e-mail opnieuw invoeren",
@@ -2551,7 +2763,8 @@
       "mandarin": "重新输入辅助邮箱",
       "portuguese": "digite novamente o e-mail de recuperação",
       "spanish": "vuelve a ingresar el correo de recuperación",
-      "turkish": "kurtarma emailini yeniden girin"
+      "turkish": "kurtarma emailini yeniden girin",
+      "russian": "введите заново адрес электронной почты для восстановления"
     },
     "register-backup-phrase-desc": {
       "dutch": "Een e-mail wordt naar u verzonden met de back-upzin. Het helpt u bij het herstellen van uw account als u uw apparaat verliest.",
@@ -2563,7 +2776,8 @@
       "mandarin": "包含备用短语的电子邮件将发送给您。如果您丢失了设备，它将帮助您进行帐户恢复。",
       "portuguese": "Um e-mail será enviado para você contendo a frase de backup. Ele ajuda na recuperação da conta caso você perca seu dispositivo.",
       "spanish": "Se le enviará un correo electrónico con la frase de respaldo. Le ayuda con la recuperación de la cuenta en caso de que pierda su dispositivo.",
-      "turkish": "Size yedekleme ifadesini içeren bir e-posta gönderilecektir. Cihazınızı kaybetmeniz durumunda hesap kurtarma konusunda size yardımcı olur."
+      "turkish": "Size yedekleme ifadesini içeren bir e-posta gönderilecektir. Cihazınızı kaybetmeniz durumunda hesap kurtarma konusunda size yardımcı olur.",
+      "russian": "Вам будет отправлено письмо, содержащее резервную фразу. Она поможет вам восстановить аккаунт в случае потери устройства."
     },
     "register-backup-phrase-desc1": {
       "dutch": "Er wordt een e-mail naar u verzonden met de back-upzin.",
@@ -2575,7 +2789,8 @@
       "mandarin": "将向您发送一封包含备份短语的电子邮件。",
       "portuguese": "Um e-mail será enviado para você contendo a frase de backup.",
       "spanish": "Se le enviará un correo electrónico con la frase de respaldo.",
-      "turkish": "Size yedekleme ifadesini içeren bir e-posta gönderilecektir."
+      "turkish": "Size yedekleme ifadesini içeren bir e-posta gönderilecektir.",
+      "russian": "Вам будет отправлено письмо, содержащее резервную фразу."
     },
     "register-backup-phrase-desc2": {
       "dutch": "Het helpt u bij het herstellen van uw account in geval van verlies van uw apparaat.",
@@ -2587,7 +2802,8 @@
       "mandarin": "它可以帮助您在丢失设备时恢复帐户。",
       "portuguese": "Ele ajuda na recuperação da conta caso você perca seu dispositivo.",
       "spanish": "Le ayuda con la recuperación de la cuenta en caso de que pierda su dispositivo.",
-      "turkish": "Cihazınızı kaybetmeniz durumunda hesap kurtarma konusunda size yardımcı olur."
+      "turkish": "Cihazınızı kaybetmeniz durumunda hesap kurtarma konusunda size yardımcı olur.",
+      "russian": "Оно помогает вам восстановить доступ к аккаунту в случае потери вашего устройства."
     },
     "register-backup-phrase-placeholder": {
       "dutch": "Voer het herstel-e-mailadres in",
@@ -2599,7 +2815,8 @@
       "mandarin": "输入辅助邮箱",
       "portuguese": "Digite o e-mail de recuperação",
       "spanish": "Ingresa el correo de recuperación",
-      "turkish": "Kurtarma e-postasını girin"
+      "turkish": "Kurtarma e-postasını girin",
+      "russian": "Введите адрес восстановления электронной почты"
     },
     "register-backup-phrase-send": {
       "dutch": "Herstel e-mail verzenden",
@@ -2611,7 +2828,8 @@
       "mandarin": "发送恢复电子邮件",
       "portuguese": "Enviar e-mail de recuperação",
       "spanish": "Enviar correo de recuperación",
-      "turkish": "Kurtarma e-postası gönder"
+      "turkish": "Kurtarma e-postası gönder",
+      "russian": "Отправить письмо для восстановления"
     },
     "register-backup-phrase-title": {
       "dutch": "Doorgaan met een herstel-e-mail",
@@ -2623,7 +2841,8 @@
       "mandarin": "继续发送辅助邮箱",
       "portuguese": "Continuar com um e-mail de recuperação",
       "spanish": "Continuar con un correo de recuperación",
-      "turkish": "Kurtarma e-postasıyla devam et"
+      "turkish": "Kurtarma e-postasıyla devam et",
+      "russian": "Продолжить с помощью восстановительного электронного письма"
     },
     "register-biometrics-desc": {
       "dutch": "Registreer uw apparaat met Face ID of Touch ID. Biometrie verlaat uw apparaat nooit.",
@@ -2635,7 +2854,8 @@
       "mandarin": "使用面容 ID 或触控 ID 注册您的设备。 生物识别技术永远不会离开您的设备。",
       "portuguese": "Registre seu dispositivo com Face ID ou Touch ID. A biometria nunca sai do seu dispositivo.",
       "spanish": "Registre su dispositivo con Face ID o Touch ID. La biometría nunca abandona su dispositivo.",
-      "turkish": "Cihazınızı Face ID veya Touch ID ile kaydedin. Biyometri cihazınızdan asla çıkmaz."
+      "turkish": "Cihazınızı Face ID veya Touch ID ile kaydedin. Biyometri cihazınızdan asla çıkmaz.",
+      "russian": "Зарегистрируйте ваше устройство с помощью Face ID или Touch ID. Биометрические данные никогда не покидают ваше устройство."
     },
     "register-biometrics-enable": {
       "dutch": "Activeer Touch ID / Face ID",
@@ -2647,7 +2867,8 @@
       "mandarin": "启用触摸ID /面部ID",
       "portuguese": "Ativar Touch ID / Face ID",
       "spanish": "Habilitar Touch ID / Face ID",
-      "turkish": "Touch ID / Face ID'yi etkinleştirin"
+      "turkish": "Touch ID / Face ID'yi etkinleştirin",
+      "russian": "Включить Touch ID / Face ID"
     },
     "register-biometrics-title": {
       "dutch": "Doorgaan met Face ID of Touch ID",
@@ -2659,7 +2880,8 @@
       "mandarin": "继续使用Face ID或Touch ID",
       "portuguese": "Continue com Face ID ou Touch ID",
       "spanish": "Continuar con Face ID o Touch ID",
-      "turkish": "Face ID veya Touch ID ile devam edin"
+      "turkish": "Face ID veya Touch ID ile devam edin",
+      "russian": "Продолжить с использованием Face ID или Touch ID"
     },
     "register-continue": {
       "dutch": "Doorgaan",
@@ -2671,7 +2893,8 @@
       "mandarin": "继续",
       "portuguese": "Continuar",
       "spanish": "Continuar",
-      "turkish": "Devam et"
+      "turkish": "Devam et",
+      "russian": "Продолжить"
     },
     "register-external-transports-desc": {
       "dutch": "Registreer uw apparaat voor alle webauthenticatiemethoden.",
@@ -2683,7 +2906,8 @@
       "mandarin": "注册您的设备任何Web身份验证方法。",
       "portuguese": "Registre seu dispositivo em qualquer método de autenticação da web.",
       "spanish": "Registre su dispositivo cualquier método de autenticación web.",
-      "turkish": "Cihazınızı herhangi bir web kimlik doğrulama yöntemiyle kaydedin."
+      "turkish": "Cihazınızı herhangi bir web kimlik doğrulama yöntemiyle kaydedin.",
+      "russian": "Зарегистрируйте ваше устройство любыми методами веб-аутентификации."
     },
     "register-external-transports-webauthn-title": {
       "dutch": "Ga door met elke Web Authenticatie Methode",
@@ -2695,7 +2919,8 @@
       "mandarin": "继续使用任何Web身份验证方法",
       "portuguese": "Continue com qualquer método de autenticação da web",
       "spanish": "Continuar con cualquier método de autenticación web",
-      "turkish": "Herhangi bir Web Kimlik Doğrulama Yöntemi ile devam edin"
+      "turkish": "Herhangi bir Web Kimlik Doğrulama Yöntemi ile devam edin",
+      "russian": "Продолжить с любыми методами веб-аутентификации"
     },
     "register-multiple-transports-cta": {
       "dutch": "Instellen",
@@ -2707,7 +2932,8 @@
       "mandarin": "设置它",
       "portuguese": "Configurá-lo",
       "spanish": "Prepararlo",
-      "turkish": "Kurun"
+      "turkish": "Kurun",
+      "russian": "Установи это"
     },
     "register-multiple-transports-desc": {
       "dutch": "Registreer uw apparaat met biometrie of een webauthenticatiemethode.",
@@ -2719,7 +2945,8 @@
       "mandarin": "用生物识别技术或任何Web身份验证方法注册您的设备。",
       "portuguese": "Registre seu dispositivo com biometria ou qualquer método de autenticação da web.",
       "spanish": "Registre su dispositivo con Biometrics o cualquier método de autenticación web.",
-      "turkish": "Cihazınızı biyometri veya herhangi bir web kimlik doğrulama yöntemiyle kaydedin."
+      "turkish": "Cihazınızı biyometri veya herhangi bir web kimlik doğrulama yöntemiyle kaydedin.",
+      "russian": "Зарегистрируйте свое устройство с помощью биометрии или любых методов веб-аутентификации."
     },
     "register-multiple-transports-webauthn-title": {
       "dutch": "Ga verder met biometrie of een van de webauthenticatiemethoden",
@@ -2731,7 +2958,8 @@
       "mandarin": "继续使用生物识别技术或任何Web身份验证方法",
       "portuguese": "Continue com a biometria ou qualquer método de autenticação da Web",
       "spanish": "Continuar con biometría o cualquier método de autenticación web",
-      "turkish": "Biyometri veya herhangi bir Web Kimlik Doğrulama Yöntemi ile devam edin"
+      "turkish": "Biyometri veya herhangi bir Web Kimlik Doğrulama Yöntemi ile devam edin",
+      "russian": "Продолжить с биометрией или любыми методами веб-аутентификации"
     },
     "register-password-confirm": {
       "dutch": "Wachtwoord instellen",
@@ -2743,7 +2971,8 @@
       "mandarin": "设定密码",
       "portuguese": "Configurar senha",
       "spanish": "Configurar contraseña",
-      "turkish": "Şifre ayarla"
+      "turkish": "Şifre ayarla",
+      "russian": "Установить пароль"
     },
     "register-password-password": {
       "dutch": "Voer uw wachtwoord in",
@@ -2755,7 +2984,8 @@
       "mandarin": "输入密码",
       "portuguese": "Coloque sua senha",
       "spanish": "Ingresa tu contraseña",
-      "turkish": "Şifrenizi girin"
+      "turkish": "Şifrenizi girin",
+      "russian": "Введите ваш пароль"
     },
     "register-password-password-confirm": {
       "dutch": "Voer uw wachtwoord opnieuw in",
@@ -2767,7 +2997,8 @@
       "mandarin": "重新输入密码",
       "portuguese": "Redigite sua senha",
       "spanish": "reingresa tu contraseña",
-      "turkish": "Şifrenizi tekrar girin"
+      "turkish": "Şifrenizi tekrar girin",
+      "russian": "Введите ваш пароль еще раз"
     },
     "register-password-title": {
       "dutch": "Stel wachtwoord voor account in",
@@ -2779,7 +3010,8 @@
       "mandarin": "设置帐号密码",
       "portuguese": "Configurar senha da conta",
       "spanish": "Configurar la contraseña de la cuenta",
-      "turkish": "Hesap şifresini ayarla"
+      "turkish": "Hesap şifresini ayarla",
+      "russian": "Установите пароль для аккаунта"
     },
     "register-skip": {
       "dutch": "Nu overslaan",
@@ -2791,7 +3023,8 @@
       "mandarin": "立即跳过",
       "portuguese": "Pular por agora",
       "spanish": "Saltar por ahora",
-      "turkish": "Şimdilik Atla"
+      "turkish": "Şimdilik Atla",
+      "russian": "Пропустить пока"
     },
     "register-subtitle": {
       "dutch": "Selecteer een van de volgende",
@@ -2803,7 +3036,8 @@
       "mandarin": "选择以下之一",
       "portuguese": "Selecione um dos seguintes",
       "spanish": "Selecciona uno de los siguientes",
-      "turkish": "Aşağıdakilerden birini seçin"
+      "turkish": "Aşağıdakilerden birini seçin",
+      "russian": "Выберите одно из следующих"
     },
     "register-subtitle-additional-security": {
       "dutch": "Uw accountbeveiliging is belangrijk. Laten we het backuppen.",
@@ -2815,7 +3049,8 @@
       "mandarin": "您的帐户安全很重要。 让我们支持它。",
       "portuguese": "A segurança da sua conta é importante. Vamos fazer backup.",
       "spanish": "La seguridad de su cuenta es importante. Hagamos una copia de seguridad.",
-      "turkish": "Hesap güvenliğiniz önemlidir. Yedekleyelim."
+      "turkish": "Hesap güvenliğiniz önemlidir. Yedekleyelim.",
+      "russian": "Безопасность вашего аккаунта важна. Давайте создадим резервную копию."
     },
     "register-subtitle-try-webauth": {
       "dutch": "Wilt u Touch ID / Face ID op dit apparaat inschakelen?",
@@ -2827,7 +3062,8 @@
       "mandarin": "您要在此设备上启用Touch ID / Face ID吗？",
       "portuguese": "Gostaria de ativar o Touch ID / Face ID neste dispositivo?",
       "spanish": "¿Le gustaría habilitar Touch ID / Face ID en este dispositivo?",
-      "turkish": "Bu cihazda Touch ID / Face ID'yi etkinleştirmek ister misiniz?"
+      "turkish": "Bu cihazda Touch ID / Face ID'yi etkinleştirmek ister misiniz?",
+      "russian": "Вы хотите включить Touch ID / Face ID на этом устройстве?"
     },
     "register-title": {
       "dutch": "Beveilig uw {0} account",
@@ -2839,7 +3075,8 @@
       "mandarin": "保护您的{0}帐户",
       "portuguese": "Protegendo sua conta {0}",
       "spanish": "Asegurar su cuenta de {0}",
-      "turkish": "{0} hesabınızın güvenliğini sağlama"
+      "turkish": "{0} hesabınızın güvenliğini sağlama",
+      "russian": "Обеспечение безопасности вашего аккаунта {0}"
     },
     "register-title-additional-security": {
       "dutch": "Een laatste stap voordat je gaat",
@@ -2851,7 +3088,8 @@
       "mandarin": "出发前的最后一步",
       "portuguese": "Um último passo antes de ir",
       "spanish": "Un último paso antes de irte",
-      "turkish": "Başlamadan önce son bir adım"
+      "turkish": "Başlamadan önce son bir adım",
+      "russian": "Еще один шаг перед тем пойти дальше"
     },
     "register-title-try-webauth": {
       "dutch": "Beveilig uw account",
@@ -2863,7 +3101,8 @@
       "mandarin": "保护您的帐户",
       "portuguese": "Protegendo sua conta",
       "spanish": "Asegurar su cuenta",
-      "turkish": "Hesabınızın güvenliğini sağlama"
+      "turkish": "Hesabınızın güvenliğini sağlama",
+      "russian": "Защита вашего аккаунта"
     },
     "resend-code-cta": {
       "dutch": "Code opnieuw verzenden",
@@ -2875,7 +3114,8 @@
       "mandarin": "重新发送验证码",
       "portuguese": "Reenviar código",
       "spanish": "Reenviar codigo",
-      "turkish": "Kodu tekrar gönder"
+      "turkish": "Kodu tekrar gönder",
+      "russian": "Отправить код повторно"
     },
     "resend-otp-code": {
       "dutch": "Code opnieuw verzenden in {time}",
@@ -2887,7 +3127,8 @@
       "mandarin": "重新发送代码 {time}",
       "portuguese": "Reduzir o código em {time}",
       "spanish": "Reenviar código en {time}",
-      "turkish": "Kodu {time} saniye içinde tekrar gönder"
+      "turkish": "Kodu {time} saniye içinde tekrar gönder",
+      "russian": "Отправить код повторно через {время}"
     },
     "returning-confirm-btn": {
       "dutch": "Ja, doorgaan met biometrie",
@@ -2899,7 +3140,8 @@
       "mandarin": "是的，继续生物识别",
       "portuguese": "Sim, continuar com a biometria",
       "spanish": "Sí, continuar con la biometría",
-      "turkish": "Evet, biyometri ile devam et"
+      "turkish": "Evet, biyometri ile devam et",
+      "russian": "Да, продолжайте с биометрией."
     },
     "returning-confirm-desc": {
       "dutch": "Doorgaan met inloggen via biometrie?",
@@ -2911,7 +3153,8 @@
       "mandarin": "继续通过生物识别登录？",
       "portuguese": "Continuar seu login via biometria?",
       "spanish": "¿Continuar con el inicio de sesión mediante datos biométricos?",
-      "turkish": "Biyometri ile oturum açmaya devam mı ediyorsunuz?"
+      "turkish": "Biyometri ile oturum açmaya devam mı ediyorsunuz?",
+      "russian": "Продолжить вход через биометрию?"
     },
     "returning-confirm-title": {
       "dutch": "We willen gewoon zeker zijn.",
@@ -2923,7 +3166,8 @@
       "mandarin": "我们只是想确定一下。",
       "portuguese": "Só queremos ter certeza.",
       "spanish": "Solo queremos estar seguros.",
-      "turkish": "Sadece emin olmak istiyoruz."
+      "turkish": "Sadece emin olmak istiyoruz.",
+      "russian": "Мы просто хотим быть уверенными."
     },
     "returning-continue": {
       "dutch": "Doorgaan met {0}",
@@ -2935,7 +3179,8 @@
       "mandarin": "继续{0}",
       "portuguese": "Continuar com {0}",
       "spanish": "Continuar con {0}",
-      "turkish": "Şununla devam et: {0}"
+      "turkish": "Şununla devam et: {0}",
+      "russian": "Продолжить с {0}"
     },
     "returning-exist-title": {
       "dutch": "Welkom terug, {0}",
@@ -2947,7 +3192,8 @@
       "mandarin": "欢迎回来，{0}",
       "portuguese": "Bem-vindo de volta, {0}",
       "spanish": "Bienvenido de nuevo, {0}",
-      "turkish": "Tekrar hoş geldiniz, {0}"
+      "turkish": "Tekrar hoş geldiniz, {0}",
+      "russian": "Добро пожаловать обратно, {0}"
     },
     "returning-exist-use-another": {
       "dutch": "Gebruik een ander account",
@@ -2959,7 +3205,8 @@
       "mandarin": "使用其他帐户",
       "portuguese": "Usar outra conta",
       "spanish": "Usa otra cuenta",
-      "turkish": "Başka bir hesap kullan"
+      "turkish": "Başka bir hesap kullan",
+      "russian": "Использовать другой аккаунт"
     },
     "returning-header-desc": {
       "dutch": "Uw digitale portemonnee via",
@@ -2971,7 +3218,8 @@
       "mandarin": "您的数字钱包通过",
       "portuguese": "Sua carteira digital via",
       "spanish": "Tu billetera digital a través de",
-      "turkish": "Dijital cüzdanınız"
+      "turkish": "Dijital cüzdanınız",
+      "russian": "Ваш цифровой кошелек через"
     },
     "returning-header-title": {
       "dutch": "Inloggen",
@@ -2983,7 +3231,8 @@
       "mandarin": "登入",
       "portuguese": "Entrar",
       "spanish": "Registrarse",
-      "turkish": "Oturum aç"
+      "turkish": "Oturum aç",
+      "russian": "Войти"
     },
     "returning-sign-in-desc": {
       "dutch": "Ga verder met een van de volgende stappen om door te gaan",
@@ -2995,7 +3244,8 @@
       "mandarin": "继续执行以下操作之一以继续",
       "portuguese": "Continue com um dos seguintes",
       "spanish": "Continúe con uno de los siguientes para continuar",
-      "turkish": "Devam etmek için aşağıdakilerden biriyle devam edin"
+      "turkish": "Devam etmek için aşağıdakilerden biriyle devam edin",
+      "russian": "Продолжите с одним из следующих действий для продолжения"
     },
     "returning-sign-in-header1": {
       "dutch": "Gebruik een ander account",
@@ -3007,7 +3257,8 @@
       "mandarin": "使用其他帐户",
       "portuguese": "Usar outra conta",
       "spanish": "Usa otra cuenta",
-      "turkish": "Başka bir hesap kullan"
+      "turkish": "Başka bir hesap kullan",
+      "russian": "Использовать другой аккаунт"
     },
     "returning-sign-in-header2": {
       "dutch": "Het lijkt erop dat je nog niet bent aangemeld bij een account",
@@ -3019,7 +3270,8 @@
       "mandarin": "您似乎尚未登录帐户",
       "portuguese": "Parece que você ainda não está conectado a uma conta",
       "spanish": "Parece que aún no ha iniciado sesión en una cuenta",
-      "turkish": "Henüz bir hesapta oturum açmamışsınız gibi görünüyor"
+      "turkish": "Henüz bir hesapta oturum açmamışsınız gibi görünüyor",
+      "russian": "Кажется, вы еще не вошли в свой аккаунт."
     },
     "social-2fa-continue-text": {
       "dutch": "Kies hoe u verder wilt gaan",
@@ -3031,7 +3283,8 @@
       "mandarin": "选择您喜欢如何继续",
       "portuguese": "Selecione como você gostaria de continuar",
       "spanish": "Seleccione cómo le gusta continuar",
-      "turkish": "Nasıl devam etmek istediğinizi seçin"
+      "turkish": "Nasıl devam etmek istediğinizi seçin",
+      "russian": "Выберите, как вы хотите продолжить"
     },
     "social-2fa-heading": {
       "dutch": "Stel sociaal herstelfactor in",
@@ -3043,7 +3296,8 @@
       "mandarin": "设定社会恢复因素",
       "portuguese": "Definir fator de recuperação social",
       "spanish": "Establecer factor de recuperación social",
-      "turkish": "Sosyal Medya kurtarma faktörünü ayarlayın"
+      "turkish": "Sosyal Medya kurtarma faktörünü ayarlayın",
+      "russian": "Настроить соцсеть для восстановления доступа"
     },
     "social-2fa-subtitle-1": {
       "dutch": "Log in met een van de sociale accounts om het als herstelfactor in te stellen",
@@ -3055,7 +3309,8 @@
       "mandarin": "用任何社会帐户登录将其设置为恢复因素",
       "portuguese": "Faça login com qualquer conta social para defini-la como fator de recuperação",
       "spanish": "Inicie sesión con cualquiera de la cuenta social para establecerla como factor de recuperación",
-      "turkish": "Kurtarma faktörü olarak ayarlamak için herhangi bir sosyal medya hesabıyla giriş yapın"
+      "turkish": "Kurtarma faktörü olarak ayarlamak için herhangi bir sosyal medya hesabıyla giriş yapın",
+      "russian": "Войдите с помощью любого аккаунта соцсети, чтобы установить его как средство восстановления"
     },
     "social-2fa-subtitle-2": {
       "dutch": "Als u geen toegang meer heeft tot uw opgeslagen browser, kunt u zich authenticeren met uw sociale account.",
@@ -3067,7 +3322,8 @@
       "mandarin": "如果您无法访问保存的浏览器，则可以通过社交帐户进行身份验证。",
       "portuguese": "Caso perca o acesso ao seu navegador salvo, você pode se autenticar com sua conta Social.",
       "spanish": "En caso de que pierda acceso a su navegador guardado, puede autenticarse con su cuenta social.",
-      "turkish": "Kayıtlı tarayıcınıza erişiminizi kaybetmeniz durumunda, Sosyal medya hesabınızla kimlik doğrulaması yapabilirsiniz."
+      "turkish": "Kayıtlı tarayıcınıza erişiminizi kaybetmeniz durumunda, Sosyal medya hesabınızla kimlik doğrulaması yapabilirsiniz.",
+      "russian": "В случае, если вы потеряете доступ к сохраненному браузеру, вы можете аутентифицироваться с помощью своего аккаунта в социальной сети."
     },
     "social-2fa-used-passwordless": {
       "dutch": "{0} login is niet beschikbaar omdat het is gebruikt voor uw login, selecteer een andere optie voor herstel.",
@@ -3079,7 +3335,8 @@
       "mandarin": "{0} 登录不可用，因为它已被用于您的登录，请选择其他选项进行恢复。",
       "portuguese": "{0} login não está disponível porque foi usado para seu login, selecione outra opção para recuperação.",
       "spanish": "El inicio de sesión de {0} no está disponible ya que se ha utilizado para su inicio de sesión, seleccione otra opción para la recuperación.",
-      "turkish": "{0} girişi, girişiniz için kullanıldığından kullanılamaz, lütfen kurtarma için başka bir seçenek seçin."
+      "turkish": "{0} girişi, girişiniz için kullanıldığından kullanılamaz, lütfen kurtarma için başka bir seçenek seçin.",
+      "russian": "'Вход {0} недоступен, поскольку он был использован для вашего входа в систему, выберите другой вариант для восстановления.'"
     },
     "social-2fa-used-social": {
       "dutch": "{0} is gebruikt voor uw aanmelding, selecteer een andere optie voor herstel.",
@@ -3091,7 +3348,8 @@
       "mandarin": "{0} 已用于您的登录，请选择其他选项进行恢复。",
       "portuguese": "{0} foi usado para seu login, selecione outra opção para recuperação.",
       "spanish": "{0} se ha utilizado para su inicio de sesión, seleccione otra opción para la recuperación.",
-      "turkish": "Girişiniz için {0} kullanıldı, lütfen kurtarma için başka bir seçenek seçin."
+      "turkish": "Girişiniz için {0} kullanıldı, lütfen kurtarma için başka bir seçenek seçin.",
+      "russian": "'{0} уже использовался для вашего входа в систему, пожалуйста, выберите другой вариант для восстановления.'"
     },
     "social-2fa-verify-account": {
       "dutch": "Verifieer met uw sociale account",
@@ -3103,7 +3361,8 @@
       "mandarin": "验证您的社交帐户",
       "portuguese": "Verifique com sua conta social",
       "spanish": "Verifique con su cuenta social",
-      "turkish": "Sosyal medya hesabınızla doğrulayın"
+      "turkish": "Sosyal medya hesabınızla doğrulayın",
+      "russian": "Подтвердите с помощью вашего социального аккаунта"
     },
     "social-2fa-verify-email": {
       "dutch": "Verifieer met uw e-mail",
@@ -3115,7 +3374,8 @@
       "mandarin": "通过电子邮件验证",
       "portuguese": "Verifique com seu e-mail",
       "spanish": "Verifique con su correo electrónico",
-      "turkish": "E-postanızla doğrulayın"
+      "turkish": "E-postanızla doğrulayın",
+      "russian": "Подтвердите с помощью вашей электронной почты"
     },
     "social-2fa-verify-heading": {
       "dutch": "Sociale herstelfactor",
@@ -3127,7 +3387,8 @@
       "mandarin": "社会恢复因素",
       "portuguese": "Fator de Recuperação Social",
       "spanish": "Factor de recuperación social",
-      "turkish": "Sosyal Medya Kurtarma Faktörü"
+      "turkish": "Sosyal Medya Kurtarma Faktörü",
+      "russian": "Фактор восстановления через соцсети"
     },
     "social-2fa-view-less": {
       "dutch": "Minder bekijken",
@@ -3139,7 +3400,8 @@
       "mandarin": "少查看",
       "portuguese": "Ver menos",
       "spanish": "Ver menos",
-      "turkish": "Daha az görüntüle"
+      "turkish": "Daha az görüntüle",
+      "russian": "Показать меньше"
     },
     "social-2fa-view-more": {
       "dutch": "Bekijk meer",
@@ -3151,7 +3413,8 @@
       "mandarin": "查看更多",
       "portuguese": "Veja mais",
       "spanish": "Ver más",
-      "turkish": "Daha fazla görüntüle"
+      "turkish": "Daha fazla görüntüle",
+      "russian": "Посмотреть ещё"
     },
     "social-2fa-warn-text-1": {
       "dutch": "Deze sociale factor dient alleen als back-up om uw account gekoppeld aan \"abcd{'@'}xyz.com\" te herstellen.",
@@ -3163,7 +3426,8 @@
       "mandarin": "这个社会因素仅充当备份共享，以恢复您的帐户链接到“ abcd{'@'}xyz.com”。",
       "portuguese": "Este fator social atua apenas como um compartilhamento de backup para recuperar sua conta vinculada a “abcd{'@'}xyz.com”.",
       "spanish": "Este factor social solo actúa como una participación de respaldo para recuperar su cuenta vinculada a \"abcd{'@'}xyz.com\".",
-      "turkish": "Bu Sosyal medya faktör yalnızca “abcd{'@'}xyz.com“ ile bağlantılı hesabınızı kurtarmak için bir yedek parça görevi görür."
+      "turkish": "Bu Sosyal medya faktör yalnızca “abcd{'@'}xyz.com“ ile bağlantılı hesabınızı kurtarmak için bir yedek parça görevi görür.",
+      "russian": "Этот фактор соцсети действует только как резервная доля для восстановления вашего аккаунта, связанного с \"abcd{'@'}xyz.com\"."
     },
     "social-2fa-warn-text-2": {
       "dutch": "Inloggen met deze sociale factor op de inlogpagina geeft u een nieuw account.",
@@ -3175,7 +3439,8 @@
       "mandarin": "在登录页面上使用此社交因素签名将为您提供一个新帐户。",
       "portuguese": "Entrar com este fator social na página de login lhe dará uma nova conta.",
       "spanish": "Iniciar sesión con este factor social en la página de inicio de sesión le dará una nueva cuenta.",
-      "turkish": "Giriş sayfasında bu Sosyal medya faktörü ile oturum açmak size yeni bir hesap verecektir."
+      "turkish": "Giriş sayfasında bu Sosyal medya faktörü ile oturum açmak size yeni bir hesap verecektir.",
+      "russian": "Вход через фактор этой соцсети на странице входа даст вам новый аккаунт."
     },
     "social-2fa-warning-cta-1": {
       "dutch": "Ja, ik accepteer het risico",
@@ -3187,7 +3452,8 @@
       "mandarin": "是的，我接受风险",
       "portuguese": "Sim, eu aceito o risco",
       "spanish": "Sí, acepto el riesgo",
-      "turkish": "Evet, riski kabul ediyorum"
+      "turkish": "Evet, riski kabul ediyorum",
+      "russian": "Да, я принимаю риск."
     },
     "social-2fa-warning-cta-2": {
       "dutch": "Nee, gebruik een ander e-mailadres",
@@ -3199,7 +3465,8 @@
       "mandarin": "不，使用另一封电子邮件",
       "portuguese": "Não, use outro e-mail",
       "spanish": "No, usa otro correo electrónico",
-      "turkish": "Hayır, başka e-posta kullan"
+      "turkish": "Hayır, başka e-posta kullan",
+      "russian": "Нет, используй другой email."
     },
     "social-2fa-warning-text": {
       "dutch": "U gebruikt hetzelfde e-mailadres voor het inloggen op uw account en het sociale aspect. Dit is onveilig. Wilt u toch doorgaan?",
@@ -3211,7 +3478,8 @@
       "mandarin": "您正在使用同一电子邮件进行帐户登录和社会因素。这是不安全的。您还想继续吗？",
       "portuguese": "Você está usando o mesmo e-mail para login da conta e fator social. Isso é inseguro. Você ainda gostaria de prosseguir?",
       "spanish": "Está utilizando el mismo correo electrónico para el inicio de sesión de la cuenta y el factor social. Esto es inseguro. ¿Todavía te gustaría continuar?",
-      "turkish": "Hesap girişi ve sosyal medya faktörü için aynı e-postayı kullanıyorsunuz. Bu güvenli değil. Hala devam etmek istiyor musunuz?"
+      "turkish": "Hesap girişi ve sosyal medya faktörü için aynı e-postayı kullanıyorsunuz. Bu güvenli değil. Hala devam etmek istiyor musunuz?",
+      "russian": "Вы используете один и тот же адрес электронной почты для входа в аккаунт и фактора соцсети. Это небезопасно. Вы все еще хотите продолжить?"
     },
     "social-factor-verification": {
       "dutch": "Verificatie van sociale factoren",
@@ -3223,7 +3491,8 @@
       "mandarin": "社会因素验证",
       "portuguese": "Verificação do fator social",
       "spanish": "Verificación del factor social",
-      "turkish": "Sosyal medya faktörü doğrulaması"
+      "turkish": "Sosyal medya faktörü doğrulaması",
+      "russian": "Подтверждение через социальную сеть"
     },
     "social-factor-verification-desc": {
       "dutch": "Ga verder met degene die u als sociaal herstelfactor heeft ingesteld",
@@ -3235,7 +3504,8 @@
       "mandarin": "继续您设置为社会恢复因素的因素",
       "portuguese": "Continue com aquele que você definiu como um fator de recuperação social",
       "spanish": "Continúe con uno que establezca como factor de recuperación social",
-      "turkish": "Sosyal medya kurtarma faktörü olarak belirlediğiniz faktörle devam edin"
+      "turkish": "Sosyal medya kurtarma faktörü olarak belirlediğiniz faktörle devam edin",
+      "russian": "Продолжите через социальную сеть, которую вы указали для восстановления доступа"
     },
     "social-policy": {
       "dutch": "We slaan geen gegevens op die verband houden met uw sociale logins.",
@@ -3247,7 +3517,8 @@
       "mandarin": "我们不存储与您的社交登录相关的任何数据。",
       "portuguese": "Não armazenamos nenhum dado relacionado ao seu login por rede social.",
       "spanish": "No almacenamos ningún dato relacionado con sus inicios de sesión sociales.",
-      "turkish": "Sosyal medya girişlerinizle ilgili hiçbir veriyi saklamıyoruz."
+      "turkish": "Sosyal medya girişlerinizle ilgili hiçbir veriyi saklamıyoruz.",
+      "russian": "Мы не сохраняем данные о ваших входах через соцсети"
     },
     "start": {
       "dutch": "Aan de slag",
@@ -3259,7 +3530,8 @@
       "mandarin": "开始使用",
       "portuguese": "Começar",
       "spanish": "Empezar",
-      "turkish": "Başlayın"
+      "turkish": "Başlayın",
+      "russian": "Начать"
     },
     "subtitle": {
       "dutch": "Klik op Aan de slag om door te gaan",
@@ -3271,7 +3543,8 @@
       "mandarin": "点击开始以继续",
       "portuguese": "Clique em Começar para continuar",
       "spanish": "Haga clic en comenzar para continuar",
-      "turkish": "Devam etmek için Başlayın'a tıklayın"
+      "turkish": "Devam etmek için Başlayın'a tıklayın",
+      "russian": "Нажмите \"Начать\" для продолжения"
     },
     "title": {
       "dutch": "Beheer al uw webinteracties op één plek",
@@ -3283,7 +3556,8 @@
       "mandarin": "一站式管理所有网络互动",
       "portuguese": "Gerencie todas as suas interações na web em um só lugar",
       "spanish": "Administre todas sus interacciones web en un solo lugar",
-      "turkish": "Tüm web etkileşimlerinizi tek bir yerden yönetin"
+      "turkish": "Tüm web etkileşimlerinizi tek bir yerden yönetin",
+      "russian": "Управляйте всеми своими взаимодействиями в вебе в одном месте."
     },
     "tooltip-phone-details": {
       "dutch": "Uw landcode wordt automatisch gedetecteerd, maar als u een telefoonnummer uit een ander land gebruikt, moet u de juiste landcode handmatig invoeren.",
@@ -3295,7 +3569,8 @@
       "mandarin": "您的国家代码将自动检测到，但是如果您使用来自其他国家 /地区的电话号码，则需要手动输入正确的国家代码。",
       "portuguese": "O código do seu país será detectado automaticamente, mas se você estiver usando um número de telefone de um país diferente, precisará inserir o código correto do país manualmente.",
       "spanish": "Su código de país se detectará automáticamente, pero si está utilizando un número de teléfono de un país diferente, deberá ingresar el código de país correcto manualmente.",
-      "turkish": "Ülke kodunuz otomatik olarak algılanacaktır, ancak farklı bir ülkeden bir telefon numarası kullanıyorsanız, doğru ülke kodunu manuel olarak girmeniz gerekecektir."
+      "turkish": "Ülke kodunuz otomatik olarak algılanacaktır, ancak farklı bir ülkeden bir telefon numarası kullanıyorsanız, doğru ülke kodunu manuel olarak girmeniz gerekecektir.",
+      "russian": "Код вашей страны будет определен автоматически, но если вы используете номер телефона из другой страны, вам потребуется ввести правильный код страны вручную."
     },
     "tooltip-phone-header": {
       "dutch": "Telefoonnummer en landcode",
@@ -3307,7 +3582,8 @@
       "mandarin": "电话号码和国家代码",
       "portuguese": "Número de telefone e código de país",
       "spanish": "Número de teléfono y código de país",
-      "turkish": "Telefon numarası ve ülke kodu"
+      "turkish": "Telefon numarası ve ülke kodu",
+      "russian": "Номер телефона и код страны"
     },
     "verifier-email-desc": {
       "dutch": "Doorgaan met e-mail",
@@ -3319,7 +3595,8 @@
       "mandarin": "继续发送电子邮件",
       "portuguese": "Continuar com e-mail",
       "spanish": "Continuar con el correo electrónico",
-      "turkish": "E-posta ile devam et"
+      "turkish": "E-posta ile devam et",
+      "russian": "Продолжить с электронной почтой"
     },
     "verifier-email-placeholder": {
       "dutch": "E-mailadres",
@@ -3331,7 +3608,8 @@
       "mandarin": "电子邮件",
       "portuguese": "E-mail",
       "spanish": "Correo electrónico",
-      "turkish": "E-posta"
+      "turkish": "E-posta",
+      "russian": "Электронная почта"
     },
     "verifier-google-desc": {
       "dutch": "Doorgaan met Google",
@@ -3343,7 +3621,8 @@
       "mandarin": "继续使用Google",
       "portuguese": "Continuar com o Google",
       "spanish": "Continuar con Google",
-      "turkish": "Google ile devam et"
+      "turkish": "Google ile devam et",
+      "russian": "Продолжить с Google"
     },
     "verifier-sms-desc": {
       "dutch": "Doorgaan met telefoon",
@@ -3355,7 +3634,8 @@
       "mandarin": "继续电话",
       "portuguese": "Continue com o telefone",
       "spanish": "Continuar con el teléfono",
-      "turkish": "Telefon ile devam et"
+      "turkish": "Telefon ile devam et",
+      "russian": "Продолжить с телефоном"
     },
     "verifier-sms-desc-2": {
       "dutch": "Doorgaan met mobiel",
@@ -3367,7 +3647,8 @@
       "mandarin": "继续移动",
       "portuguese": "Continue com o celular",
       "spanish": "Continuar con Mobile",
-      "turkish": "Mobil ile devam et"
+      "turkish": "Mobil ile devam et",
+      "russian": "Продолжить с мобильного"
     },
     "verifier-sms-placeholder": {
       "dutch": "Bijvoorbeeld:",
@@ -3379,7 +3660,8 @@
       "mandarin": "例如：",
       "portuguese": "Por exemplo:",
       "spanish": "P.ej:",
-      "turkish": "Örn:"
+      "turkish": "Örn:",
+      "russian": "Например:"
     },
     "verifier-webauth-desc": {
       "dutch": "Doorgaan met WebAuthn",
@@ -3391,7 +3673,8 @@
       "mandarin": "继续使用WebAuthn",
       "portuguese": "Continuar com WebAuthn",
       "spanish": "Continuar con WebAuthn",
-      "turkish": "WebAuthn ile devam et"
+      "turkish": "WebAuthn ile devam et",
+      "russian": "Продолжить с WebAuthn"
     },
     "verify-factorList-desc": {
       "dutch": "Controleer met een van de volgende om door te gaan",
@@ -3403,7 +3686,8 @@
       "mandarin": "验证以下一个继续",
       "portuguese": "Verifique com um dos seguintes para continuar",
       "spanish": "Verifique con uno de los siguientes para continuar",
-      "turkish": "Devam etmek için aşağıdakilerden biriyle doğrulayın"
+      "turkish": "Devam etmek için aşağıdakilerden biriyle doğrulayın",
+      "russian": "Подтвердите с помощью одного из следующих методов, чтобы продолжить"
     },
     "verify-otp-description": {
       "dutch": "Voer de OTP-code in die naar {number} is verzonden",
@@ -3415,7 +3699,8 @@
       "mandarin": "输入发送到发送到的OTP代码 {number}",
       "portuguese": "Digite o código OTP enviado para {number}",
       "spanish": "Ingrese el código OTP enviado a {number}",
-      "turkish": "{number} numarasına gönderilen OTP kodunu girin"
+      "turkish": "{number} numarasına gönderilen OTP kodunu girin",
+      "russian": "Введите OTP-код, отправленный на {номер}"
     },
     "verify-otp-heading-1": {
       "dutch": "Er is een OTP verzonden naar {number}",
@@ -3426,7 +3711,8 @@
       "korean": "{number}로 OTP가 전송되었습니다",
       "mandarin": "OTP已发送到 {number}",
       "portuguese": "Um OTP foi enviado para {number}",
-      "spanish": "Se ha enviado un OTP a {number}"
+      "spanish": "Se ha enviado un OTP a {number}",
+      "russian": "OTP был отправлен на {number}"
     },
     "verify-otp-heading-2": {
       "dutch": "Voer OTP in om door te gaan",
@@ -3438,7 +3724,8 @@
       "mandarin": "输入OTP继续",
       "portuguese": "Digite o OTP para continuar",
       "spanish": "Ingrese OTP para continuar",
-      "turkish": "Devam etmek için OTP kodunu girin"
+      "turkish": "Devam etmek için OTP kodunu girin",
+      "russian": "Введите OTP для продолжения"
     },
     "verify-otp-title-popup": {
       "dutch": "OTP-verificatie",
@@ -3450,7 +3737,8 @@
       "mandarin": "OTP验证",
       "portuguese": "Verificação de OTP",
       "spanish": "Verificación OTP",
-      "turkish": "OTP Doğrulaması"
+      "turkish": "OTP Doğrulaması",
+      "russian": "Проверка OTP"
     },
     "verify-otp-title-redirect": {
       "dutch": "Voer uw OTP in",
@@ -3462,7 +3750,8 @@
       "mandarin": "输入您的OTP",
       "portuguese": "Digite seu OTP",
       "spanish": "Ingrese su OTP",
-      "turkish": "OTP kodunu girin"
+      "turkish": "OTP kodunu girin",
+      "russian": "Введите ваш OTP"
     },
     "verify-with-password-factor-desc": {
       "dutch": "Controleer met nog een factor om door te gaan",
@@ -3474,7 +3763,8 @@
       "mandarin": "验证另一个因素继续",
       "portuguese": "Verifique com mais um fator para continuar",
       "spanish": "Verifique con un factor más para continuar",
-      "turkish": "Devam etmek için bir faktör daha doğrulayın"
+      "turkish": "Devam etmek için bir faktör daha doğrulayın",
+      "russian": "Подтвердите с помощью еще одного фактора для продолжения"
     },
     "verify-with-recovery-factor-desc": {
       "dutch": "Controleer met uw herstelzin die is verzonden om door te gaan",
@@ -3486,7 +3776,8 @@
       "mandarin": "用发送的恢复短语验证以继续",
       "portuguese": "Verifique com sua frase de recuperação enviada para continuar",
       "spanish": "Verifique con su frase de recuperación enviada para continuar",
-      "turkish": "Devam etmek için gönderilen kurtarma ifadenizle doğrulayın"
+      "turkish": "Devam etmek için gönderilen kurtarma ifadenizle doğrulayın",
+      "russian": "Проверьте с помощью фразы восстановления, отправленной для продолжения."
     },
     "verify-with-social-factor-desc": {
       "dutch": "Controleer met de sociale herstelfactor die u eerder had opgezet.",
@@ -3498,7 +3789,8 @@
       "mandarin": "使用您先前设置的社会恢复因素进行验证。",
       "portuguese": "Verifique com o fator de recuperação social que você configurou anteriormente.",
       "spanish": "Verifique con el factor de recuperación social que había establecido anteriormente.",
-      "turkish": "Daha önce kurmuş olduğunuz sosyal medya kurtarma faktörü ile doğrulayın."
+      "turkish": "Daha önce kurmuş olduğunuz sosyal medya kurtarma faktörü ile doğrulayın.",
+      "russian": "Подтвердите вход через настроенную ранее социальную сеть"
     }
   }
 }

--- a/Openlogin-locale/locales-nav.json
+++ b/Openlogin-locale/locales-nav.json
@@ -10,7 +10,8 @@
       "mandarin": "关闭",
       "portuguese": "fechar",
       "spanish": "Cerrar",
-      "turkish": "kapat"
+      "turkish": "kapat",
+      "russian": "закрыть"
     },
     "drawer": {
       "dutch": "Hoofdnavigatie",
@@ -22,7 +23,8 @@
       "mandarin": "主要导航",
       "portuguese": "Navegação Principal",
       "spanish": "Navegación Principal",
-      "turkish": "Ana Menü"
+      "turkish": "Ana Menü",
+      "russian": "Основная навигация"
     },
     "lang-select": {
       "dutch": "Taalkeuze",
@@ -34,7 +36,8 @@
       "mandarin": "语言选择器",
       "portuguese": "Seletor de idiomas",
       "spanish": "selector de idiomas",
-      "turkish": "Dil Seçimi"
+      "turkish": "Dil Seçimi",
+      "russian": "выбор языка"
     },
     "link-account": {
       "dutch": "Account",
@@ -46,7 +49,8 @@
       "mandarin": "帐户",
       "portuguese": "Conta",
       "spanish": "Cuenta",
-      "turkish": "Hesap"
+      "turkish": "Hesap",
+      "russian": "Аккаунт"
     },
     "link-apps": {
       "dutch": "Geautoriseerde apps",
@@ -58,7 +62,8 @@
       "mandarin": "授权应用",
       "portuguese": "Aplicativos autorizados",
       "spanish": "Aplicaciones autorizadas",
-      "turkish": "Yetkili Uygulamalar"
+      "turkish": "Yetkili Uygulamalar",
+      "russian": "Авторизованные приложения"
     },
     "link-home": {
       "dutch": "Startpagina",
@@ -70,7 +75,8 @@
       "mandarin": "主页",
       "portuguese": "Início",
       "spanish": "Página principal",
-      "turkish": "Ana sayfa"
+      "turkish": "Ana sayfa",
+      "russian": "Главная"
     },
     "link-logout": {
       "dutch": "Uitloggen",
@@ -82,7 +88,8 @@
       "mandarin": "登出",
       "portuguese": "Sair",
       "spanish": "Cerrar sesión",
-      "turkish": "Çıkış yap"
+      "turkish": "Çıkış yap",
+      "russian": "Выйти"
     },
     "link-support": {
       "dutch": "Ondersteuning",
@@ -94,7 +101,8 @@
       "mandarin": "支持",
       "portuguese": "Suporte",
       "spanish": "Ayuda",
-      "turkish": "Destek"
+      "turkish": "Destek",
+      "russian": "Поддержка"
     },
     "list-bottom": {
       "dutch": "Hoofdnavigatie onderaan",
@@ -106,7 +114,8 @@
       "mandarin": "主导航底部",
       "portuguese": "Parte inferior da navegação principal",
       "spanish": "Botón principal de navegación",
-      "turkish": "Ana Menü altı"
+      "turkish": "Ana Menü altı",
+      "russian": "Нижняя часть основной навигации"
     },
     "logo": {
       "dutch": "logo",
@@ -118,7 +127,8 @@
       "mandarin": "标识",
       "portuguese": "logotipo",
       "spanish": "logo",
-      "turkish": "logo"
+      "turkish": "logo",
+      "russian": "логотип"
     },
     "toggle-btn": {
       "dutch": "Navigatiebalk schakelen",
@@ -130,7 +140,8 @@
       "mandarin": "导航栏切换",
       "portuguese": "Navigação Bargle de barra",
       "spanish": "Barra de navegación",
-      "turkish": "Gezinti Çubuğu geçişi"
+      "turkish": "Gezinti Çubuğu geçişi",
+      "russian": "Переключить панель навигации"
     },
     "user-info": {
       "dutch": "Gebruikersinformatie",
@@ -142,7 +153,8 @@
       "mandarin": "用户信息",
       "portuguese": "Informação do usuário",
       "spanish": "Información del usuario",
-      "turkish": "Kullanıcı bilgisi"
+      "turkish": "Kullanıcı bilgisi",
+      "russian": "Информация о пользователе"
     }
   }
 }

--- a/Openlogin-locale/locales-nav.json
+++ b/Openlogin-locale/locales-nav.json
@@ -37,7 +37,7 @@
       "portuguese": "Seletor de idiomas",
       "spanish": "selector de idiomas",
       "turkish": "Dil Seçimi",
-      "russian": "выбор языка"
+      "russian": "Выбор языка"
     },
     "link-account": {
       "dutch": "Account",

--- a/Openlogin-locale/locales-passkeys.json
+++ b/Openlogin-locale/locales-passkeys.json
@@ -10,7 +10,8 @@
       "mandarin": "浏览器不支持",
       "portuguese": "Navegador não suportado",
       "spanish": "Navegador no compatible",
-      "turkish": "Tarayıcı desteklenmiyor"
+      "turkish": "Tarayıcı desteklenmiyor",
+      "russian": "Браузер не поддерживается"
     },
     "browser-not-supported-info": {
       "dutch": "Uw Browser wordt niet Ondersteund. Gebruik een ondersteunde browser om door te gaan.",
@@ -22,7 +23,8 @@
       "mandarin": "不支持您的浏览器。请使用支持的浏览器继续。",
       "portuguese": "Seu navegador não é suportado. Use um navegador suportado para continuar.",
       "spanish": "Su navegador no es compatible. Utilice uno compatible para continuar.",
-      "turkish": "Tarayıcınız desteklenmiyor. Devam etmek için lütfen desteklenen bir tarayıcı kullanın."
+      "turkish": "Tarayıcınız desteklenmiyor. Devam etmek için lütfen desteklenen bir tarayıcı kullanın.",
+      "russian": "Ваш браузер не поддерживается. Пожалуйста, используйте поддерживаемый браузер для продолжения."
     },
     "cancel": {
       "dutch": "Annuleren",
@@ -34,7 +36,8 @@
       "mandarin": "取消",
       "portuguese": "Cancelar",
       "spanish": "Cancelar",
-      "turkish": "İptal etmek"
+      "turkish": "İptal etmek",
+      "russian": "Отменить"
     },
     "error-verifying-passkey": {
       "dutch": "Fout bij het verifiëren van Passkey",
@@ -46,7 +49,8 @@
       "mandarin": "错误验证Passkey",
       "portuguese": "Erro verificando o Passkey",
       "spanish": "Error a verificar PassKey",
-      "turkish": "Passkey'i doğrulama hatası"
+      "turkish": "Passkey'i doğrulama hatası",
+      "russian": "Ошибка проверки passkey"
     },
     "setup-failed": {
       "dutch": "Passkey -opstelling is mislukt",
@@ -58,7 +62,8 @@
       "mandarin": "Passkey设置失败",
       "portuguese": "A instalação da Passkey falhou",
       "spanish": "Falló la configuración de PassKey",
-      "turkish": "Passkey kurulumu başarısız oldu"
+      "turkish": "Passkey kurulumu başarısız oldu",
+      "russian": "Не удалось настроить passkey"
     },
     "verification-desc-login": {
       "dutch": "Bijna daar! Bevestig je Passkey nog een keer om ervoor te zorgen dat het is opgeslagen voor dit apparaat.",
@@ -70,7 +75,8 @@
       "mandarin": "差不多了！只需再次确认您的Passkey即可确保为此设备保存它即可。",
       "portuguese": "Quase lá! Basta confirmar sua pasta mais uma vez para garantir que ela seja salva para este dispositivo.",
       "spanish": "¡Casi terminamos! Simplemente confirme su PassKey una vez más para asegurarse de que se guarde para este dispositivo.",
-      "turkish": ""
+      "turkish": "",
+      "russian": "Почти готово! Просто подтвердите ваш passkey ещё раз, чтобы убедиться, что он сохранен для этого устройства."
     },
     "verification-desc-register": {
       "dutch": "Registreer uw Passkey om te zorgen voor een naadloze login.",
@@ -82,7 +88,8 @@
       "mandarin": "注册您的Passkey以确保无缝登录。",
       "portuguese": "Registre sua chave passada para garantir o login sem costura.",
       "spanish": "Registre su PassKey para garantizar un inicio de sesión fluido.",
-      "turkish": "Kesintisiz giriş sağlamak için passey'inizi kaydedin."
+      "turkish": "Kesintisiz giriş sağlamak için passey'inizi kaydedin.",
+      "russian": "Зарегистрируйте passkey для беспрепятственного входа."
     },
     "verification-title-login": {
       "dutch": "Passkey verificatie",
@@ -94,7 +101,8 @@
       "mandarin": "Passkey验证",
       "portuguese": "Verificação da Passkey",
       "spanish": "Verificación de Passkey",
-      "turkish": "Passkey doğrulama"
+      "turkish": "Passkey doğrulama",
+      "russian": "Проверка passkey"
     },
     "verification-title-register": {
       "dutch": "Register Passkey",
@@ -106,7 +114,8 @@
       "mandarin": "注册Passkey",
       "portuguese": "Registre a Passkey",
       "spanish": "Registre su PassKey",
-      "turkish": "Passkey'i kaydet"
+      "turkish": "Passkey'i kaydet",
+      "russian": "Регистрация passkey"
     },
     "verify-cta-login": {
       "dutch": "Controleer Passkey",
@@ -118,7 +127,8 @@
       "mandarin": "验证Passkey",
       "portuguese": "Verifique se a pasta",
       "spanish": "Verifique PassKey",
-      "turkish": "Passkey'i doğrulayın"
+      "turkish": "Passkey'i doğrulayın",
+      "russian": "Проверить passkey"
     },
     "verify-cta-register": {
       "dutch": "Register Passkey",
@@ -130,7 +140,8 @@
       "mandarin": "注册Passkey",
       "portuguese": "Registre a Passkey",
       "spanish": "Registre PassKey",
-      "turkish": "Passkey'i kaydet"
+      "turkish": "Passkey'i kaydet",
+      "russian": "Зарегистрировать passkey"
     }
   }
 }

--- a/Openlogin-locale/locales-passwordless.json
+++ b/Openlogin-locale/locales-passwordless.json
@@ -244,7 +244,7 @@
       "portuguese": "Autoconfiança via",
       "spanish": "Autocustodia a través de",
       "turkish": "Kendi kendine saklama",
-      "russian": "Самостоятельное хранение через"
+      "russian": "Самостоятельное управление ключами через"
     },
     "invalid-phone-number-heading": {
       "dutch": "Ongeldig telefoonnummer",

--- a/Openlogin-locale/locales-passwordless.json
+++ b/Openlogin-locale/locales-passwordless.json
@@ -10,7 +10,8 @@
       "mandarin": "编辑电话号码",
       "portuguese": "Edite o número de telefone",
       "spanish": "Editar número de teléfono",
-      "turkish": "Telefon numarasını düzenle"
+      "turkish": "Telefon numarasını düzenle",
+      "russian": "Редактировать номер телефона"
     },
     "error-boundary-btn-home": {
       "dutch": "Klik hier om naar huis te gaan",
@@ -22,7 +23,8 @@
       "mandarin": "点击这里回家",
       "portuguese": "Clique aqui para ir para a página inicial",
       "spanish": "Presione aquí para ir a la página de inicio",
-      "turkish": "Ana sayfaya gitmek için buraya tıklayın"
+      "turkish": "Ana sayfaya gitmek için buraya tıklayın",
+      "russian": "Нажмите здесь, чтобы вернуться на главную"
     },
     "error-boundary-title": {
       "dutch": "Server kan verzoek niet verwerken. Doorsturen.",
@@ -34,7 +36,8 @@
       "mandarin": "服务器无法处理请求。 重定向。",
       "portuguese": "O servidor não pode processar a solicitação. Redirecionando.",
       "spanish": "El servidor no puede procesar la solicitud. Redirigiendo.",
-      "turkish": "Sunucu isteği işleyemiyor. Yeniden yönlendirme yapılıyor."
+      "turkish": "Sunucu isteği işleyemiyor. Yeniden yönlendirme yapılıyor.",
+      "russian": "Сервер не может обработать запрос. Перенаправление."
     },
     "error-invalid-link": {
       "dutch": "Ongeldige verificatielink of link verlopen",
@@ -46,7 +49,8 @@
       "mandarin": "无效的验证链接或链接已过期",
       "portuguese": "Link de verificação inválido ou link expirado",
       "spanish": "El enlace o el enlace de verificación ha expirado",
-      "turkish": "Hatalı ya da süresi geçmiş doğrulama linki"
+      "turkish": "Hatalı ya da süresi geçmiş doğrulama linki",
+      "russian": "Неверная ссылка для проверки или ссылка истекла"
     },
     "error-invalid-otp": {
       "dutch": "Ongeldige OTP, probeer het opnieuw",
@@ -58,7 +62,8 @@
       "mandarin": "无效的OTP，请重试",
       "portuguese": "OTP inválido, por favor tente novamente",
       "spanish": "OTP no válido, intente nuevamente",
-      "turkish": "Hatalı OTP, lütfen tekrar deneyin."
+      "turkish": "Hatalı OTP, lütfen tekrar deneyin.",
+      "russian": "Неверный OTP, попробуйте еще раз"
     },
     "error-invalid-params": {
       "dutch": "Ontbrekende of ongeldige parameters",
@@ -70,7 +75,8 @@
       "mandarin": "缺失或无效参数",
       "portuguese": "Parâmetros ausentes ou inválidos",
       "spanish": "Parámetros faltantes o no válidos",
-      "turkish": "Eksik ya da hatalı parametreler var."
+      "turkish": "Eksik ya da hatalı parametreler var.",
+      "russian": "Отсутствующие или недействительные параметры"
     },
     "error-max-retry-limit-reached": {
       "dutch": "U heeft de limiet voor verkeerde pogingen bereikt. Start de stroom opnieuw om de verificatie te voltooien.",
@@ -82,7 +88,8 @@
       "mandarin": "您已经达到了错误的尝试的极限。请再次重新启动流程以完成验证。",
       "portuguese": "Você atingiu o limite para tentativas erradas. Reinicie o fluxo novamente para concluir a verificação.",
       "spanish": "Has alcanzado el límite para intentos incorrectos. Reinicie el proceso para completar la verificación.",
-      "turkish": "Hatalı deneme limitine ulaştınız. Doğrulamayı tamamlamak için lütfen akışı baştan başlatın."
+      "turkish": "Hatalı deneme limitine ulaştınız. Doğrulamayı tamamlamak için lütfen akışı baştan başlatın.",
+      "russian": "Вы достигли лимита неправильных попыток. Пожалуйста, перезапустите процесс для завершения проверки."
     },
     "error-new-link-generated-heading": {
       "dutch": "Nieuwe verificatielink gegenereerd",
@@ -94,7 +101,8 @@
       "mandarin": "生成的新验证链接",
       "portuguese": "Novo link de verificação gerado",
       "spanish": "Nuevo enlace de verificación generado",
-      "turkish": "Yeni doğrulama linki oluşturuldu."
+      "turkish": "Yeni doğrulama linki oluşturuldu.",
+      "russian": "Создана новая ссылка для проверки"
     },
     "error-new-link-generated-info": {
       "dutch": "Verifieer met behulp van de laatste e-mail die u heeft ontvangen.",
@@ -106,7 +114,8 @@
       "mandarin": "请使用电子邮件中收到的最新邮件验证。",
       "portuguese": "Verifique o uso do e -mail mais recente recebido em seu e -mail.",
       "spanish": "Verifique el uso del último correo recibido en su correo electrónico.",
-      "turkish": "Lütfen e-postanıza gelen son e-posta ile doğrulama yapın."
+      "turkish": "Lütfen e-postanıza gelen son e-posta ile doğrulama yapın.",
+      "russian": "Пожалуйста, подтвердите через последнее письмо, полученное на вашу почту."
     },
     "error-no-mail-generated": {
       "dutch": "Geen e-mail gegenereerd. Start eerst de wachtwoordloze flow.",
@@ -118,7 +127,8 @@
       "mandarin": "没有生成邮件。请先启动无密码流。",
       "portuguese": "Nenhum correio gerado. Inicie o fluxo sem senha primeiro.",
       "spanish": "No se generó el correo. Inicie primero el proceso sin contraseña.",
-      "turkish": "E-posta oluşturulmadı. Lütfen önce şifresiz akışı başlatın."
+      "turkish": "E-posta oluşturulmadı. Lütfen önce şifresiz akışı başlatın.",
+      "russian": "Письмо не сгенерировано. Пожалуйста, сначала запустите процесс без пароля."
     },
     "error-no-sms-generated": {
       "dutch": "Geen OTP gegenereerd. Start eerst de wachtwoordloze flow.",
@@ -130,7 +140,8 @@
       "mandarin": "没有生成OTP。请先启动无密码流。",
       "portuguese": "Nenhum OTP gerado. Inicie o fluxo sem senha primeiro.",
       "spanish": "No se generó OTP. Inicie primero el proceso sin contraseña.",
-      "turkish": "OTP oluşturulmadı. Lütfen önce şifresiz akışı başlatın."
+      "turkish": "OTP oluşturulmadı. Lütfen önce şifresiz akışı başlatın.",
+      "russian": "OTP не сгенерирован. Пожалуйста, сначала запустите процесс без пароля."
     },
     "error-plan-limit-reached": {
       "dutch": "Planlimiet bereikt. Upgrade naar een groei- of hoger plan om meer sms-berichten te verzenden.",
@@ -142,7 +153,8 @@
       "mandarin": "已达到计划限制。请升级到增长或更高版本以发送更多短信",
       "portuguese": "Limite do plano atingido. Atualize para o plano de crescimento ou superior para enviar mais SMS",
       "spanish": "Se alcanzó el límite del plan. Actualice al plan de crecimiento o superior para enviar más SMS.",
-      "turkish": "Plan sınırına ulaşıldı.Daha fazla SMS göndermek için lütfen büyüme veya daha yüksek bir plana geçin."
+      "turkish": "Plan sınırına ulaşıldı.Daha fazla SMS göndermek için lütfen büyüme veya daha yüksek bir plana geçin.",
+      "russian": "Достигнут лимит плана. Пожалуйста, обновитесь до тарифа «Рост» или выше, чтобы отправлять больше SMS."
     },
     "error-otp-expired": {
       "dutch": "OTP verlopen",
@@ -154,7 +166,8 @@
       "mandarin": "OTP过期",
       "portuguese": "OTP expirou",
       "spanish": "OTP expiró",
-      "turkish": "OTP'nin süresi geçti."
+      "turkish": "OTP'nin süresi geçti.",
+      "russian": "OTP истек"
     },
     "error-sending-sms-failed": {
       "dutch": "Er is een fout opgetreden bij het verzenden van een sms. Probeer het opnieuw.",
@@ -166,7 +179,8 @@
       "mandarin": "发送短信的错误。请再试一遍。",
       "portuguese": "Houve um erro de envio de um SMS. Por favor, tente novamente.",
       "spanish": "Hubo un error al enviar el SMS. Inténtalo de nuevo.",
-      "turkish": "SMS gönderilirken bir hata oldu. Lütfen tekrar deneyin."
+      "turkish": "SMS gönderilirken bir hata oldu. Lütfen tekrar deneyin.",
+      "russian": "Ошибка при отправке SMS. Пожалуйста, попробуйте снова."
     },
     "error-something-wrong-error": {
       "dutch": "Er is iets misgegaan",
@@ -178,7 +192,8 @@
       "mandarin": "出问题了",
       "portuguese": "Algo deu errado",
       "spanish": "Algo salió mal",
-      "turkish": "Bir şeyler ters gitti"
+      "turkish": "Bir şeyler ters gitti",
+      "russian": "Что-то пошло не так"
     },
     "error-too-many-requests": {
       "dutch": "Te veel ontvangen verzoeken",
@@ -190,7 +205,8 @@
       "mandarin": "收到的请求太多",
       "portuguese": "Muitos pedidos recebidos",
       "spanish": "Demasiadas solicitudes recibidas",
-      "turkish": "Çok fazla talep alındı."
+      "turkish": "Çok fazla talep alındı.",
+      "russian": "Получено слишком много запросов"
     },
     "error-too-many-requests-info": {
       "dutch": "Je hebt te veel pogingen gedaan. Wacht 60 seconden voordat u het opnieuw probeert",
@@ -202,7 +218,8 @@
       "mandarin": "你已经做了太多的尝试。请等待 60 秒，然后重试",
       "portuguese": "Você fez muitas tentativas. Aguarde 60 segundos antes de tentar novamente",
       "spanish": "Ha hecho demasiados intentos. Espere 60 segundos antes de volver a intentarlo.",
-      "turkish": "Çok fazla deneme yaptınız. Tekrar denemeden önce lütfen 60 saniye bekleyin"
+      "turkish": "Çok fazla deneme yaptınız. Tekrar denemeden önce lütfen 60 saniye bekleyin.",
+      "russian": "Вы сделали слишком много попыток. Пожалуйста, подождите 60 секунд перед повторной попыткой"
     },
     "error-invalid-origin": {
       "english": "Something went wrong, error code: E002",
@@ -214,7 +231,7 @@
       "portuguese": "Algo deu errado, código de erro: E002",
       "spanish": "Algo salió mal, código de error: E002",
       "turkish": "Bir şeyler ters gitti, hata kodu: E002",
-      "dutch": "Er is iets misgegaan, foutcode: E002"
+      "russian": "Что-то пошло не так, код ошибки: E002"
     },
     "footer-text": {
       "dutch": "Zelfkusten via",
@@ -226,7 +243,8 @@
       "mandarin": "自我castody通过",
       "portuguese": "Autoconfiança via",
       "spanish": "Autocustodia a través de",
-      "turkish": "Kendi kendine saklama"
+      "turkish": "Kendi kendine saklama",
+      "russian": "Самостоятельное хранение через"
     },
     "invalid-phone-number-heading": {
       "dutch": "Ongeldig telefoonnummer",
@@ -238,7 +256,8 @@
       "mandarin": "无效的电话号码",
       "portuguese": "Número de telefone inválido",
       "spanish": "Numero de telefono invalido",
-      "turkish": "Hatalı telefon numarası."
+      "turkish": "Hatalı telefon numarası.",
+      "russian": "Неверный номер телефона"
     },
     "captcha-default-error": {
       "english": "An unexpected error occurred during verification. Please try reloading the page.",
@@ -250,7 +269,7 @@
       "portuguese": "Ocorreu um erro inesperado durante a verificação. Por favor, tente recarregar a página.",
       "spanish": "Se ha producido un error inesperado durante la verificación. Por favor, inténtelo de nuevo recargando la página.",
       "turkish": "Doğrulama sırasında beklenmedik bir hata oluştu. Lütfen sayfayı yeniden yükleyin.",
-      "dutch": "Er is iets misgegaan tijdens het verifiëren. Probeer het opnieuw door de pagina te laden."
+      "russian": "Во время проверки произошла непредвиденная ошибка. Пожалуйста, перезагрузите страницу."
     },
     "error-recaptcha-verification-failed": {
       "english": "Captcha verification failed. Please try again.",
@@ -262,7 +281,7 @@
       "portuguese": "A verificação Captcha falhou. Por favor, tente novamente.",
       "spanish": "La verificación de Captcha ha fallado. Por favor, inténtelo de nuevo.",
       "turkish": "Captcha doğrulama hatası. Lütfen tekrar deneyin.",
-      "dutch": "Er is iets misgegaan tijdens het verifiëren. Probeer het opnieuw door de pagina te laden."
+      "russian": "Проверка Captcha не удалась. Пожалуйста, попробуйте снова."
     },
     "invalid-phone-number-sub": {
       "dutch": "Voer het telefoonnummer in het volgende formaat in, bijvoorbeeld: +{'{cc}'}-{'{number}'}",
@@ -274,7 +293,8 @@
       "mandarin": "请以以下格式输入电话号码 例如： +{'{cc}'}-{'{number}'}",
       "portuguese": "Por favor, insira o número de telefone no seguinte formato Por exemplo: +{'{cc}'}-{'{number}'}",
       "spanish": "Ingrese el número de teléfono en el siguiente formato P.ej: +{'{cc}'}-{'{number}'}",
-      "turkish": "Lütfen telefon numaranızı şu formatta yazın: +{'{cc}'}-{'{numara}'}"
+      "turkish": "Lütfen telefon numaranızı şu formatta yazın: +{'{cc}'}-{'{numara}'}",
+      "russian": "Пожалуйста, введите номер телефона в формате: +{'{cc}'}-{'{number}'}"
     },
     "link-expire-subheading": {
       "dutch": "Verificatielink verloopt om de 5 minuten en kan slechts eenmaal worden gebruikt. Maak je geen zorgen, we kunnen de link opnieuw verzenden",
@@ -286,7 +306,8 @@
       "mandarin": "验证链接每5分钟到期，只能使用一次。不用担心，我们可以再次发送链接",
       "portuguese": "O link de verificação expira a cada 5 minutos e só pode ser usado uma vez. Não se preocupe, podemos enviar o link novamente",
       "spanish": "El enlace de verificación expira cada 5 minutos y solo se puede usar una vez. No te preocupes, podemos enviar el enlace nuevamente",
-      "turkish": "Doğrulama linki her 5 dakikada zaman aşımına uğrar ve tek seferliktir. Ancak endişelenmeyin, linki tekrardan gönderebiliriz."
+      "turkish": "Doğrulama linki her 5 dakikada zaman aşımına uğrar ve tek seferliktir. Ancak endişelenmeyin, linki tekrardan gönderebiliriz.",
+      "russian": "Ссылка истекает каждые 5 минут и может быть использована только один раз. Не волнуйтесь, мы можем отправить её снова"
     },
     "link-expired": {
       "dutch": "E -mailverificatie link is verlopen",
@@ -298,7 +319,8 @@
       "mandarin": "电子邮件验证链接已过期",
       "portuguese": "O link de verificação por e -mail expirou",
       "spanish": "El enlace de verificación por correo electrónico ha expirado",
-      "turkish": "E-posta doğrulama linkinin süresi doldu"
+      "turkish": "E-posta doğrulama linkinin süresi doldu",
+      "russian": "Ссылка для проверки электронной почты истекла"
     },
     "loader-done": {
       "dutch": "Klaar",
@@ -310,7 +332,8 @@
       "mandarin": "完毕",
       "portuguese": "Feito",
       "spanish": "Listo",
-      "turkish": "Tamamlandı"
+      "turkish": "Tamamlandı",
+      "russian": "Готово"
     },
     "loader-done-note": {
       "dutch": "Sluit dit en ga terug naar uw vorige venster",
@@ -322,7 +345,8 @@
       "mandarin": "关闭它并返回上一个窗口",
       "portuguese": "Feche isso e volte para a janela anterior",
       "spanish": "Cierra esto y vuelve a tu ventana anterior",
-      "turkish": "Bu sekmeyi kapatın ve önceki sekmeye geri dönün."
+      "turkish": "Bu sekmeyi kapatın ve önceki sekmeye geri dönün.",
+      "russian": "Закройте это и вернитесь к предыдущему окну"
     },
     "loader-logging-in": {
       "dutch": "Je wordt ingelogd",
@@ -334,7 +358,8 @@
       "mandarin": "登录",
       "portuguese": "Conectando você",
       "spanish": "Iniciar sesión",
-      "turkish": "Giriş yapılıyor."
+      "turkish": "Giriş yapılıyor.",
+      "russian": "Выполняется вход"
     },
     "loader-not-done-note": {
       "dutch": "We zijn er over een paar seconden",
@@ -346,7 +371,8 @@
       "mandarin": "我们将在几秒钟内到达",
       "portuguese": "Estaremos lá em alguns segundos",
       "spanish": "Estaremos allí en unos segundos",
-      "turkish": "Birkaç saniye sonra orada olacağız."
+      "turkish": "Birkaç saniye sonra orada olacağız.",
+      "russian": "Мы будем готовы через несколько секунд"
     },
     "loading": {
       "dutch": "Laden",
@@ -358,7 +384,8 @@
       "mandarin": "加载中",
       "portuguese": "Carregando",
       "spanish": "Cargando",
-      "turkish": "Yükleniyor"
+      "turkish": "Yükleniyor",
+      "russian": "Загрузка"
     },
     "login-code-verification-heading": {
       "dutch": "Verifieer uw e-mail",
@@ -370,7 +397,8 @@
       "mandarin": "验证您的电子邮件",
       "portuguese": "Verifique seu e-mail",
       "spanish": "Verifique su correo electrónico",
-      "turkish": "E-postanızı doğrulayın"
+      "turkish": "E-postanızı doğrulayın",
+      "russian": "Подтвердите вашу электронную почту"
     },
     "login-code-verification-sub-heading": {
       "dutch": "Bevestig de verzonden e-mail met dezelfde inlogcode",
@@ -382,7 +410,8 @@
       "mandarin": "请确认带有相同登录代码的发送电子邮件",
       "portuguese": "Confirme o e -mail enviado com o mesmo código de login",
       "spanish": "Confirme el correo electrónico enviado con el mismo código de inicio de sesión",
-      "turkish": "Lütfen size gönderilen e-postayı aynı giriş kodu ile doğrulayın."
+      "turkish": "Lütfen size gönderilen e-postayı aynı giriş kodu ile doğrulayın.",
+      "russian": "Пожалуйста, подтвердите отправленное письмо тем же кодом входа"
     },
     "otp-verification-response-success": {
       "dutch": "OTP geverifieerd",
@@ -394,7 +423,8 @@
       "mandarin": "已验证OTP",
       "portuguese": "OTP Verificado",
       "spanish": "OTP verificado",
-      "turkish": "OTP doğrulandı"
+      "turkish": "OTP doğrulandı",
+      "russian": "OTP подтвержден"
     },
     "resend-code-cta": {
       "dutch": "Code opnieuw verzenden",
@@ -406,7 +436,8 @@
       "mandarin": "重新发送验证码",
       "portuguese": "Reenviar código",
       "spanish": "Reenviar codigo",
-      "turkish": "Kodu yeniden gönder"
+      "turkish": "Kodu yeniden gönder",
+      "russian": "Отправить код повторно"
     },
     "resend-email-verification": {
       "dutch": "Stuur e -mailverificatie opnieuw",
@@ -418,7 +449,8 @@
       "mandarin": "重新发送电子邮件验证",
       "portuguese": "Reenviar a verificação de email",
       "spanish": "Reenviar la verificación del correo electrónico",
-      "turkish": "E-posta doğrulamasını tekrar gönder"
+      "turkish": "E-posta doğrulamasını tekrar gönder",
+      "russian": "Отправить проверку по электронной почте повторно"
     },
     "resend-mail-link": {
       "dutch": "E-mail opnieuw verzenden over {time} sec",
@@ -430,7 +462,8 @@
       "mandarin": "在 {time} 秒后重新发送邮件",
       "portuguese": "Reenviar e-mail em {time} seg",
       "spanish": "Reenviar correo en {time} seg",
-      "turkish": "Postayı {time} saniye içinde yeniden gönder"
+      "turkish": "Postayı {time} saniye içinde yeniden gönder",
+      "russian": "Отправить письмо повторно через {time} сек"
     },
     "resend-otp-code": {
       "dutch": "Code opnieuw verzenden over {time} sec",
@@ -442,7 +475,8 @@
       "mandarin": "在 {time} 秒内重新发送代码",
       "portuguese": "Reenviar código em {time} s",
       "spanish": "Reenviar código en {time} seg",
-      "turkish": "Kodu {time} saniye içinde yeniden gönder"
+      "turkish": "Kodu {time} saniye içinde yeniden gönder",
+      "russian": "Повторно отправить код через {time} сек"
     },
     "something-went-wrong-subheading": {
       "dutch": "Er was een fout tijdens uw inlogpoging. Probeer opnieuw in te loggen.",
@@ -454,7 +488,8 @@
       "mandarin": "在您的登录过程中存在错误。请尝试再次登录。",
       "portuguese": "Houve um erro durante sua tentativa de login. Por favor tente logar novamente.",
       "spanish": "Hubo un error durante su intento de inicio de sesión. Intente iniciar sesión nuevamente.",
-      "turkish": "Giriş yapmaya çalışırken bir hata ortaya çıktı. Lütfen giriş yapmayı tekrar deneyin."
+      "turkish": "Giriş yapmaya çalışırken bir hata ortaya çıktı. Lütfen giriş yapmayı tekrar deneyin.",
+      "russian": "Произошла ошибка во время попытки входа. Пожалуйста, попробуйте войти снова."
     },
     "start-invalid-url-error": {
       "dutch": "Ongeldige authenticatie-URL",
@@ -466,7 +501,8 @@
       "mandarin": "验证网址无效",
       "portuguese": "URL de autenticação inválido",
       "spanish": "URL de autenticación no válida",
-      "turkish": "Geçersiz kimlik doğrulama URL'si"
+      "turkish": "Geçersiz kimlik doğrulama URL'si",
+      "russian": "Неверный URL аутентификации"
     },
     "start-invalid-url-sub": {
       "dutch": "Url bevat ongeldige parameters",
@@ -478,7 +514,8 @@
       "mandarin": "网址包含无效参数",
       "portuguese": "URL contém parâmetros inválidos",
       "spanish": "La URL contiene parámetros no válidos",
-      "turkish": "URL geçersiz parametreler içeriyor."
+      "turkish": "URL geçersiz parametreler içeriyor.",
+      "russian": "URL содержит недействительные параметры"
     },
     "start-link-error": {
       "dutch": "De link is verlopen. Log opnieuw in om een nieuwe link te krijgen",
@@ -490,7 +527,8 @@
       "mandarin": "该链接已过期。再次登录以获取新链接",
       "portuguese": "O link expirou. Faça o login novamente para obter um novo link",
       "spanish": "El enlace ha expirado. Por favor, inicie sesión nuevamente para obtener un nuevo enlace",
-      "turkish": "Linkin süresi doldu. Yeni link almak için lütfen tekrar giriş yapın."
+      "turkish": "Linkin süresi doldu. Yeni link almak için lütfen tekrar giriş yapın.",
+      "russian": "Ссылка устарела. Пожалуйста, войдите снова, чтобы получить новую ссылку"
     },
     "start-link-sub": {
       "dutch": "Time-out",
@@ -502,7 +540,8 @@
       "mandarin": "超时",
       "portuguese": "Tempo esgotado",
       "spanish": "Se acabó el tiempo",
-      "turkish": "Zaman aşımı"
+      "turkish": "Zaman aşımı",
+      "russian": "Тайм-аут"
     },
     "start-magic-link-error": {
       "dutch": "Magische link verlopen",
@@ -514,7 +553,8 @@
       "mandarin": "魔法链接已过期",
       "portuguese": "Link mágico expirado",
       "spanish": "Enlace mágico caducado",
-      "turkish": "Sihirli linkin süresi doldu"
+      "turkish": "Sihirli linkin süresi doldu",
+      "russian": "Срок действия магической ссылки истек"
     },
     "start-resend-btn": {
       "dutch": "E-mail opnieuw verzenden",
@@ -526,7 +566,8 @@
       "mandarin": "重发电子邮件",
       "portuguese": "Reenviar email",
       "spanish": "Reenviar email",
-      "turkish": "E-postayı tekrar gönder"
+      "turkish": "E-postayı tekrar gönder",
+      "russian": "Отправить письмо повторно"
     },
     "start-resend-subtitle": {
       "dutch": "Verzoek om een andere e-mail te sturen om door te gaan met verificatie.",
@@ -538,7 +579,8 @@
       "mandarin": "请求发送另一封电子邮件以继续验证。",
       "portuguese": "Solicite o envio de outro e-mail para continuar com a verificação.",
       "spanish": "Solicite enviar otro correo electrónico para continuar con la verificación.",
-      "turkish": "Kimlik doğrulamasına devam etmek için yeni bir e-posta gönder."
+      "turkish": "Kimlik doğrulamasına devam etmek için yeni bir e-posta gönder.",
+      "russian": "Запросите отправку другого письма для продолжения проверки."
     },
     "start-something-wrong-error": {
       "dutch": "Er is iets misgegaan",
@@ -550,7 +592,8 @@
       "mandarin": "出问题了",
       "portuguese": "Algo deu errado",
       "spanish": "Algo salió mal",
-      "turkish": "Bir şeyler ters gitti"
+      "turkish": "Bir şeyler ters gitti",
+      "russian": "Что-то пошло не так"
     },
     "start-something-wrong-sub": {
       "dutch": "Onverwachte fout.",
@@ -562,7 +605,8 @@
       "mandarin": "意外的错误。",
       "portuguese": "Erro inesperado.",
       "spanish": "Error inesperado.",
-      "turkish": "Beklenmedik bir hata"
+      "turkish": "Beklenmedik bir hata",
+      "russian": "Неожиданная ошибка."
     },
     "start-verification-btn-toinbox": {
       "dutch": "Ga naar mijn inbox",
@@ -574,7 +618,8 @@
       "mandarin": "转到我的收件箱",
       "portuguese": "Ir para minha caixa de entrada",
       "spanish": "Ir a mi bandeja de entrada",
-      "turkish": "Gelen kutuma git"
+      "turkish": "Gelen kutuma git",
+      "russian": "Перейти во входящие"
     },
     "start-verification-subtitle1": {
       "dutch": "Verifieer uw e-mail",
@@ -586,7 +631,8 @@
       "mandarin": "请验证您的电子邮件",
       "portuguese": "Verifique seu e-mail",
       "spanish": "Verifique su correo electrónico",
-      "turkish": "Lütfen e-postanızı doğrulayın"
+      "turkish": "Lütfen e-postanızı doğrulayın",
+      "russian": "Пожалуйста, подтвердите вашу электронную почту"
     },
     "start-verification-subtitle2": {
       "dutch": "Er is een e-mail verzonden naar",
@@ -598,7 +644,8 @@
       "mandarin": "一封电子邮件已经发送至",
       "portuguese": "Um e-mail foi enviado para",
       "spanish": "Se ha enviado un correo electrónico a",
-      "turkish": "Bir e-posta gönderildi"
+      "turkish": "Bir e-posta gönderildi",
+      "russian": "Письмо было отправлено на"
     },
     "start-verification-subtitle3": {
       "dutch": "Verifieer uw e-mail om door te gaan.",
@@ -610,7 +657,8 @@
       "mandarin": "请验证您的电子邮件以继续。",
       "portuguese": "Verifique seu e-mail para continuar.",
       "spanish": "Verifique su correo electrónico para continuar.",
-      "turkish": "Devam etmek için lütfen e-postanızı doğrulayın"
+      "turkish": "Devam etmek için lütfen e-postanızı doğrulayın",
+      "russian": "Пожалуйста, подтвердите вашу электронную почту, чтобы продолжить."
     },
     "start-verification-subtitle4": {
       "dutch": "Geen e-mail ontvangen?",
@@ -622,7 +670,8 @@
       "mandarin": "没收到邮件吗？",
       "portuguese": "Não recebeu o email?",
       "spanish": "No recibiste el email?",
-      "turkish": "E-posta almadınız mı?"
+      "turkish": "E-posta almadınız mı?",
+      "russian": "Не получили письмо?"
     },
     "start-verification-text": {
       "dutch": "Controleer de e -mail met dezelfde inlogcode als hierboven.",
@@ -634,7 +683,8 @@
       "mandarin": "使用与上述相同的登录代码验证电子邮件。",
       "portuguese": "Verifique o email com o mesmo código de login acima.",
       "spanish": "Verifique el correo electrónico con el mismo código de inicio de sesión que el anterior.",
-      "turkish": "E-postanızı yukarıdaki kod ile doğrulayın."
+      "turkish": "E-postanızı yukarıdaki kod ile doğrulayın.",
+      "russian": "Подтвердите письмо тем же кодом входа, что и выше."
     },
     "start-verification-title": {
       "dutch": "Verificatie",
@@ -646,7 +696,8 @@
       "mandarin": "确认",
       "portuguese": "Verificação",
       "spanish": "Verificación",
-      "turkish": "Doğrulama"
+      "turkish": "Doğrulama",
+      "russian": "Проверка"
     },
     "verify-email-code-subheading": {
       "dutch": "Voer de 6-cijferige verificatiecode in die is verzonden naar uw e-mail",
@@ -658,7 +709,8 @@
       "mandarin": "请输入发送到您的电子邮件的6位验证代码",
       "portuguese": "Por favor, insira o código de verificação de 6 dígitos que foi enviado para o seu email",
       "spanish": "Ingrese el código de verificación de 6 dígitos que se envió a su correo electrónico",
-      "turkish": "Lütfen e-postanıza gelen 6 haneli doğrulama kodunu girin"
+      "turkish": "Lütfen e-postanıza gelen 6 haneli doğrulama kodunu girin",
+      "russian": "Пожалуйста, введите 6-значный код подтверждения, отправленный на вашу электронную почту"
     },
     "verify-email-code-title": {
       "dutch": "email verificatie",
@@ -670,7 +722,8 @@
       "mandarin": "电子邮件验证",
       "portuguese": "verificação de e-mail",
       "spanish": "Verificación de email",
-      "turkish": "E-posta doğrulaması"
+      "turkish": "E-posta doğrulaması",
+      "russian": "Подтверждение электронной почты"
     },
     "verify-error-error": {
       "dutch": "Er is iets misgegaan",
@@ -682,7 +735,8 @@
       "mandarin": "出问题了",
       "portuguese": "Algo deu errado",
       "spanish": "Algo salió mal",
-      "turkish": "Bir şeyler ters gitti"
+      "turkish": "Bir şeyler ters gitti",
+      "russian": "Что-то пошло не так"
     },
     "verify-error-info": {
       "dutch": "Fout",
@@ -694,7 +748,8 @@
       "mandarin": "错误",
       "portuguese": "Erro",
       "spanish": "Error",
-      "turkish": "Hata"
+      "turkish": "Hata",
+      "russian": "Ошибка"
     },
     "verify-invalid-link-error": {
       "dutch": "Ongeldige link",
@@ -706,7 +761,8 @@
       "mandarin": "无效的链接",
       "portuguese": "Link inválido",
       "spanish": "Enlace inválido",
-      "turkish": "Geçersiz link"
+      "turkish": "Geçersiz link",
+      "russian": "Неверная ссылка"
     },
     "verify-invalid-link-info": {
       "dutch": "Ongeldige parameters gevonden in link",
@@ -718,7 +774,8 @@
       "mandarin": "在链接中发现无效参数",
       "portuguese": "Parâmetros inválidos encontrados no link",
       "spanish": "Se encontraron parámetros no válidos en el enlace",
-      "turkish": "Link içerisinde geçersiz parametreler bulundu"
+      "turkish": "Link içerisinde geçersiz parametreler bulundu",
+      "russian": "В ссылке найдены недействительные параметры"
     },
     "verify-invalid-link-tempkey-error": {
       "dutch": "Ongeldige link, geldige link moet tempPubKey bevatten",
@@ -730,7 +787,8 @@
       "mandarin": "无效链接，有效链接应包含 tempPubKey",
       "portuguese": "Link inválido, link válido deve conter tempPubKey",
       "spanish": "Enlace no válido, el enlace válido debe contener tempPubKey",
-      "turkish": "Geçersiz link, geçerli linkin temPubKey içermesi gerekiyor."
+      "turkish": "Geçersiz link, geçerli linkin tempPubKey içermesi gerekiyor.",
+      "russian": "Неверная ссылка, действительная ссылка должна содержать tempPubKey"
     },
     "verify-link-expired-error": {
       "dutch": "Link verlopen",
@@ -742,7 +800,8 @@
       "mandarin": "链接已过期",
       "portuguese": "Link expirado",
       "spanish": "Enlace expirado",
-      "turkish": "Linkin süresi doldu"
+      "turkish": "Linkin süresi doldu",
+      "russian": "Срок действия ссылки истек"
     },
     "verify-link-expired-guide1": {
       "dutch": "Keer terug naar het oorspronkelijke venster om een nieuwe link aan te vragen",
@@ -754,7 +813,8 @@
       "mandarin": "返回原始窗口以请求新链接",
       "portuguese": "Retorne à janela original para solicitar um novo link",
       "spanish": "Regrese a la ventana original para solicitar un nuevo enlace",
-      "turkish": "Yeni bir link istemek için orijinal sayfaya geri dönün"
+      "turkish": "Yeni bir link istemek için orijinal sayfaya geri dönün",
+      "russian": "Вернитесь к исходному окну, чтобы запросить новую ссылку"
     },
     "verify-link-expired-guide2": {
       "dutch": "U kunt dit venster sluiten",
@@ -766,7 +826,8 @@
       "mandarin": "您可以关闭此窗口",
       "portuguese": "Você pode fechar esta janela",
       "spanish": "Puedes cerrar esta ventana",
-      "turkish": "Bu sayfayı kapatabilirsiniz."
+      "turkish": "Bu sayfayı kapatabilirsiniz.",
+      "russian": "Вы можете закрыть это окно"
     },
     "verify-link-expired-info": {
       "dutch": "Time-out",
@@ -778,7 +839,8 @@
       "mandarin": "超时",
       "portuguese": "Tempo esgotado",
       "spanish": "Se acabó el tiempo",
-      "turkish": "Zaman aşımı"
+      "turkish": "Zaman aşımı",
+      "russian": "Тайм-аут"
     },
     "verify-loggedin": {
       "dutch": "U bent ingelogd, u kunt terugkeren naar uw oorspronkelijke tabblad.",
@@ -790,7 +852,8 @@
       "mandarin": "您已登录，您可以返回原来的选项卡。",
       "portuguese": "Você está logado, você pode voltar para sua guia original.",
       "spanish": "Ha iniciado sesión, puede volver a la pestaña original.",
-      "turkish": "Giriş yaptınız, orijinal sekmeye geri dönebilirsiniz."
+      "turkish": "Giriş yaptınız, orijinal sekmeye geri dönebilirsiniz.",
+      "russian": "Вы вошли в систему, вы можете вернуться на исходную вкладку."
     },
     "verify-otp-heading-1": {
       "dutch": "Er is een OTP verzonden naar",
@@ -802,7 +865,8 @@
       "mandarin": "OTP已发送到",
       "portuguese": "Um OTP foi enviado para",
       "spanish": "Se ha enviado un OTP a",
-      "turkish": "Bir OTP gönderildi"
+      "turkish": "Bir OTP gönderildi",
+      "russian": "OTP был отправлен на"
     },
     "verify-otp-heading-2": {
       "dutch": "Voer OTP in om door te gaan",
@@ -814,7 +878,8 @@
       "mandarin": "输入OTP继续",
       "portuguese": "Digite o OTP para continuar",
       "spanish": "Ingrese OTP para continuar",
-      "turkish": "Devam etmek için OTP'yi girin"
+      "turkish": "Devam etmek için OTP'yi girin",
+      "russian": "Введите OTP, чтобы продолжить"
     },
     "verify-otp-subheading": {
       "dutch": "Voer de OTP in die wordt verzonden naar",
@@ -826,7 +891,8 @@
       "mandarin": "输入发送到的OTP",
       "portuguese": "Digite o OTP enviado para",
       "spanish": "Ingrese el OTP enviado a",
-      "turkish": "Aldığınız OTP'yi girin."
+      "turkish": "Aldığınız OTP'yi girin.",
+      "russian": "Введите OTP, отправленный на "
     },
     "verify-otp-title": {
       "dutch": "OTP -verificatie",
@@ -838,7 +904,8 @@
       "mandarin": "OTP验证",
       "portuguese": "Verificação de OTP",
       "spanish": "Verificación OTP",
-      "turkish": "OTP doğrulaması"
+      "turkish": "OTP doğrulaması",
+      "russian": "Подтверждение OTP"
     },
     "verify-otp-title-redirect": {
       "dutch": "Voer uw OTP in",
@@ -850,7 +917,8 @@
       "mandarin": "输入您的OTP",
       "portuguese": "Digite seu OTP",
       "spanish": "Ingrese su OTP",
-      "turkish": "OTP'nizi girin"
+      "turkish": "OTP'nizi girin",
+      "russian": "Введите ваш OTP"
     }
   }
 }

--- a/Openlogin-locale/locales-wallet-account.json
+++ b/Openlogin-locale/locales-wallet-account.json
@@ -180,7 +180,7 @@
       "portuguese": "Logins sociais via Torus nodes",
       "spanish": "Inicios de sesión de redes sociales a través de nodos Torus",
       "turkish": "Torus nodes ile sosyal medya oturumu aç",
-      "russian": "Социальный вход через узлы Torus"
+      "russian": "Вход через социальные сети с использованием узлов Torus"
     },
     "auth-factors-password": {
       "dutch": "Account wachtwoord",
@@ -661,7 +661,7 @@
       "portuguese": "Alterar Fator Social",
       "spanish": "Cambiar el factor social",
       "turkish": "Sosyal medya faktörünü değiştirin",
-      "russian": "Изменить социальный фактор"
+      "russian": "Изменить способ восстановления через соцсети"
     },
     "title": {
       "dutch": "Account",

--- a/Openlogin-locale/locales-wallet-account.json
+++ b/Openlogin-locale/locales-wallet-account.json
@@ -10,7 +10,8 @@
       "mandarin": "启用生物识别",
       "portuguese": "biometria cadastrada",
       "spanish": "biometría registrada",
-      "turkish": "biyometrik veriler kaydedildi"
+      "turkish": "biyometrik veriler kaydedildi",
+      "russian": "биометрия зарегистрирована"
     },
     "auth-factors-device-current": {
       "dutch": "Huidig",
@@ -22,7 +23,8 @@
       "mandarin": "当前的",
       "portuguese": "Atual",
       "spanish": "Actual",
-      "turkish": "Mevcut"
+      "turkish": "Mevcut",
+      "russian": "Текущий"
     },
     "auth-factors-device-desc": {
       "dutch": "Deze apparaten zijn unieke factoren die gemachtigd zijn om toegang te krijgen tot uw account.",
@@ -34,7 +36,8 @@
       "mandarin": "这些设备是被授权访问您的帐户的独特因素。",
       "portuguese": "Esses dispositivos são fatores exclusivos autorizados a acessar sua conta.",
       "spanish": "Estos dispositivos son factores únicos autorizados para acceder a su cuenta.",
-      "turkish": "Hesabınıza yalnızca bu cihazlar ile erişilebilir."
+      "turkish": "Hesabınıza yalnızca bu cihazlar ile erişilebilir.",
+      "russian": "Эти устройства являются уникальными факторами, авторизованными для доступа к вашему аккаунту."
     },
     "auth-factors-device-empty": {
       "dutch": "Geen apparaat delingen gevonden",
@@ -46,7 +49,8 @@
       "mandarin": "未找到设备共享",
       "portuguese": "Nenhum compartilhamento de dispositivo encontrado",
       "spanish": "No se encontraron fragmentos de dispositivos",
-      "turkish": "Cihaz şifre parçaları bulunamadı"
+      "turkish": "Cihaz şifre parçaları bulunamadı",
+      "russian": "Не найдено ни одного устройства"
     },
     "auth-factors-device-title": {
       "dutch": "Appara(a)t(en)",
@@ -58,7 +62,8 @@
       "mandarin": "设备",
       "portuguese": "Dispositivo(s)",
       "spanish": "Dispositivos",
-      "turkish": "Cihaz(lar)"
+      "turkish": "Cihaz(lar)",
+      "russian": "Устройство(а)"
     },
     "auth-factors-downloaded-on": {
       "dutch": "Gedownload op {0}",
@@ -70,7 +75,8 @@
       "mandarin": "于 {0} 下载",
       "portuguese": "Baixado em {0}",
       "spanish": "Descargado el {0}",
-      "turkish": "Şuraya indirildi {0}"
+      "turkish": "Şuraya indirildi {0}",
+      "russian": "Загружено {0}"
     },
     "auth-factors-email": {
       "dutch": "Herstel e-mail",
@@ -82,7 +88,8 @@
       "mandarin": "辅助邮箱",
       "portuguese": "Email de recuperação",
       "spanish": "Correo electrónico de recuperación",
-      "turkish": "Kurtarma e-postası"
+      "turkish": "Kurtarma e-postası",
+      "russian": "Почта для восстановления"
     },
     "auth-factors-email-enter": {
       "dutch": "Voer het herstel-e-mailadres in",
@@ -94,7 +101,8 @@
       "mandarin": "输入辅助邮箱",
       "portuguese": "Digite o e-mail de recuperação",
       "spanish": "Ingresa el correo de recuperación",
-      "turkish": "Kurtarma e-postasını girin"
+      "turkish": "Kurtarma e-postasını girin",
+      "russian": "Введите адрес электронной почты для восстановления"
     },
     "auth-factors-email-old": {
       "dutch": "Herstel e-mail (bestaand)",
@@ -106,7 +114,8 @@
       "mandarin": "辅助邮箱（现有）",
       "portuguese": "E-mail de recuperação (existente)",
       "spanish": "Correo electrónico de recuperación (existente)",
-      "turkish": "Kurtarma e-postası (mevcut)"
+      "turkish": "Kurtarma e-postası (mevcut)",
+      "russian": "Почта для восстановления (существующая)"
     },
     "auth-factors-email-resend": {
       "dutch": "Opnieuw verzenden",
@@ -118,7 +127,8 @@
       "mandarin": "重发",
       "portuguese": "Reenviar",
       "spanish": "Reenviar",
-      "turkish": "Tekrar gönder"
+      "turkish": "Tekrar gönder",
+      "russian": "Отправить повторно"
     },
     "auth-factors-email-sent": {
       "dutch": "Verzonden",
@@ -130,7 +140,8 @@
       "mandarin": "发送",
       "portuguese": "Enviado",
       "spanish": "Enviado",
-      "turkish": "Gönderildi"
+      "turkish": "Gönderildi",
+      "russian": "Отправлено"
     },
     "auth-factors-email-sent-to": {
       "dutch": "Verzonden naar {0}",
@@ -142,7 +153,8 @@
       "mandarin": "发送到{0}",
       "portuguese": "Enviado para {0}",
       "spanish": "Enviado a {0}",
-      "turkish": "Şuna gönder {0}"
+      "turkish": "Şuna gönder {0}",
+      "russian": "Отправлено на {0}"
     },
     "auth-factors-enable-biometrics": {
       "dutch": "Biometrie inschakelen",
@@ -154,7 +166,8 @@
       "mandarin": "生物识别注册",
       "portuguese": "Ativar biometria",
       "spanish": "Habilitar la biometría",
-      "turkish": "Biyometrik özelliği aktifleştir"
+      "turkish": "Biyometrik özelliği aktifleştir",
+      "russian": "Включить биометрию"
     },
     "auth-factors-network": {
       "dutch": "Sociale logins via Torus-nodes",
@@ -166,7 +179,8 @@
       "mandarin": "通过Torus节点进行社交登录",
       "portuguese": "Logins sociais via Torus nodes",
       "spanish": "Inicios de sesión de redes sociales a través de nodos Torus",
-      "turkish": "Torus nodes ile sosyal medya oturumu aç"
+      "turkish": "Torus nodes ile sosyal medya oturumu aç",
+      "russian": "Социальный вход через узлы Torus"
     },
     "auth-factors-password": {
       "dutch": "Account wachtwoord",
@@ -178,7 +192,8 @@
       "mandarin": "户口密码",
       "portuguese": "Senha da conta",
       "spanish": "Contraseña de la cuenta",
-      "turkish": "Hesap şifresi"
+      "turkish": "Hesap şifresi",
+      "russian": "Пароль аккаунта"
     },
     "auth-factors-password-change": {
       "dutch": "Wachtwoord wijzigen",
@@ -190,7 +205,8 @@
       "mandarin": "更改密码",
       "portuguese": "Mudar senha",
       "spanish": "Cambia la contraseña",
-      "turkish": "Şifreyi değiştirin"
+      "turkish": "Şifreyi değiştirin",
+      "russian": "Сменить пароль"
     },
     "auth-factors-password-confirm": {
       "dutch": "Voer uw wachtwoord opnieuw in",
@@ -202,7 +218,8 @@
       "mandarin": "重新输入密码",
       "portuguese": "Redigite sua senha",
       "spanish": "Reingresa tu contraseña",
-      "turkish": "Şifreyi tekrar girin"
+      "turkish": "Şifreyi tekrar girin",
+      "russian": "Повторно введите пароль"
     },
     "auth-factors-password-set": {
       "dutch": "Stel je wachtwoord in",
@@ -214,7 +231,8 @@
       "mandarin": "设置你的密码",
       "portuguese": "Coloque sua senha",
       "spanish": "Establece tu contraseña",
-      "turkish": "Şifrenizi belirleyin"
+      "turkish": "Şifrenizi belirleyin",
+      "russian": "Установить пароль"
     },
     "auth-factors-recovery-phrase": {
       "dutch": "Herstelzin",
@@ -226,7 +244,8 @@
       "mandarin": "恢复短语",
       "portuguese": "Frase de recuperação",
       "spanish": "Frase de recuperación",
-      "turkish": "Kurtarma aşaması"
+      "turkish": "Kurtarma aşaması",
+      "russian": "Фраза восстановления"
     },
     "auth-factors-subtitle": {
       "dutch": "Lijst van authenticatiefactoren",
@@ -238,7 +257,8 @@
       "mandarin": "认证因素清单",
       "portuguese": "Lista de fatores de autenticação",
       "spanish": "Lista de factores de autenticación",
-      "turkish": "Kimlik doğrulama faktörlerinin listesi"
+      "turkish": "Kimlik doğrulama faktörlerinin listesi",
+      "russian": "Список факторов аутентификации"
     },
     "auth-factors-threshold": {
       "dutch": "Beveiligingsfactoren",
@@ -250,7 +270,8 @@
       "mandarin": "安全因素",
       "portuguese": "Fatores de segurança",
       "spanish": "Factores de seguridad",
-      "turkish": "Güvenlik faktörleri"
+      "turkish": "Güvenlik faktörleri",
+      "russian": "Факторы безопасности"
     },
     "auth-factors-threshold-desc": {
       "dutch": "Het aantal factoren dat geauthenticeerd moet worden om toegang te krijgen tot uw account.",
@@ -262,7 +283,8 @@
       "mandarin": "要访问您的帐户进行身份验证的因素数量。",
       "portuguese": "O número de fatores a serem autenticados para acessar sua conta.",
       "spanish": "La cantidad de factores que se deben autenticar para acceder a su cuenta.",
-      "turkish": "Hesabınıza erişmek için kimlik doğrulama faktörlerinin sayısı"
+      "turkish": "Hesabınıza erişmek için kimlik doğrulama faktörlerinin sayısı",
+      "russian": "Количество факторов, необходимых для доступа к вашему аккаунту."
     },
     "auth-factors-threshold-factor": {
       "dutch": "{0} Authenticatiefactor",
@@ -274,7 +296,8 @@
       "mandarin": "{0}认证因素",
       "portuguese": "{0} Fator de autenticação",
       "spanish": "{0} Factor de autenticación",
-      "turkish": "{0} Kimlik doğrulama faktörü"
+      "turkish": "{0} Kimlik doğrulama faktörü",
+      "russian": "{0} фактор аутентификации"
     },
     "auth-factors-title": {
       "dutch": "Beveiligingsinstellingen",
@@ -286,7 +309,8 @@
       "mandarin": "安全设定",
       "portuguese": "Configurações de segurança",
       "spanish": "Configuraciones de seguridad",
-      "turkish": "Güvenlik Ayarları"
+      "turkish": "Güvenlik Ayarları",
+      "russian": "Настройки безопасности"
     },
     "copy-recovery-phrase-desc": {
       "dutch": "Sla een kopie op van uw herstelfrase",
@@ -298,7 +322,8 @@
       "mandarin": "保存恢复短语的副本",
       "portuguese": "Salve uma cópia da sua frase de recuperação",
       "spanish": "Guarde una copia de tu frase de recuperación",
-      "turkish": "Kurtarma aşamanızın bir kopyasını kaydedin"
+      "turkish": "Kurtarma aşamanızın bir kopyasını kaydedin",
+      "russian": "Сохраните копию фразы восстановления"
     },
     "delete-recovery-title": {
       "dutch": "Herstelfactor verwijderen",
@@ -310,7 +335,8 @@
       "mandarin": "删除恢复因子",
       "portuguese": "Excluir fator de recuperação",
       "spanish": "Eliminar factor de recuperación",
-      "turkish": "Kurtarma faktörünü sil"
+      "turkish": "Kurtarma faktörünü sil",
+      "russian": "Удалить фактор восстановления"
     },
     "delete-share-desc-1": {
       "dutch": "Wees heel zeker als",
@@ -322,7 +348,8 @@
       "mandarin": "非常确定",
       "portuguese": "Tenha muita certeza como",
       "spanish": "Está muy seguro de querer",
-      "turkish": "Emin olun"
+      "turkish": "Emin olun",
+      "russian": "Будьте очень уверены, так как"
     },
     "delete-share-desc-2": {
       "dutch": "deze actie is permanent en kan niet ongedaan worden gemaakt.",
@@ -334,7 +361,8 @@
       "mandarin": "此操作是永久性的，无法撤消。",
       "portuguese": "esta ação é permanente e não pode ser desfeita.",
       "spanish": "esta acción es permanente y no se puede deshacer.",
-      "turkish": "bu eylem kalıcıdır ve geri alınamaz."
+      "turkish": "bu eylem kalıcıdır ve geri alınamaz.",
+      "russian": "это действие необратимо и не может быть отменено."
     },
     "delete-share-title": {
       "dutch": "Verwijder authenticatiefactor",
@@ -346,7 +374,8 @@
       "mandarin": "删除认证因素",
       "portuguese": "Excluir fator de autenticação",
       "spanish": "Eliminar factor de autenticación",
-      "turkish": "Kimlik doğrulama faktörünü sil"
+      "turkish": "Kimlik doğrulama faktörünü sil",
+      "russian": "Удалить фактор аутентификации"
     },
     "desc": {
       "dutch": "Beheer hier uw OpenLogin-instellingen",
@@ -358,7 +387,8 @@
       "mandarin": "在此处管理您的OpenLogin设置",
       "portuguese": "Gerencie suas configurações do OpenLogin aqui",
       "spanish": "Administre su configuración de OpenLogin aquí",
-      "turkish": "OpenLogin ayarlarınızı buradan kontrol edin"
+      "turkish": "OpenLogin ayarlarınızı buradan kontrol edin",
+      "russian": "Управляйте настройками OpenLogin здесь"
     },
     "email-with-date": {
       "dutch": "Verstuurd via e-mail op {0} naar:",
@@ -370,7 +400,8 @@
       "mandarin": "于 {0} 通过电子邮件发送至：",
       "portuguese": "Enviado por e-mail em {0} para:",
       "spanish": "Enviado por correo electrónico el {0} a:",
-      "turkish": "{0}'a e-posta gönderildi"
+      "turkish": "{0}'a e-posta gönderildi",
+      "russian": "Отправлено по электронной почте {0} на:"
     },
     "export-onkey-2fa": {
       "dutch": "Twee-factor authenticatie",
@@ -382,7 +413,8 @@
       "mandarin": "双因素身份验证",
       "portuguese": "Autenticação de dois fatores",
       "spanish": "Autenticación de dos factores",
-      "turkish": "İki-aşamalı kimlik doğrulama"
+      "turkish": "İki-aşamalı kimlik doğrulama",
+      "russian": "Двухфакторная аутентификация"
     },
     "export-onkey-2fa-enable": {
       "dutch": "2FA inschakelen",
@@ -394,7 +426,8 @@
       "mandarin": "启用 2FA",
       "portuguese": "Ativar 2FA",
       "spanish": "Habilitar segundo factor de autenticación (2FA)",
-      "turkish": "2FA'yı aktive et"
+      "turkish": "2FA'yı aktive et",
+      "russian": "Включить 2FA"
     },
     "export-onkey-2fa-recommend": {
       "dutch": "We raden u ten zeerste aan om 2FA in te schakelen op uw account",
@@ -406,7 +439,8 @@
       "mandarin": "我们强烈建议您在您的帐户上启用 2FA",
       "portuguese": "Recomendamos vivamente que ative o 2FA na sua conta",
       "spanish": "Le recomendamos encarecidamente que habilite 2FA en su cuenta",
-      "turkish": "2FA'yı aktive etmenizi şiddetle öneriyoruz."
+      "turkish": "2FA'yı aktive etmenizi şiddetle öneriyoruz.",
+      "russian": "Мы настоятельно рекомендуем включить 2FA для вашего аккаунта"
     },
     "export-onkey-not-setup": {
       "dutch": "Nog niet ingesteld",
@@ -418,7 +452,8 @@
       "mandarin": "尚未设置",
       "portuguese": "Ainda não configurado",
       "spanish": "Aún no configurado",
-      "turkish": "Henüz bir ayar yok"
+      "turkish": "Henüz bir ayar yok",
+      "russian": "Еще не настроено"
     },
     "export-onkey-note": {
       "dutch": "Verhoog uw accountbeveiliging door 2FA in te schakelen",
@@ -430,7 +465,8 @@
       "mandarin": "通过启用 2FA 提高您的帐户安全性",
       "portuguese": "Aumente a segurança da sua conta ativando o 2FA",
       "spanish": "Aumente la seguridad de su cuenta habilitando 2FA",
-      "turkish": "2FA'yı aktive ederek hesap güvenliğinizi arttırın."
+      "turkish": "2FA'yı aktive ederek hesap güvenliğinizi arttırın.",
+      "russian": "Повысить безопасность аккаунта, включив 2FA"
     },
     "export-onkey-setup": {
       "dutch": "Stel het in",
@@ -442,7 +478,8 @@
       "mandarin": "设置它",
       "portuguese": "Configurá-lo",
       "spanish": "Prepararlo",
-      "turkish": "Ayarla"
+      "turkish": "Ayarla",
+      "russian": "Настроить"
     },
     "export-share-copy": {
       "dutch": "Klik om te kopiëren",
@@ -454,7 +491,8 @@
       "mandarin": "点击复制",
       "portuguese": "Clique para copiar",
       "spanish": "Haga clic para copiar",
-      "turkish": "Kopyalamak için tıklayın"
+      "turkish": "Kopyalamak için tıklayın",
+      "russian": "Нажмите, чтобы скопировать"
     },
     "export-share-desc": {
       "dutch": "Sla een kopie op van uw back-upzin",
@@ -466,7 +504,8 @@
       "mandarin": "保存备份短语的副本",
       "portuguese": "Salve uma cópia da sua frase de backup",
       "spanish": "Guarde una copia de su frase de respaldo",
-      "turkish": "Yedekleme aşamanız için bir kopya kaydedin."
+      "turkish": "Yedekleme aşamanız için bir kopya kaydedin.",
+      "russian": "Сохраните копию вашей резервной фразы"
     },
     "export-share-note": {
       "dutch": "Opmerking: deze herstelzin is 1 van de factoren die nodig zijn om uw account te authenticeren. Bewaar het op een veilige plaats als onderdeel van uw accountherstel in de toekomst.",
@@ -478,7 +517,8 @@
       "mandarin": "注意：此恢复短语是验证您的帐户所需的因素之一。 将其保存在安全的地方，作为将来恢复帐户的一部分。",
       "portuguese": "Observação: esta frase de recuperação é um dos fatores necessários para autenticar sua conta. Guarde-o em algum lugar seguro como parte da recuperação de sua conta no futuro.",
       "spanish": "Nota: Esta frase de recuperación es uno de los factores necesarios para autenticar su cuenta. Guárdelo en un lugar seguro como parte de la recuperación de su cuenta en el futuro.",
-      "turkish": "Not: Bu kurtarma aşaması, hesabınızın kimlik doğrulaması sırasında gerekli faktörlerden birisi. İleride hesabınızı kurtarabilmeniz için güvenli bir yerde saklayın."
+      "turkish": "Not: Bu kurtarma aşaması, hesabınızın kimlik doğrulaması sırasında gerekli faktörlerden birisi. İleride hesabınızı kurtarabilmeniz için güvenli bir yerde saklayın.",
+      "russian": "Примечание: эта фраза восстановления является одним из факторов, необходимых для аутентификации вашего аккаунта. Храните ее в надежном месте как часть процесса восстановления аккаунта в будущем."
     },
     "export-share-title": {
       "dutch": "Back-up zin",
@@ -490,7 +530,8 @@
       "mandarin": "备用词组",
       "portuguese": "Frase de backup",
       "spanish": "Frase de respaldo",
-      "turkish": "Yedekleme aşaması"
+      "turkish": "Yedekleme aşaması",
+      "russian": "Фраза резервного копирования"
     },
     "mpc-auth-factors-recovery-phrase": {
       "dutch": "Herstelfactor",
@@ -502,7 +543,8 @@
       "mandarin": "恢复系数",
       "portuguese": "Fator de recuperação",
       "spanish": "Factor de recuperación",
-      "turkish": "Kurtarma faktörü"
+      "turkish": "Kurtarma faktörü",
+      "russian": "Фактор восстановления"
     },
     "mpc-export-share-note": {
       "dutch": "Opmerking: Dit herstelfactor is 1 van de factoren die nodig zijn om uw account te authenticeren. Bewaar het op een veilige plaats als onderdeel van uw accountherstel in de toekomst.",
@@ -514,7 +556,8 @@
       "mandarin": "注意：此恢复因素是验证您的帐户所需的因素之一。将其保存在安全的地方，作为您未来帐户恢复的一部分。",
       "portuguese": "Observação: esse fator de recuperação é um dos fatores necessários para autenticar sua conta. Guarde-o em algum lugar seguro como parte da recuperação de sua conta no futuro.",
       "spanish": "Nota: este factor de recuperación es uno de los factores necesarios para autenticar su cuenta. Manténgalo en un lugar seguro como parte de la recuperación de su cuenta en el futuro.",
-      "turkish": "Not: Bu kurtarma faktörü, hesabınızın kimlik doğrulaması sırasında gerekli faktörlerden birisi. İleride hesabınızı kurtarabilmeniz için güvenli bir yerde saklayın."
+      "turkish": "Not: Bu kurtarma faktörü, hesabınızın kimlik doğrulaması sırasında gerekli faktörlerden birisi. İleride hesabınızı kurtarabilmeniz için güvenli bir yerde saklayın.",
+      "russian": "Примечание: этот фактор восстановления является одним из необходимых для аутентификации вашего аккаунта. Сохраните его в надежном месте как часть восстановления аккаунта в будущем."
     },
     "password-requirement": {
       "dutch": "Wachtwoordvereisten:",
@@ -526,7 +569,8 @@
       "mandarin": "密码要求：",
       "portuguese": "Requisitos de senha:",
       "spanish": "Requisitos de la contraseña:",
-      "turkish": "Şifre gereklilikleri"
+      "turkish": "Şifre gereklilikleri",
+      "russian": "Требования к паролю:"
     },
     "password-requirement-10-char": {
       "dutch": "Minimaal 10 tekens (en maximaal 100 tekens)",
@@ -538,7 +582,8 @@
       "mandarin": "至少 10 个字符（最多 100 个字符）",
       "portuguese": "Pelo menos 10 caracteres (e até 100 caracteres)",
       "spanish": "Al menos 10 caracteres (y hasta 100 caracteres)",
-      "turkish": "En az 10 karakter (ve en fazla 100 karakter)"
+      "turkish": "En az 10 karakter (ve en fazla 100 karakter)",
+      "russian": "Не менее 10 символов (и до 100 символов)"
     },
     "password-requirement-desc": {
       "dutch": "Zorg ervoor dat aan deze vereisten wordt voldaan:",
@@ -550,7 +595,8 @@
       "mandarin": "确保满足这些要求：",
       "portuguese": "Certifique-se de que estes requisitos sejam atendidos:",
       "spanish": "Asegúrese de que se cumplan estos requisitos:",
-      "turkish": "Bu gerekliliklerin yerine getirildiğinden emin olun:"
+      "turkish": "Bu gerekliliklerin yerine getirildiğinden emin olun:",
+      "russian": "Убедитесь, что эти требования выполнены:"
     },
     "password-requirement-lowercase": {
       "dutch": "Minstens één kleine letter vereist",
@@ -562,7 +608,8 @@
       "mandarin": "至少一个小写字符",
       "portuguese": "Pelo menos um caractere minúsculo",
       "spanish": "Al menos un carácter en minúscula",
-      "turkish": "En az bir küçük karakter"
+      "turkish": "En az bir küçük karakter",
+      "russian": "Не менее одного строчного символа"
     },
     "password-requirement-specialchar": {
       "dutch": "Inclusief ten minste één speciaal teken, bijv. {'! @ # ?'}",
@@ -574,7 +621,8 @@
       "mandarin": "至少包含一个特殊字符，例如，{'! @ # ?'}",
       "portuguese": "Inclusão de pelo menos um caractere especial, por exemplo, {'! @ # ?'}",
       "spanish": "Incluya al menos un carácter especial, por ejemplo, {'! @ # ?'}",
-      "turkish": "En az bir özel karakter içermelidir, {'!@#?'}"
+      "turkish": "En az bir özel karakter içermelidir, {'!@#?'}",
+      "russian": "Включите хотя бы один специальный символ, например {'! @ # ?'}"
     },
     "password-requirement-upercase": {
       "dutch": "Minimaal 10 tekens (en maximaal 100 tekens) met ten minste één hoofdletter",
@@ -586,7 +634,8 @@
       "mandarin": "至少一个大写字符",
       "portuguese": "Pelo menos um caractere maiúsculo",
       "spanish": "Al menos un carácter en mayúscula",
-      "turkish": "En az bir büyük harf"
+      "turkish": "En az bir büyük harf",
+      "russian": "Не менее одного заглавного символа"
     },
     "remove-share-button": {
       "dutch": "Verwijder deelknop",
@@ -598,7 +647,8 @@
       "mandarin": "删除共享",
       "portuguese": "Remover compartilhamento",
       "spanish": "Remover fragmento",
-      "turkish": "Şifre parçasını sil"
+      "turkish": "Şifre parçasını sil",
+      "russian": "Удалить долю"
     },
     "social-factor-change": {
       "dutch": "Verander sociale factor",
@@ -610,7 +660,8 @@
       "mandarin": "改变社会因素",
       "portuguese": "Alterar Fator Social",
       "spanish": "Cambiar el factor social",
-      "turkish": "Sosyal medya faktörünü değiştirin"
+      "turkish": "Sosyal medya faktörünü değiştirin",
+      "russian": "Изменить социальный фактор"
     },
     "title": {
       "dutch": "Account",
@@ -622,7 +673,8 @@
       "mandarin": "帐户",
       "portuguese": "Conta",
       "spanish": "Cuenta",
-      "turkish": "Hesap"
+      "turkish": "Hesap",
+      "russian": "Аккаунт"
     }
   }
 }

--- a/Openlogin-locale/locales-wallet-apps.json
+++ b/Openlogin-locale/locales-wallet-apps.json
@@ -10,7 +10,8 @@
       "mandarin": "当前设备",
       "portuguese": "Dispositivo atual",
       "spanish": "Dispositivo actual",
-      "turkish": "Mevcut cihaz"
+      "turkish": "Mevcut cihaz",
+      "russian": "Текущее устройство"
     },
     "apps-empty": {
       "dutch": "Je bent nog niet verbonden met enige applicaties.",
@@ -22,7 +23,8 @@
       "mandarin": "您尚未连接到任何应用程序。",
       "portuguese": "Você ainda não está conectado a nenhum aplicativo.",
       "spanish": "Aún no estás conectado a ninguna aplicación.",
-      "turkish": "Henüz herhangi bir uygulamaya bağlı değilsiniz."
+      "turkish": "Henüz herhangi bir uygulamaya bağlı değilsiniz.",
+      "russian": "Вы еще не подключены ни к одному приложению."
     },
     "apps-subtitle": {
       "dutch": "Lijst met apps",
@@ -34,7 +36,8 @@
       "mandarin": "应用清单",
       "portuguese": "Lista de aplicativos",
       "spanish": "Lista de aplicaciones",
-      "turkish": "Uygulama Listesi"
+      "turkish": "Uygulama Listesi",
+      "russian": "Список приложений"
     },
     "apps-title": {
       "dutch": "Geautoriseerde applicaties",
@@ -46,7 +49,8 @@
       "mandarin": "授权申请",
       "portuguese": "Aplicativos autorizados",
       "spanish": "Aplicaciones autorizadas",
-      "turkish": "Yetkili uygulamalar"
+      "turkish": "Yetkili uygulamalar",
+      "russian": "Авторизованные приложения"
     },
     "desc": {
       "dutch": "Beheer hier uw geautoriseerde applicaties",
@@ -58,7 +62,8 @@
       "mandarin": "在这里管理您的授权应用程序",
       "portuguese": "Gerencie seus aplicativos autorizados aqui",
       "spanish": "Gestione sus aplicaciones autorizadas aquí",
-      "turkish": "Yetkili uygulamaları buradan yönetin"
+      "turkish": "Yetkili uygulamaları buradan yönetin",
+      "russian": "Управляйте авторизованными приложениями здесь"
     },
     "devices": {
       "dutch": "Apparaat/Apparaten",
@@ -70,7 +75,8 @@
       "mandarin": "设备",
       "portuguese": "Dispositivos",
       "spanish": "Dispositivos",
-      "turkish": "Cihaz(lar)"
+      "turkish": "Cihaz(lar)",
+      "russian": "Устройство(а)"
     },
     "download-key": {
       "dutch": "Download sleutel",
@@ -82,7 +88,8 @@
       "mandarin": "下载密钥",
       "portuguese": "Chave de download",
       "spanish": "Descargar llave",
-      "turkish": "Anahtarı indir"
+      "turkish": "Anahtarı indir",
+      "russian": "Скачать ключ"
     },
     "export-private-key": {
       "dutch": "Privésleutel",
@@ -94,7 +101,8 @@
       "mandarin": "私钥",
       "portuguese": "Chave privada",
       "spanish": "Llave privada",
-      "turkish": "Gizli şifre"
+      "turkish": "Gizli şifre",
+      "russian": "Приватный ключ"
     },
     "last-access": {
       "dutch": "Laatst bezocht op",
@@ -106,7 +114,8 @@
       "mandarin": "最后访问",
       "portuguese": "Último acesso em",
       "spanish": "Último acceso en",
-      "turkish": "Son erişim tarihi"
+      "turkish": "Son erişim tarihi",
+      "russian": "Последний доступ"
     },
     "revoke": {
       "dutch": "Intrekken",
@@ -118,7 +127,8 @@
       "mandarin": "撤销",
       "portuguese": "Revogar",
       "spanish": "Revocar",
-      "turkish": "Geçersiz hale getir"
+      "turkish": "Geçersiz hale getir",
+      "russian": "Отозвать"
     },
     "see-all": {
       "dutch": "Bekijk alles",
@@ -130,7 +140,8 @@
       "mandarin": "查看全部",
       "portuguese": "Veja tudo",
       "spanish": "Ver todo",
-      "turkish": "Tamamını görüntüle"
+      "turkish": "Tamamını görüntüle",
+      "russian": "Показать все"
     },
     "see-less": {
       "dutch": "Minder bekijken",
@@ -142,7 +153,8 @@
       "mandarin": "少看",
       "portuguese": "ver menos",
       "spanish": "Ver menos",
-      "turkish": "Daha az görüntüle"
+      "turkish": "Daha az görüntüle",
+      "russian": "Показать меньше"
     },
     "title": {
       "dutch": "Geautoriseerde apps",
@@ -154,7 +166,8 @@
       "mandarin": "授权应用",
       "portuguese": "Apps autorizados",
       "spanish": "Aplicaciones autorizadas",
-      "turkish": "Yetkili uygulamalar"
+      "turkish": "Yetkili uygulamalar",
+      "russian": "Авторизованные приложения"
     }
   }
 }

--- a/Openlogin-locale/locales-wallet-home.json
+++ b/Openlogin-locale/locales-wallet-home.json
@@ -10,7 +10,8 @@
       "mandarin": "使用OpenLogin来管理您的数字业务。",
       "portuguese": "Assuma o controle de sua presença digital com OpenLogin.",
       "spanish": "Tome el control de su presencia digital con OpenLogin.",
-      "turkish": "OpenLogin ile dijital varlığınızın kontrolünü elinize alın."
+      "turkish": "OpenLogin ile dijital varlığınızın kontrolünü elinize alın.",
+      "russian": "Возьмите под контроль своё цифровое присутствие с помощью OpenLogin."
     },
     "learn-more-title": {
       "dutch": "Aan de slag gaan",
@@ -22,7 +23,8 @@
       "mandarin": "开始",
       "portuguese": "Começando",
       "spanish": "Empezando",
-      "turkish": "Başlarken"
+      "turkish": "Başlarken",
+      "russian": "Начало работы"
     },
     "link-account-name": {
       "dutch": "Account beheren",
@@ -34,7 +36,8 @@
       "mandarin": "管理帐户",
       "portuguese": "Gerenciar conta",
       "spanish": "Administrar cuenta",
-      "turkish": "Hesabı yönet"
+      "turkish": "Hesabı yönet",
+      "russian": "Управление аккаунтом"
     },
     "link-account-type": {
       "dutch": "account",
@@ -46,7 +49,8 @@
       "mandarin": "帐户",
       "portuguese": "conta",
       "spanish": "cuenta",
-      "turkish": "hesap"
+      "turkish": "hesap",
+      "russian": "аккаунт"
     },
     "link-apps-name": {
       "dutch": "Bekijk geautoriseerde apps",
@@ -58,7 +62,8 @@
       "mandarin": "查看授权的应用",
       "portuguese": "Ver aplicativos autorizados",
       "spanish": "Ver aplicaciones autorizadas",
-      "turkish": "Yetkili uygulamaları gör"
+      "turkish": "Yetkili uygulamaları gör",
+      "russian": "Просмотреть авторизованные приложения"
     },
     "link-apps-type": {
       "dutch": "apps",
@@ -70,7 +75,8 @@
       "mandarin": "应用",
       "portuguese": "aplicativos",
       "spanish": "aplicaciones",
-      "turkish": "uygulamalar"
+      "turkish": "uygulamalar",
+      "russian": "приложения"
     },
     "share-approval-desc1": {
       "dutch": "Een nieuwe login probeert toegang te krijgen tot uw account.",
@@ -82,7 +88,8 @@
       "mandarin": "新的登录名正在尝试登记入您的帐户。",
       "portuguese": "Um novo login está tentando acessar sua conta.",
       "spanish": "Un nuevo inicio de sesión está intentando acceder a su cuenta.",
-      "turkish": "Yeni bir kullanıcı hesabınıza erişmeye çalışıyor."
+      "turkish": "Yeni bir kullanıcı hesabınıza erişmeye çalışıyor.",
+      "russian": "Новый вход пытается получить доступ к вашему аккаунту."
     },
     "share-approval-desc2": {
       "dutch": "Match de referentie-ID en bevestig dat dit u bent:",
@@ -94,7 +101,8 @@
       "mandarin": "匹配参考ID并确认这是您 :",
       "portuguese": "Corresponda ao ID de referência e confirme que é você:",
       "spanish": "Haga coincidir la ID de referencia y confirme que es usted:",
-      "turkish": "Referans Kimliğini eşleştirin ve bunun siz olduğunuzu onaylayın:"
+      "turkish": "Referans Kimliğini eşleştirin ve bunun siz olduğunuzu onaylayın:",
+      "russian": "Сверьте идентификатор и подтвердите, что это вы:"
     },
     "share-approval-not-me": {
       "dutch": "Dit ben ik niet,",
@@ -106,7 +114,8 @@
       "mandarin": "这不是我，",
       "portuguese": "Este não sou eu,",
       "spanish": "Este no soy yo,",
-      "turkish": "Bu ben değilim,"
+      "turkish": "Bu ben değilim,",
+      "russian": "Это не я,"
     },
     "share-approval-report": {
       "dutch": "Rapporteer het",
@@ -118,7 +127,8 @@
       "mandarin": "举报",
       "portuguese": "denuncie",
       "spanish": "Informe",
-      "turkish": "bildir"
+      "turkish": "bildir",
+      "russian": "сообщить об этом"
     },
     "share-approval-secure": {
       "dutch": "Veilige Torus-aanmelding",
@@ -130,7 +140,8 @@
       "mandarin": "安全Torus登录",
       "portuguese": "Login seguro da Torus",
       "spanish": "Iniciar sesión Secure Torus",
-      "turkish": "Güvenli Torus oturum açma"
+      "turkish": "Güvenli Torus oturum açma",
+      "russian": "Безопасный вход через Torus"
     },
     "share-approval-support": {
       "dutch": "Neem contact op met de ondersteuning",
@@ -142,7 +153,8 @@
       "mandarin": "联系支持人员",
       "portuguese": "Entre em contato com o suporte",
       "spanish": "Soporte de contacto",
-      "turkish": "Destekle iletişime geçin"
+      "turkish": "Destekle iletişime geçin",
+      "russian": "Связаться со службой поддержки"
     },
     "share-approval-title": {
       "dutch": "Nieuwe login gedetecteerd",
@@ -154,7 +166,8 @@
       "mandarin": "检测到新登录",
       "portuguese": "Novo login detectado",
       "spanish": "Nuevo inicio de sesión detectado",
-      "turkish": "Yeni oturum açma algılandı"
+      "turkish": "Yeni oturum açma algılandı",
+      "russian": "Обнаружен новый вход"
     },
     "title": {
       "dutch": "Welkom, {0}",
@@ -166,7 +179,8 @@
       "mandarin": "欢迎，{0}",
       "portuguese": "Bem-vindo, {0}",
       "spanish": "Bienvenido, {0}",
-      "turkish": "Hoş geldin, {0}"
+      "turkish": "Hoş geldin, {0}",
+      "russian": "Добро пожаловать, {0}"
     }
   }
 }

--- a/Openlogin-locale/locales-webauthn.json
+++ b/Openlogin-locale/locales-webauthn.json
@@ -10,7 +10,8 @@
       "mandarin": "取消",
       "portuguese": "Cancelar",
       "spanish": "Cancelar",
-      "turkish": "İptal"
+      "turkish": "İptal",
+      "russian": "Отменить"
     },
     "action-no": {
       "dutch": "Nee",
@@ -22,7 +23,8 @@
       "mandarin": "不",
       "portuguese": "Não",
       "spanish": "No",
-      "turkish": "Hayır"
+      "turkish": "Hayır",
+      "russian": "Нет"
     },
     "action-sign-in": {
       "dutch": "Inloggen",
@@ -34,7 +36,8 @@
       "mandarin": "登入",
       "portuguese": "Entrar",
       "spanish": "Registrarse",
-      "turkish": "Oturum aç"
+      "turkish": "Oturum aç",
+      "russian": "Войти"
     },
     "action-yes": {
       "dutch": "Ja",
@@ -46,7 +49,8 @@
       "mandarin": "是的",
       "portuguese": "Sim",
       "spanish": "sí",
-      "turkish": "Evet"
+      "turkish": "Evet",
+      "russian": "Да"
     },
     "browser-not-supported": {
       "dutch": "Browser niet ondersteund",
@@ -58,7 +62,8 @@
       "mandarin": "浏览器不支持",
       "portuguese": "Navegador não suportado",
       "spanish": "Navegador no compatible",
-      "turkish": "Desteklenmeyen tarayıcı"
+      "turkish": "Desteklenmeyen tarayıcı",
+      "russian": "Браузер не поддерживается"
     },
     "browser-not-supported-note": {
       "dutch": "U gebruikt een browser die wij niet ondersteunen. Probeer een van deze opties om een betere ervaring te hebben op deze applicatie. Als u al een browser uit de onderstaande lijst gebruikt, update dan naar de nieuwste versie",
@@ -70,7 +75,8 @@
       "mandarin": "您正在使用我们不支持的浏览器。 尝试这些选项之一以获得在此应用程序上的更好体验。 如果您已经在使用以下列表中的浏览器，请更新到最新版本",
       "portuguese": "Você está usando um navegador que não suportamos. Experimente uma dessas opções para ter uma melhor experiência neste aplicativo. Se você já estiver usando um navegador da lista abaixo, atualize para a versão mais recente",
       "spanish": "Está utilizando un navegador que no soportamos. Pruebe una de estas opciones para tener una mejor experiencia en esta aplicación. Si ya está utilizando un navegador de la siguiente lista, actualice a la última versión",
-      "turkish": "Desteklemediğimiz bir tarayıcı kullanıyorsunuz. Bu uygulamada daha iyi bir deneyim yaşamak için bu seçeneklerden birini deneyin. Aşağıdaki listeden bir tarayıcı kullanıyorsanız, lütfen en son sürüme güncelleyin"
+      "turkish": "Desteklemediğimiz bir tarayıcı kullanıyorsunuz. Bu uygulamada daha iyi bir deneyim yaşamak için bu seçeneklerden birini deneyin. Aşağıdaki listeden bir tarayıcı kullanıyorsanız, lütfen en son sürüme güncelleyin",
+      "russian": "Вы используете браузер, который мы не поддерживаем. Попробуйте один из этих вариантов для лучшей работы с этим приложением. Если вы уже используете браузер из списка ниже, пожалуйста, обновитесь до последней версии."
     },
     "improve-experience": {
       "dutch": "Verbeter uw ervaring",
@@ -82,7 +88,8 @@
       "mandarin": "改善您的体验",
       "portuguese": "Melhore sua experiência",
       "spanish": "Mejora tu experiencia",
-      "turkish": "Deneyiminizi geliştirin"
+      "turkish": "Deneyiminizi geliştirin",
+      "russian": "Улучшите свой опыт"
     },
     "invalid-url": {
       "dutch": "Ongeldige omleidings-URI",
@@ -94,7 +101,8 @@
       "mandarin": "重定向 URI 无效",
       "portuguese": "URI de redirecionamento inválido",
       "spanish": "URI de redireccionamiento no válido",
-      "turkish": "Geçersiz yönlendirme URI'ı"
+      "turkish": "Geçersiz yönlendirme URI'ı",
+      "russian": "Недействительный URI перенаправления"
     },
     "learn-more": {
       "dutch": "Meer informatie",
@@ -106,7 +114,8 @@
       "mandarin": "了解更多",
       "portuguese": "Saber mais",
       "spanish": "Saber más",
-      "turkish": "Daha fazla bilgi edinin"
+      "turkish": "Daha fazla bilgi edinin",
+      "russian": "Узнать больше"
     },
     "missing-params": {
       "dutch": "Ontbrekende parameters",
@@ -118,7 +127,8 @@
       "mandarin": "缺少参数",
       "portuguese": "Parâmetros ausentes",
       "spanish": "Faltan parámetros",
-      "turkish": "Eksik parametreler"
+      "turkish": "Eksik parametreler",
+      "russian": "Отсутствуют параметры"
     },
     "operation-timeout": {
       "dutch": "De bewerking is verlopen of niet toegestaan",
@@ -130,7 +140,8 @@
       "mandarin": "操作超时或不允许",
       "portuguese": "A operação expirou ou não foi permitida",
       "spanish": "La operación agotó el tiempo de espera o no se permitió",
-      "turkish": "İşlem ya zaman aşımına uğradı ya da izin verilmedi"
+      "turkish": "İşlem ya zaman aşımına uğradı ya da izin verilmedi",
+      "russian": "Операция либо истекла по времени, либо не разрешена"
     },
     "register-device": {
       "dutch": "Wilt u dit apparaat registreren?",
@@ -142,7 +153,8 @@
       "mandarin": "您要注册此设备吗？",
       "portuguese": "Deseja registrar este dispositivo?",
       "spanish": "¿Le gustaría registrar este dispositivo?",
-      "turkish": "Bu cihazı kaydettirmek ister misiniz?"
+      "turkish": "Bu cihazı kaydettirmek ister misiniz?",
+      "russian": "Хотите зарегистрировать это устройство?"
     },
     "registering-device": {
       "dutch": "Uw apparaat registreren",
@@ -154,7 +166,8 @@
       "mandarin": "注册您的设备",
       "portuguese": "Registrando seu dispositivo",
       "spanish": "Registrando su dispositivo",
-      "turkish": "Cihazınız kaydediliyor"
+      "turkish": "Cihazınız kaydediliyor",
+      "russian": "Регистрация вашего устройства"
     },
     "required-params-note": {
       "dutch": "Eén of meer van de volgende verplichte parameters ontbreken",
@@ -166,7 +179,8 @@
       "mandarin": "缺少以下一项或多项必需参数",
       "portuguese": "Um ou mais dos seguintes parâmetros obrigatórios estão ausentes",
       "spanish": "Falta uno o más de los siguientes parámetros obligatorios",
-      "turkish": "Aşağıdaki gerekli parametrelerden biri veya daha fazlası eksik"
+      "turkish": "Aşağıdaki gerekli parametrelerden biri veya daha fazlası eksik",
+      "russian": "Отсутствует один или несколько обязательных параметров"
     },
     "sign-in": {
       "dutch": "Inloggen via Touch ID / Face ID?",
@@ -178,7 +192,8 @@
       "mandarin": "通过 Touch ID / Face ID 登录？",
       "portuguese": "Entrar via Touch ID / Face ID?",
       "spanish": "¿Iniciar sesión a través de Touch ID / Face ID?",
-      "turkish": "Touch ID / Face ID ile oturum açma?"
+      "turkish": "Touch ID / Face ID ile oturum açma?",
+      "russian": "Войти через Touch ID / Face ID?"
     },
     "something-wrong-note": {
       "dutch": "Er is iets misgegaan",
@@ -190,7 +205,8 @@
       "mandarin": "出问题了",
       "portuguese": "Algo deu errado",
       "spanish": "Algo salió mal",
-      "turkish": "Bir şeyler ters gitti"
+      "turkish": "Bir şeyler ters gitti",
+      "russian": "Что-то пошло не так"
     },
     "status-done": {
       "dutch": "Voltooid",
@@ -202,7 +218,8 @@
       "mandarin": "完毕",
       "portuguese": "Feito",
       "spanish": "Hecho",
-      "turkish": "Bitti"
+      "turkish": "Bitti",
+      "russian": "Готово"
     },
     "status-loading": {
       "dutch": "Laden",
@@ -214,7 +231,8 @@
       "mandarin": "加载中",
       "portuguese": "Carregando",
       "spanish": "Cargando",
-      "turkish": "Yükleniyor"
+      "turkish": "Yükleniyor",
+      "russian": "Загрузка"
     },
     "status-registered": {
       "dutch": "Apparaat geregistreerd",
@@ -226,7 +244,8 @@
       "mandarin": "设备注册",
       "portuguese": "Dispositivo registrado",
       "spanish": "Dispositivo registrado",
-      "turkish": "Kayıtlı cihaz"
+      "turkish": "Kayıtlı cihaz",
+      "russian": "Устройство зарегистрировано"
     },
     "user-denied": {
       "dutch": "Gebruiker heeft autorisatie geweigerd",
@@ -238,7 +257,8 @@
       "mandarin": "用户已拒绝授权",
       "portuguese": "O usuário negou a autorização",
       "spanish": "El usuario ha denegado la autorización",
-      "turkish": "Kullanıcı yetkiyi reddetti"
+      "turkish": "Kullanıcı yetkiyi reddetti",
+      "russian": "Пользователь отказал в авторизации"
     },
     "webauthn-not-supported": {
       "dutch": "Webauthn wordt niet ondersteund op dit apparaat",
@@ -250,7 +270,8 @@
       "mandarin": "此设备不支持 Webauthn",
       "portuguese": "Webauthn não é compatível com este dispositivo",
       "spanish": "Webauthn no es compatible con este dispositivo",
-      "turkish": "Webauthn bu cihazda desteklenmiyor"
+      "turkish": "Webauthn bu cihazda desteklenmiyor",
+      "russian": "Webauthn не поддерживается на этом устройстве"
     }
   }
 }

--- a/Wallet-service-locale/locales-checkout.json
+++ b/Wallet-service-locale/locales-checkout.json
@@ -10,7 +10,8 @@
       "mandarin": "所有付款方式",
       "portuguese": "Todos os métodos de pagamento",
       "spanish": "Todos los métodos de pago",
-      "turkish": "Tüm ödeme yöntemleri"
+      "turkish": "Tüm ödeme yöntemleri",
+      "russian": "Все способы оплаты"
     },
     "cancel": {
       "dutch": "Annuleren",
@@ -22,7 +23,8 @@
       "mandarin": "取消",
       "portuguese": "Cancelar",
       "spanish": "Cancelar",
-      "turkish": "İptal etmek"
+      "turkish": "İptal etmek",
+      "russian": "Отмена"
     },
     "close": {
       "dutch": "Dichtbij",
@@ -34,7 +36,8 @@
       "mandarin": "关闭",
       "portuguese": "Fechar",
       "spanish": "Cerrar",
-      "turkish": "Kapalı"
+      "turkish": "Kapalı",
+      "russian": "Закрыть"
     },
     "continue": {
       "dutch": "Doorgaan",
@@ -46,7 +49,8 @@
       "mandarin": "继续",
       "portuguese": "Continuar",
       "spanish": "Continuar",
-      "turkish": "Devam etmek"
+      "turkish": "Devam etmek",
+      "russian": "Продолжить"
     },
     "for": {
       "dutch": "voor",
@@ -58,7 +62,8 @@
       "mandarin": "为了",
       "portuguese": "para",
       "spanish": "para",
-      "turkish": "için"
+      "turkish": "için",
+      "russian": "для"
     },
     "limit": {
       "dutch": "Begrenzing:",
@@ -70,7 +75,8 @@
       "mandarin": "限制：",
       "portuguese": "Limite:",
       "spanish": "Límite:",
-      "turkish": "Sınır:"
+      "turkish": "Sınır:",
+      "russian": "Лимит:"
     },
     "noProviderSelected": {
       "dutch": "Nog geen providers geselecteerd",
@@ -82,7 +88,8 @@
       "mandarin": "尚未选择提供商",
       "portuguese": "Nenhum provedor selecionado ainda",
       "spanish": "Aún no se han seleccionado proveedores",
-      "turkish": "Henüz Sağlayıcı Seçilmedi"
+      "turkish": "Henüz Sağlayıcı Seçilmedi",
+      "russian": "Провайдеры еще не выбраны"
     },
     "payWith": {
       "dutch": "Betaal met",
@@ -94,7 +101,8 @@
       "mandarin": "使用。。。支付",
       "portuguese": "Pagar com",
       "spanish": "Pagar con",
-      "turkish": "İle ödemek"
+      "turkish": "İle ödemek",
+      "russian": "Оплатить с помощью"
     },
     "poweredBy": {
       "dutch": "Mogelijk gemaakt door {0}",
@@ -106,7 +114,8 @@
       "mandarin": "由{0}提供支持",
       "portuguese": "Desenvolvido por {0}",
       "spanish": "Desarrollado por {0}",
-      "turkish": "{0} tarafından desteklenmektedir"
+      "turkish": "{0} tarafından desteklenmektedir",
+      "russian": "Работает на {0}"
     },
     "provider": {
       "dutch": "Aanbieder",
@@ -118,7 +127,8 @@
       "mandarin": "提供者",
       "portuguese": "Fornecedor",
       "spanish": "Proveedor",
-      "turkish": "Sağlayıcı"
+      "turkish": "Sağlayıcı",
+      "russian": "Провайдер"
     },
     "providerSelectionMsg": {
       "dutch": "Selecteer wat u wilt kopen en betaalmethode om offertes van beschikbare aanbieders te krijgen",
@@ -130,7 +140,8 @@
       "mandarin": "选择要购买的商品和付款方式，以从可用供应商处获取报价",
       "portuguese": "Selecione o que deseja comprar e o método de pagamento para obter cotações dos fornecedores disponíveis",
       "spanish": "Seleccione lo que desea comprar y el método de pago para obtener cotizaciones de los proveedores disponibles.",
-      "turkish": "Mevcut sağlayıcılardan teklif almak için ne satın almak istediğinizi ve ödeme yöntemini seçin"
+      "turkish": "Mevcut sağlayıcılardan teklif almak için ne satın almak istediğinizi ve ödeme yöntemini seçin",
+      "russian": "Выберите, что вы хотите купить, и способ оплаты, чтобы получить котировки от доступных провайдеров"
     },
     "rates": {
       "dutch": "Tarieven",
@@ -142,7 +153,8 @@
       "mandarin": "价格",
       "portuguese": "Cotações",
       "spanish": "Tarifas",
-      "turkish": "Oranlar"
+      "turkish": "Oranlar",
+      "russian": "Курсы"
     },
     "redirectMsg": {
       "dutch": "U wordt doorgestuurd naar de pagina van de derde partij",
@@ -154,7 +166,8 @@
       "mandarin": "您将被重定向到第三方页面",
       "portuguese": "Você será redirecionado para a página de terceiros",
       "spanish": "Serás redirigido a la página del tercero.",
-      "turkish": "Üçüncü taraf sayfasına yönlendirileceksiniz"
+      "turkish": "Üçüncü taraf sayfasına yönlendirileceksiniz",
+      "russian": "Вы будете перенаправлены на стороннюю страницу"
     },
     "selectProvider": {
       "dutch": "Selecteer Aanbieder",
@@ -166,7 +179,8 @@
       "mandarin": "选择提供商",
       "portuguese": "Selecione o provedor",
       "spanish": "Seleccionar Proveedor",
-      "turkish": "Sağlayıcı Seçin"
+      "turkish": "Sağlayıcı Seçin",
+      "russian": "Выбрать провайдера"
     },
     "serviceFee": {
       "dutch": "servicekosten",
@@ -178,7 +192,8 @@
       "mandarin": "服务费",
       "portuguese": "taxa de serviço",
       "spanish": "tarifa de servicio",
-      "turkish": "servis ücreti"
+      "turkish": "servis ücreti",
+      "russian": "Комиссия за обслуживание"
     },
     "topupSuccess": {
       "dutch": "Opwaarderen succesvol",
@@ -190,7 +205,8 @@
       "mandarin": "充值成功",
       "portuguese": "Recarga bem-sucedida",
       "spanish": "Recarga exitosa",
-      "turkish": "Yükleme Başarılı"
+      "turkish": "Yükleme Başarılı",
+      "russian": "Пополнение успешно"
     },
     "transactionFee": {
       "dutch": "Transactiekosten",
@@ -202,7 +218,8 @@
       "mandarin": "手续费",
       "portuguese": "Taxa de transação",
       "spanish": "Tarifa de transacción",
-      "turkish": "İşlem ücreti"
+      "turkish": "İşlem ücreti",
+      "russian": "Комиссия за транзакцию"
     },
     "validationMsg": {
       "dutch": "Houd uw identiteitskaart/paspoort gereed om de aankoop te voltooien.",
@@ -214,7 +231,8 @@
       "mandarin": "请准备好您的身份证/护照以完成购买。",
       "portuguese": "Por favor, prepare o seu Bilhete de Identidade/Passaporte para concluir a compra.",
       "spanish": "Por favor prepara tu DNI/Pasaporte para completar la compra.",
-      "turkish": "Satın alma işlemini tamamlamak için lütfen Kimlik Kartınızı/Pasaportunuzu hazırlayın."
+      "turkish": "Satın alma işlemini tamamlamak için lütfen Kimlik Kartınızı/Pasaportunuzu hazırlayın.",
+      "russian": "Пожалуйста, подготовьте удостоверение личности или паспорт для завершения покупки."
     },
     "value": {
       "dutch": "Waarde:",
@@ -226,7 +244,8 @@
       "mandarin": "价值：",
       "portuguese": "Valor:",
       "spanish": "Valor:",
-      "turkish": "Değer:"
+      "turkish": "Değer:",
+      "russian": "Значение:"
     },
     "youBuy": {
       "dutch": "Je koopt",
@@ -238,7 +257,8 @@
       "mandarin": "你买",
       "portuguese": "Você compra",
       "spanish": "Tu compras",
-      "turkish": "Sen satın al"
+      "turkish": "Sen satın al",
+      "russian": "Вы покупаете"
     },
     "youPay": {
       "dutch": "Je betaalt",
@@ -250,7 +270,8 @@
       "mandarin": "你付钱",
       "portuguese": "Você paga",
       "spanish": "Tu pagas",
-      "turkish": "Öde"
+      "turkish": "Öde",
+      "russian": "Вы платите"
     },
     "youReceive": {
       "dutch": "Jij ontvangt",
@@ -262,7 +283,8 @@
       "mandarin": "你收到",
       "portuguese": "Tu recebes",
       "spanish": "Recibes",
-      "turkish": "Aldığın"
+      "turkish": "Aldığın",
+      "russian": "Вы получаете"
     },
     "youReceived": {
       "dutch": "Je hebt ontvangen",
@@ -274,7 +296,8 @@
       "mandarin": "你收到了",
       "portuguese": "Você recebeu",
       "spanish": "Has recibido",
-      "turkish": "Almış olduğunuz"
+      "turkish": "Almış olduğunuz",
+      "russian": "Вы получили"
     }
   }
 }

--- a/Wallet-service-locale/locales-checkout.json
+++ b/Wallet-service-locale/locales-checkout.json
@@ -206,7 +206,7 @@
       "portuguese": "Recarga bem-sucedida",
       "spanish": "Recarga exitosa",
       "turkish": "Yükleme Başarılı",
-      "russian": "Пополнение успешно"
+      "russian": "Пополнение выполнено  успешно"
     },
     "transactionFee": {
       "dutch": "Transactiekosten",

--- a/Wallet-service-locale/locales-portfolio.json
+++ b/Wallet-service-locale/locales-portfolio.json
@@ -10,7 +10,8 @@
       "mandarin": "一旦您开始移动资产，您的交易就会出现在这里。",
       "portuguese": "Depois de começar a mover seus ativos, suas transações aparecerão aqui.",
       "spanish": "Una vez que comience a mover sus activos, sus transacciones aparecerán aquí.",
-      "turkish": "Bir varlığınızı taşıdığınızda, bu işlemler burada görünür."
+      "turkish": "Bir varlığınızı taşıdığınızda, bu işlemler burada görünür.",
+      "russian": "Как только вы начнете перемещать свои активы, ваши транзакции появятся здесь."
     },
     "noTxnMsg": {
       "dutch": "U hebt nog geen transacties",
@@ -22,7 +23,8 @@
       "mandarin": "您还没有任何交易",
       "portuguese": "Você ainda não tem transações",
       "spanish": "Todavía no tienes transacciones",
-      "turkish": "Henüz herhangi bir işlem yok"
+      "turkish": "Henüz herhangi bir işlem yok",
+      "russian": "У вас еще нет никаких транзакций."
     },
     "selectTxnDetails": {
       "dutch": "Selecteer transactie om details te bekijken",
@@ -34,7 +36,8 @@
       "mandarin": "选择交易来查看详细信息",
       "portuguese": "Selecione a transação para visualizar detalhes",
       "spanish": "Seleccione la transacción para ver los detalles",
-      "turkish": "Detayları görmek için bir işlem seçin"
+      "turkish": "Detayları görmek için bir işlem seçin",
+      "russian": "Выберите транзакцию для просмотра деталей"
     },
     "selectTxnSubDetails": {
       "dutch": "Selecteer elke transactie om details te bekijken",
@@ -46,7 +49,8 @@
       "mandarin": "选择任何交易以查看详细信息",
       "portuguese": "Selecione qualquer transação para visualizar detalhes",
       "spanish": "Seleccione cualquier transacción para ver los detalles",
-      "turkish": "Detayları görmek için herhangi bir işlem seçin"
+      "turkish": "Detayları görmek için herhangi bir işlem seçin",
+      "russian": "Выберите любую транзакцию для просмотра деталей"
     }
   },
   "home": {
@@ -60,7 +64,8 @@
       "mandarin": "NFT合同地址",
       "portuguese": "Endereço do contrato da NFT",
       "spanish": "Dirección del contrato NFT",
-      "turkish": "NFT Sözleşme Adresi"
+      "turkish": "NFT Sözleşme Adresi",
+      "russian": "Адрес контракта NFT"
     },
     "copyAddress": {
       "dutch": "Kopieeradres",
@@ -72,7 +77,8 @@
       "mandarin": "复制地址",
       "portuguese": "Endereço de cópia",
       "spanish": "Dirección de copia",
-      "turkish": "Adres kopyala"
+      "turkish": "Adres kopyala",
+      "russian": "Скопировать адрес"
     },
     "decimalsOfPrecision": {
       "dutch": "Precimals van precisie",
@@ -84,7 +90,8 @@
       "mandarin": "精确的小数",
       "portuguese": "Decimais de precisão",
       "spanish": "Decimales de precisión",
-      "turkish": "Ondalık önem"
+      "turkish": "Ondalık önem",
+      "russian": "Десятичные дроби с точностью"
     },
     "gasCredit": {
       "dutch": "Gaskrediet",
@@ -96,7 +103,8 @@
       "mandarin": "汽油信用",
       "portuguese": "Crédito a gás",
       "spanish": "Crédito de gas",
-      "turkish": "Gaz kredisi"
+      "turkish": "Gaz kredisi",
+      "russian": "Комиссия на газ"
     },
     "noTokenNftMsg": {
       "dutch": "Je hebt nog geen {0}",
@@ -108,7 +116,8 @@
       "mandarin": "您还没有任何{0}",
       "portuguese": "Você ainda não tem {0}",
       "spanish": "No tienes {0} todavía",
-      "turkish": "Henüz {0} yok"
+      "turkish": "Henüz {0} yok",
+      "russian": "У вас еще нет {0}"
     },
     "noTokenNftSubMsg": {
       "dutch": "Nadat u een {0} hebt gekocht, ontvangt of toevoegt, verschijnen ze hier.",
@@ -120,7 +129,8 @@
       "mandarin": "购买，接收或添加任何{0}后，它们将出现在此处。",
       "portuguese": "Depois de comprar, receber ou adicionar qualquer {0}, eles aparecerão aqui.",
       "spanish": "Una vez que compre, reciba o agregue cualquier {0}, aparecerán aquí.",
-      "turkish": "Bir {0} satın aldıktan sonra, alınan veya eklendiğinde bunlar burada gösterilecektir."
+      "turkish": "Bir {0} satın aldıktan sonra, alınan veya eklendiğinde bunlar burada gösterilecektir.",
+      "russian": "Как только вы купите, получите или добавите любой {0}, он появится здесь."
     },
     "ownerEoa": {
       "dutch": "Eigenaar EOA",
@@ -132,7 +142,8 @@
       "mandarin": "所有者EOA",
       "portuguese": "Proprietário EOA",
       "spanish": "Propietario EOA",
-      "turkish": "Sahib EOA"
+      "turkish": "Sahib EOA",
+      "russian": "Владелец EOA"
     },
     "qrScanner": {
       "dutch": "QR -codescanner",
@@ -144,7 +155,8 @@
       "mandarin": "QR代码扫描仪",
       "portuguese": "Scanner de código QR",
       "spanish": "Escáner de código QR",
-      "turkish": "QR kodu tarayıcısı"
+      "turkish": "QR kodu tarayıcısı",
+      "russian": "Сканер QR-кода"
     },
     "receivedEth": {
       "dutch": "Ethereum ontvangen",
@@ -156,7 +168,8 @@
       "mandarin": "收到以太坊",
       "portuguese": "Recebeu Ethereum",
       "spanish": "Recibido Ethereum",
-      "turkish": "Alınan Ethereum"
+      "turkish": "Alınan Ethereum",
+      "russian": "Получен Ethereum"
     },
     "smartContractAcc": {
       "dutch": "Slimme contractaccount",
@@ -168,7 +181,8 @@
       "mandarin": "智能合约帐户",
       "portuguese": "Conta de contrato inteligente",
       "spanish": "Cuenta de contrato inteligente",
-      "turkish": "Akıllı sözleşme hesabı"
+      "turkish": "Akıllı sözleşme hesabı",
+      "russian": "Учетная запись смарт контракта"
     },
     "tokenContractAddress": {
       "dutch": "Token contractadres",
@@ -180,7 +194,8 @@
       "mandarin": "令牌合同地址",
       "portuguese": "Endereço do contrato de token",
       "spanish": "Dirección del contrato de token",
-      "turkish": "Token Sözleşme Adresi"
+      "turkish": "Token Sözleşme Adresi",
+      "russian": "Адрес контракта токена"
     },
     "tokenId": {
       "dutch": "Token -ID",
@@ -192,7 +207,8 @@
       "mandarin": "令牌ID",
       "portuguese": "Id token",
       "spanish": "ID de token",
-      "turkish": "Token ID"
+      "turkish": "Token ID",
+      "russian": "Идентификатор токена"
     },
     "tokenName": {
       "dutch": "Tokennaam",
@@ -204,7 +220,8 @@
       "mandarin": "令牌名称",
       "portuguese": "Nome do token",
       "spanish": "Nombre de token",
-      "turkish": "Token adı"
+      "turkish": "Token adı",
+      "russian": "Название токена"
     },
     "tokenSymbol": {
       "dutch": "Tokensymbool",
@@ -216,7 +233,8 @@
       "mandarin": "令牌符号",
       "portuguese": "Símbolo simbólico",
       "spanish": "Símbolo de token",
-      "turkish": "Token sembolü"
+      "turkish": "Token sembolü",
+      "russian": "Символ токена"
     },
     "totalWalletBalance": {
       "dutch": "Totale portemonnee balans",
@@ -228,7 +246,8 @@
       "mandarin": "总钱包平衡",
       "portuguese": "Equilíbrio total da carteira",
       "spanish": "Balance de billetera total",
-      "turkish": "Toplam cüzdan bakiyesi"
+      "turkish": "Toplam cüzdan bakiyesi",
+      "russian": "Общий баланс кошелька"
     },
     "transferredToken": {
       "dutch": "Overgedragen token",
@@ -240,7 +259,8 @@
       "mandarin": "转移令牌",
       "portuguese": "Token transferido",
       "spanish": "Token transferido",
-      "turkish": "Transfer edilen token"
+      "turkish": "Transfer edilen token",
+      "russian": "Переведенный токен"
     },
     "walletConnect": {
       "dutch": "Portemonnee verbindt",
@@ -252,7 +272,8 @@
       "mandarin": "钱包连接",
       "portuguese": "Carteira Connect",
       "spanish": "Billetera conectar",
-      "turkish": "Cüzdanı bağla"
+      "turkish": "Cüzdanı bağla",
+      "russian": "Подключение кошелька"
     }
   },
   "moca": {
@@ -266,7 +287,8 @@
       "mandarin": "总MOCA XP",
       "portuguese": "Total MOCA XP",
       "spanish": "MOCA XP total",
-      "turkish": "Toplam MOCA XP"
+      "turkish": "Toplam MOCA XP",
+      "russian": "Общий Moca XP"
     },
     "totalMocaXp": {
       "dutch": "Totaal MOCA XP",
@@ -278,7 +300,8 @@
       "mandarin": "总MOCA XP",
       "portuguese": "Total MOCA XP",
       "spanish": "MOCA XP total",
-      "turkish": "Toplam MOCA XP"
+      "turkish": "Toplam MOCA XP",
+      "russian": "Общий Moca XP"
     }
   },
   "portfolio": {
@@ -292,7 +315,8 @@
       "mandarin": "添加NFT",
       "portuguese": "Adicione a NFT",
       "spanish": "Agregar NFT",
-      "turkish": "NFT ekle"
+      "turkish": "NFT ekle",
+      "russian": "Добавить NFT"
     },
     "addToken": {
       "dutch": "Token toevoegen",
@@ -304,7 +328,8 @@
       "mandarin": "添加令牌",
       "portuguese": "Adicione token",
       "spanish": "Agregar token",
-      "turkish": "Token ekle"
+      "turkish": "Token ekle",
+      "russian": "Добавить токен"
     },
     "advanced": {
       "dutch": "Geavanceerd",
@@ -316,7 +341,8 @@
       "mandarin": "先进的",
       "portuguese": "Avançado",
       "spanish": "Avanzado",
-      "turkish": "Gelişmiş"
+      "turkish": "Gelişmiş",
+      "russian": "Расширенный"
     },
     "advancedOptions": {
       "dutch": "Geavanceerde mogelijkheden",
@@ -328,7 +354,8 @@
       "mandarin": "高级选项",
       "portuguese": "Opções avançadas",
       "spanish": "Opciones avanzadas",
-      "turkish": "Gelişmiş seçenekler"
+      "turkish": "Gelişmiş seçenekler",
+      "russian": "Расширенные настройки"
     },
     "all": {
       "dutch": "Alle",
@@ -340,7 +367,8 @@
       "mandarin": "全部",
       "portuguese": "Todos",
       "spanish": "Todo",
-      "turkish": "Hepsi"
+      "turkish": "Hepsi",
+      "russian": "Все"
     },
     "allDates": {
       "dutch": "Alle datums",
@@ -352,7 +380,8 @@
       "mandarin": "所有日期",
       "portuguese": "Todas as datas",
       "spanish": "Todas las fechas",
-      "turkish": "Tüm Tarihler"
+      "turkish": "Tüm Tarihler",
+      "russian": "Все даты"
     },
     "amount": {
       "dutch": "Hoeveelheid",
@@ -364,7 +393,8 @@
       "mandarin": "数量",
       "portuguese": "Quantia",
       "spanish": "Cantidad",
-      "turkish": "Miktar"
+      "turkish": "Miktar",
+      "russian": "Количество"
     },
     "approvedItem": {
       "dutch": "Goedgekeurde {0}",
@@ -376,7 +406,8 @@
       "mandarin": "批准的 {0}",
       "portuguese": "{0} aprovado",
       "spanish": "{0} aprobado",
-      "turkish": "{0} onaylanan"
+      "turkish": "{0} onaylanan",
+      "russian": "Одобрено {0}"
     },
     "asset": {
       "dutch": "Bezit",
@@ -388,7 +419,8 @@
       "mandarin": "资产",
       "portuguese": "Ativo",
       "spanish": "Activo",
-      "turkish": "Varlık"
+      "turkish": "Varlık",
+      "russian": "Актив"
     },
     "availableBalance": {
       "dutch": "beschikbaar saldo",
@@ -400,7 +432,8 @@
       "mandarin": "可用余额",
       "portuguese": "Saldo disponível",
       "spanish": "Saldo disponible",
-      "turkish": "Mevcut Bakiye"
+      "turkish": "Mevcut Bakiye",
+      "russian": "Доступный баланс"
     },
     "average": {
       "dutch": "Gemiddeld",
@@ -412,7 +445,8 @@
       "mandarin": "平均的",
       "portuguese": "Média",
       "spanish": "Promedio",
-      "turkish": "Ortalama"
+      "turkish": "Ortalama",
+      "russian": "Средний"
     },
     "blockExplorer": {
       "dutch": "Block-explorer",
@@ -424,7 +458,8 @@
       "mandarin": "块探索",
       "portuguese": "Block-Explorer",
       "spanish": "Explorador de bloques",
-      "turkish": "Blok Explorer"
+      "turkish": "Blok Explorer",
+      "russian": "Обозреватель блоков"
     },
     "buy": {
       "dutch": "Kopen",
@@ -436,7 +471,8 @@
       "mandarin": "买",
       "portuguese": "Comprar",
       "spanish": "Comprar",
-      "turkish": "Al"
+      "turkish": "Al",
+      "russian": "Купить"
     },
     "buyDisableTestnet": {
       "dutch": "Feature niet beschikbaar op testnet",
@@ -448,7 +484,8 @@
       "mandarin": "TestNet上无法使用的功能",
       "portuguese": "Recurso indisponível no TestNet",
       "spanish": "Característica no disponible en TestNet",
-      "turkish": "Özellik testnet'te kullanılamıyor"
+      "turkish": "Özellik testnet'te kullanılamıyor",
+      "russian": "Функция недоступна в тестовой сети"
     },
     "buySell": {
       "dutch": "Kopen verkopen",
@@ -460,7 +497,8 @@
       "mandarin": "买卖",
       "portuguese": "Compra venda",
       "spanish": "Compra venta",
-      "turkish": "Alış veriş"
+      "turkish": "Alış veriş",
+      "russian": "Купить/Продать"
     },
     "cancel": {
       "dutch": "Annuleren",
@@ -472,7 +510,8 @@
       "mandarin": "取消",
       "portuguese": "Cancelar",
       "spanish": "Cancelar",
-      "turkish": "İptal etmek"
+      "turkish": "İptal etmek",
+      "russian": "Отмена"
     },
     "claim": {
       "dutch": "Claim",
@@ -484,7 +523,8 @@
       "mandarin": "宣称",
       "portuguese": "Alegar",
       "spanish": "Afirmar",
-      "turkish": "Talep Et"
+      "turkish": "Talep Et",
+      "russian": "Забрать"
     },
     "confirm": {
       "dutch": "Bevestigen",
@@ -496,7 +536,8 @@
       "mandarin": "确认",
       "portuguese": "confirme",
       "spanish": "Confirmar",
-      "turkish": "Onayla"
+      "turkish": "Onayla",
+      "russian": "Подтвердить"
     },
     "confirmTxn": {
       "dutch": "Bevestig transactie",
@@ -508,7 +549,8 @@
       "mandarin": "确认交易",
       "portuguese": "Confirme a transação",
       "spanish": "Confirmar transacción",
-      "turkish": "İşlemi Onayla"
+      "turkish": "İşlemi Onayla",
+      "russian": "Подтвердить транзакцию"
     },
     "contractDeployment": {
       "dutch": "Contractimplementatie",
@@ -520,7 +562,8 @@
       "mandarin": "合约部署",
       "portuguese": "Implantação de contrato",
       "spanish": "Implementación del contrato",
-      "turkish": "Sözleşme Dağıtımı"
+      "turkish": "Sözleşme Dağıtımı",
+      "russian": "Развертывание контракта"
     },
     "contractInteraction": {
       "dutch": "Contractinteractie",
@@ -532,7 +575,8 @@
       "mandarin": "合约交互",
       "portuguese": "Interação Contratual",
       "spanish": "Interacción contractual",
-      "turkish": "Sözleşme Etkileşimi"
+      "turkish": "Sözleşme Etkileşimi",
+      "russian": "Взаимодействие с контрактом"
     },
     "copied": {
       "dutch": "Gekopieerd",
@@ -544,7 +588,8 @@
       "mandarin": "复制",
       "portuguese": "Copiado",
       "spanish": "Copiado",
-      "turkish": "Kopyalandı"
+      "turkish": "Kopyalandı",
+      "russian": "Скопировано"
     },
     "coveredByDapp": {
       "dutch": "Bedekt door {0}",
@@ -556,7 +601,8 @@
       "mandarin": "由{0}覆盖",
       "portuguese": "Coberto por {0}",
       "spanish": "Cubierto por {0}",
-      "turkish": "{0} tarafından kapatılır"
+      "turkish": "{0} tarafından kapatılır",
+      "russian": "Поддерживается  {0}"
     },
     "creditUsage": {
       "dutch": "Kredietgebruik",
@@ -568,7 +614,8 @@
       "mandarin": "信用使用",
       "portuguese": "Uso de crédito",
       "spanish": "Uso de crédito",
-      "turkish": "Kredi Kullanımı"
+      "turkish": "Kredi Kullanımı",
+      "russian": "Использование кредита"
     },
     "customizeGasFee": {
       "dutch": "Pas uw gaskosten aan",
@@ -580,7 +627,8 @@
       "mandarin": "自定义您的汽油费",
       "portuguese": "Personalize sua taxa de gás",
       "spanish": "Personaliza tu tarifa de gasolina",
-      "turkish": "Gaz Ücretinizi Özelleştirin"
+      "turkish": "Gaz Ücretinizi Özelleştirin",
+      "russian": "Настройте свою комиссию за газ"
     },
     "description": {
       "dutch": "Beschrijving",
@@ -592,7 +640,8 @@
       "mandarin": "描述",
       "portuguese": "Descrição",
       "spanish": "Descripción",
-      "turkish": "Açıklama"
+      "turkish": "Açıklama",
+      "russian": "Описание"
     },
     "enterRecipientAdd": {
       "dutch": "Voer het adres van de ontvanger in",
@@ -604,7 +653,8 @@
       "mandarin": "输入收件人地址",
       "portuguese": "Digite o endereço do destinatário",
       "spanish": "Ingrese la dirección del destinatario",
-      "turkish": "Alıcı Adresi Giriniz"
+      "turkish": "Alıcı Adresi Giriniz",
+      "russian": "Введите адрес получателя"
     },
     "fast": {
       "dutch": "Snel",
@@ -616,7 +666,8 @@
       "mandarin": "快速地",
       "portuguese": "Rápido",
       "spanish": "Rápido",
-      "turkish": "Hızlı"
+      "turkish": "Hızlı",
+      "russian": "Быстрый"
     },
     "featureUnavailableOnNetwork": {
       "dutch": "Functie niet beschikbaar op huidig netwerk",
@@ -628,7 +679,8 @@
       "mandarin": "当前网络上不可用的功能",
       "portuguese": "Recurso indisponível na rede atual",
       "spanish": "Característica no disponible en la red actual",
-      "turkish": "Mevcut ağda kullanılamayan özellik"
+      "turkish": "Mevcut ağda kullanılamayan özellik",
+      "russian": "Функция недоступна в текущей сети"
     },
     "firstTransaction": {
       "dutch": "Uw eerste transactie kost meer omdat het het implementeren van uw smart account betekent. Volgende transacties zullen lagere kosten hebben.",
@@ -640,7 +692,8 @@
       "mandarin": "您的第一次交易由于涉及部署您的智能账户，因此会产生较高的费用。后续交易将按较低的费用计算。",
       "portuguese": "Sua primeira transação incorre em uma taxa mais alta, pois envolve o deploy do seu conta inteligente. As transações subsequentes terão taxas menores.",
       "spanish": "Su primera transacción incurre en una tarifa más alta, ya que implica el despliegue de su cuenta inteligente. Las transacciones posteriores tendrán tarifas más bajas.",
-      "turkish": "İlk işlem, akıllı hesap dağıtımını içerdiğinden, daha yüksek bir ücretlendirmeye neden olur. Sonraki işlemler, daha düşük ücretlerle hesaplanır."
+      "turkish": "İlk işlem, akıllı hesap dağıtımını içerdiğinden, daha yüksek bir ücretlendirmeye neden olur. Sonraki işlemler, daha düşük ücretlerle hesaplanır.",
+      "russian": "Ваша первая транзакция влечет за собой более высокую комиссию, поскольку она включает в себя развертывание вашего умного аккаунта. Последующие транзакции будут иметь более низкие комиссии."
     },
     "free": {
       "dutch": "Gratis",
@@ -652,7 +705,8 @@
       "mandarin": "免费",
       "portuguese": "Gratuito",
       "spanish": "Gratuito",
-      "turkish": "Bedava"
+      "turkish": "Bedava",
+      "russian": "Бесплатно"
     },
     "gasLimit": {
       "dutch": "Gasgrens",
@@ -664,7 +718,8 @@
       "mandarin": "气限",
       "portuguese": "Limite de gás",
       "spanish": "Límite de gas",
-      "turkish": "Jener Gaz Sınırı"
+      "turkish": "Jener Gaz Sınırı",
+      "russian": "Лимит газа"
     },
     "gasPrice": {
       "dutch": "Gaskosten",
@@ -676,7 +731,8 @@
       "mandarin": "汽油价格",
       "portuguese": "Preço do gás",
       "spanish": "Precio del gas",
-      "turkish": "Gaz Ücreti"
+      "turkish": "Gaz Ücreti",
+      "russian": "Цена на газ"
     },
     "id": {
       "dutch": "ID kaart",
@@ -688,7 +744,8 @@
       "mandarin": "ID",
       "portuguese": "EU IA",
       "spanish": "IDENTIFICACIÓN",
-      "turkish": "ID"
+      "turkish": "ID",
+      "russian": "Идентификатор"
     },
     "insufficientAmtMsg": {
       "dutch": "Onvoldoende gaskrediet, portemonnee saldo wordt gebruikt om kosten te dekken",
@@ -700,7 +757,8 @@
       "mandarin": "汽油信用不足，钱包余额将用于支付费用",
       "portuguese": "Crédito a gás insuficiente, o saldo da carteira será usado para cobrir a taxa",
       "spanish": "Crédito de gas insuficiente, el saldo de la billetera se utilizará para cubrir la tarifa",
-      "turkish": "Gaz Kredisi Yetersiz, Portföy Bakiyesi Kullanılacak"
+      "turkish": "Gaz Kredisi Yetersiz, Portföy Bakiyesi Kullanılacak",
+      "russian": "Недостаточный кредит газа, баланс кошелька будет использован для покрытия комиссии."
     },
     "last1Month": {
       "dutch": "Laatste 1 maand",
@@ -712,7 +770,8 @@
       "mandarin": "最后一个月",
       "portuguese": "Último 1 mês",
       "spanish": "Último 1 mes",
-      "turkish": "Son 1 ay"
+      "turkish": "Son 1 ay",
+      "russian": "Последний 1 месяц"
     },
     "last1Week": {
       "dutch": "Laatste 1 week",
@@ -724,7 +783,8 @@
       "mandarin": "最后1周",
       "portuguese": "Última 1 semana",
       "spanish": "Última 1 semana",
-      "turkish": "Son 1 hafta"
+      "turkish": "Son 1 hafta",
+      "russian": "Последняя 1 неделя"
     },
     "last6Months": {
       "dutch": "Laatste 6 maanden",
@@ -736,7 +796,8 @@
       "mandarin": "最近6个月",
       "portuguese": "Últimos 6 meses",
       "spanish": "Últimos 6 meses",
-      "turkish": "Son 6 aylar"
+      "turkish": "Son 6 aylar",
+      "russian": "Последние 6 месяцев"
     },
     "maxFeePerGas": {
       "dutch": "Maximale kosten per gas",
@@ -748,7 +809,8 @@
       "mandarin": "最大汽油费用",
       "portuguese": "Taxa máxima por gas",
       "spanish": "Tarifa máxima por gas",
-      "turkish": "Maksimum Gaz Ücreti"
+      "turkish": "Maksimum Gaz Ücreti",
+      "russian": "Максимальная комиссия за газ"
     },
     "maxPriorityFee": {
       "dutch": "Maximale prioriteitskosten",
@@ -760,7 +822,8 @@
       "mandarin": "最大优先费",
       "portuguese": "Taxa prioritária máxima",
       "spanish": "Tarifa de prioridad máxima",
-      "turkish": "Maksimum Öncelik Ücreti"
+      "turkish": "Maksimum Öncelik Ücreti",
+      "russian": "Максимальная приоритетная комиссия"
     },
     "maxTxnFee": {
       "dutch": "Max transactiekosten",
@@ -772,7 +835,8 @@
       "mandarin": "最大交易费",
       "portuguese": "Taxa de transação máxima",
       "spanish": "Tarifa de transacción máxima",
-      "turkish": "Maksimum İşlem Ücreti"
+      "turkish": "Maksimum İşlem Ücreti",
+      "russian": "Максимальная комиссия за транзакцию"
     },
     "medium": {
       "dutch": "Medium",
@@ -784,7 +848,8 @@
       "mandarin": "中等的",
       "portuguese": "Médio",
       "spanish": "Medio",
-      "turkish": "Orta"
+      "turkish": "Orta",
+      "russian": "Средний"
     },
     "next": {
       "dutch": "Volgende",
@@ -796,7 +861,8 @@
       "mandarin": "下一个",
       "portuguese": "Próximo",
       "spanish": "Próximo",
-      "turkish": "Sonraki"
+      "turkish": "Sonraki",
+      "russian": "Следующий"
     },
     "nonce": {
       "dutch": "Nonce",
@@ -808,7 +874,8 @@
       "mandarin": "nonce",
       "portuguese": "Nonce",
       "spanish": "Mientras tanto",
-      "turkish": "Nonce"
+      "turkish": "Nonce",
+      "russian": "Nonce"
     },
     "ownerEoaAcc": {
       "dutch": "Eigenaar EOA -account",
@@ -820,7 +887,8 @@
       "mandarin": "所有者EOA帐户",
       "portuguese": "Conta do proprietário EOA",
       "spanish": "Cuenta EOA del propietario",
-      "turkish": "Sahib EOA Hesabı"
+      "turkish": "Sahib EOA Hesabı",
+      "russian": "Аккаунт владельца EOA"
     },
     "ownerEoaBalance": {
       "dutch": "Eigenaar EOA Balans",
@@ -832,7 +900,8 @@
       "mandarin": "所有者EOA余额",
       "portuguese": "Proprietário EOA Balance",
       "spanish": "Balance de propietario EOA",
-      "turkish": "Sahib EOA Bakiye"
+      "turkish": "Sahib EOA Bakiye",
+      "russian": "Баланс владельца EOA"
     },
     "porcessIn": {
       "dutch": "Proces in <{0} seconden",
@@ -844,7 +913,8 @@
       "mandarin": "<{0}秒的过程",
       "portuguese": "Processo em <{0} segundos",
       "spanish": "Proceso en <{0} segundos",
-      "turkish": "<{0} saniyede işlem"
+      "turkish": "<{0} saniyede işlem",
+      "russian": "Процесс завершен за < {0} секунд"
     },
     "processInLabel": {
       "dutch": "Verwerken",
@@ -856,7 +926,8 @@
       "mandarin": "过程中",
       "portuguese": "Processo em",
       "spanish": "Procesar",
-      "turkish": "İşlem"
+      "turkish": "İşlem",
+      "russian": "Процесс входа"
     },
     "processTime": {
       "dutch": "<{0} seconden",
@@ -868,7 +939,8 @@
       "mandarin": "<{0}秒",
       "portuguese": "<{0} segundos",
       "spanish": "<{0} segundos",
-      "turkish": "<{0} saniye"
+      "turkish": "<{0} saniye",
+      "russian": "'< {0} секунд'"
     },
     "quantity": {
       "dutch": "Hoeveelheid",
@@ -880,7 +952,8 @@
       "mandarin": "数量",
       "portuguese": "Quantidade",
       "spanish": "Cantidad",
-      "turkish": "Miktar"
+      "turkish": "Miktar",
+      "russian": "Количество"
     },
     "rate": {
       "dutch": "Tarief",
@@ -892,7 +965,8 @@
       "mandarin": "速度",
       "portuguese": "Avaliar",
       "spanish": "Tasa",
-      "turkish": "Oran"
+      "turkish": "Oran",
+      "russian": "Ставка"
     },
     "receive": {
       "dutch": "Ontvangen",
@@ -904,7 +978,8 @@
       "mandarin": "收到",
       "portuguese": "Receber",
       "spanish": "Recibir",
-      "turkish": "Al"
+      "turkish": "Al",
+      "russian": "Получить"
     },
     "received": {
       "dutch": "Ontvangen",
@@ -916,7 +991,8 @@
       "mandarin": "已收到",
       "portuguese": "Recebido",
       "spanish": "Recibió",
-      "turkish": "Alındı"
+      "turkish": "Alındı",
+      "russian": "Получено"
     },
     "receivedItem": {
       "dutch": "{0} ontvangen",
@@ -928,7 +1004,8 @@
       "mandarin": "收到{0}",
       "portuguese": "{0} recebidos",
       "spanish": "{0} recibido",
-      "turkish": "{0} alındı"
+      "turkish": "{0} alındı",
+      "russian": "Получено {0}"
     },
     "reset": {
       "dutch": "Reset",
@@ -940,7 +1017,8 @@
       "mandarin": "重置",
       "portuguese": "Reiniciar",
       "spanish": "Reiniciar",
-      "turkish": "Sıfırla"
+      "turkish": "Sıfırla",
+      "russian": "Сброс"
     },
     "selectAnAsset": {
       "dutch": "Selecteer een actief",
@@ -952,7 +1030,8 @@
       "mandarin": "选择资产",
       "portuguese": "Selecione um ativo",
       "spanish": "Seleccione un activo",
-      "turkish": "Bir varlık seçin"
+      "turkish": "Bir varlık seçin",
+      "russian": "Выберите актив"
     },
     "selectSpeed": {
       "dutch": "Selecteer snelheid",
@@ -964,7 +1043,8 @@
       "mandarin": "选择速度",
       "portuguese": "Selecione a velocidade",
       "spanish": "Velocidad de selección",
-      "turkish": "Hız Seç"
+      "turkish": "Hız Seç",
+      "russian": "Выберите скорость"
     },
     "selectToken": {
       "dutch": "Selecteer token",
@@ -976,7 +1056,8 @@
       "mandarin": "选择令牌",
       "portuguese": "Selecione token",
       "spanish": "Seleccionar token",
-      "turkish": "Token seçin"
+      "turkish": "Token seçin",
+      "russian": "Выбрать токен"
     },
     "send": {
       "dutch": "Versturen",
@@ -988,7 +1069,8 @@
       "mandarin": "发送",
       "portuguese": "Enviar",
       "spanish": "Enviar",
-      "turkish": "Gönder"
+      "turkish": "Gönder",
+      "russian": "Отправить"
     },
     "sendAll": {
       "dutch": "Verstuur alles",
@@ -1000,7 +1082,8 @@
       "mandarin": "发送所有",
       "portuguese": "Enviar tudo",
       "spanish": "Enviar todo",
-      "turkish": "Tümü gönder"
+      "turkish": "Tümü gönder",
+      "russian": "Отправить все"
     },
     "sendTo": {
       "dutch": "Verzenden naar",
@@ -1012,7 +1095,8 @@
       "mandarin": "发给",
       "portuguese": "Enviar para",
       "spanish": "Enviar a",
-      "turkish": "Gönder"
+      "turkish": "Gönder",
+      "russian": "Отправить "
     },
     "sendingFrom": {
       "dutch": "Verzenden van",
@@ -1024,7 +1108,8 @@
       "mandarin": "从",
       "portuguese": "Enviando de",
       "spanish": "Envío desde",
-      "turkish": "Gönderen"
+      "turkish": "Gönderen",
+      "russian": "Отправлено из"
     },
     "sent": {
       "dutch": "Verstuurd",
@@ -1036,7 +1121,8 @@
       "mandarin": "发送",
       "portuguese": "Enviado",
       "spanish": "Enviado",
-      "turkish": "Gönderildi"
+      "turkish": "Gönderildi",
+      "russian": "Отправлено"
     },
     "sentItem": {
       "dutch": "{0} verzonden",
@@ -1048,7 +1134,8 @@
       "mandarin": "发送 {0}",
       "portuguese": "Enviado {0}",
       "spanish": "{0} enviado",
-      "turkish": "{0} gönderildi"
+      "turkish": "{0} gönderildi",
+      "russian": "Отправлено {0}"
     },
     "showAllTokens": {
       "dutch": "Alle tokens weergeven",
@@ -1060,7 +1147,8 @@
       "mandarin": "显示所有代币",
       "portuguese": "Mostrar todos os tokens",
       "spanish": "Mostrar todos los tokens",
-      "turkish": "Tüm jetonları görüntüle"
+      "turkish": "Tüm jetonları görüntüle",
+      "russian": "Показать все токены"
     },
     "slow": {
       "dutch": "Langzaam",
@@ -1072,7 +1160,8 @@
       "mandarin": "慢的",
       "portuguese": "Lento",
       "spanish": "Lento",
-      "turkish": "Yavaş"
+      "turkish": "Yavaş",
+      "russian": "Медленный"
     },
     "submit": {
       "dutch": "Indienen",
@@ -1084,7 +1173,8 @@
       "mandarin": "提交",
       "portuguese": "Enviar",
       "spanish": "Entregar",
-      "turkish": "Göndermek"
+      "turkish": "Göndermek",
+      "russian": "Отправить"
     },
     "swap": {
       "dutch": "Ruil",
@@ -1096,7 +1186,8 @@
       "mandarin": "交换",
       "portuguese": "Trocar",
       "spanish": "Intercambio",
-      "turkish": "Değiştir"
+      "turkish": "Değiştir",
+      "russian": "Обмен"
     },
     "tokens": {
       "dutch": "Munten",
@@ -1108,7 +1199,8 @@
       "mandarin": "令牌",
       "portuguese": "Tokens",
       "spanish": "Tokens",
-      "turkish": "Token"
+      "turkish": "Token",
+      "russian": "Токены"
     },
     "top-up": {
       "dutch": "Bijvoegen",
@@ -1120,7 +1212,8 @@
       "mandarin": "充值",
       "portuguese": "Completar",
       "spanish": "Recarga",
-      "turkish": "Toplu"
+      "turkish": "Toplu",
+      "russian": "Пополнение"
     },
     "topUp": {
       "dutch": "Aanvullen",
@@ -1132,7 +1225,8 @@
       "mandarin": "充值",
       "portuguese": "Completar",
       "spanish": "Completar",
-      "turkish": "Dolu Et"
+      "turkish": "Dolu Et",
+      "russian": "Пополнить"
     },
     "toppedUpAmt": {
       "dutch": "Bedacht bedrag",
@@ -1144,7 +1238,8 @@
       "mandarin": "总额",
       "portuguese": "TODO OURMOURO",
       "spanish": "Cantidad rematada",
-      "turkish": "Toplam Tutarı"
+      "turkish": "Toplam Tutarı",
+      "russian": "Пополненная сумма"
     },
     "totalCost": {
       "dutch": "Totale prijs",
@@ -1156,7 +1251,8 @@
       "mandarin": "总成本",
       "portuguese": "Custo total",
       "spanish": "Coste total",
-      "turkish": "Toplam Maliyet"
+      "turkish": "Toplam Maliyet",
+      "russian": "Общая стоимость"
     },
     "totalEth": {
       "dutch": "Totale ETH",
@@ -1168,7 +1264,8 @@
       "mandarin": "总eth",
       "portuguese": "ETH total",
       "spanish": "Total ETH",
-      "turkish": "Toplam ETH"
+      "turkish": "Toplam ETH",
+      "russian": "Общий ETH"
     },
     "transactionCost": {
       "dutch": "Transactiekosten",
@@ -1180,7 +1277,8 @@
       "mandarin": "交易成本",
       "portuguese": "Custo da transação",
       "spanish": "Costo de la transacción",
-      "turkish": "İşlem Ücreti"
+      "turkish": "İşlem Ücreti",
+      "russian": "Стоимость транзакции"
     },
     "transferredAsset": {
       "dutch": "Overgedragen activa",
@@ -1192,7 +1290,8 @@
       "mandarin": "转移资产",
       "portuguese": "Ativo transferido",
       "spanish": "Activo transferido",
-      "turkish": "Varlık aktarıldı"
+      "turkish": "Varlık aktarıldı",
+      "russian": "Переведенный актив"
     },
     "transferredOn": {
       "dutch": "Overgedragen op",
@@ -1204,7 +1303,8 @@
       "mandarin": "转移",
       "portuguese": "Transferido em",
       "spanish": "Transferido",
-      "turkish": "Aktarıldı"
+      "turkish": "Aktarıldı",
+      "russian": "Переведено на"
     },
     "transferredToken": {
       "dutch": "Overgedragen token",
@@ -1216,7 +1316,8 @@
       "mandarin": "转移令牌",
       "portuguese": "Token transferido",
       "spanish": "Token transferido",
-      "turkish": "Token aktarıldı"
+      "turkish": "Token aktarıldı",
+      "russian": "Переведенный токен"
     },
     "txnCost": {
       "dutch": "Transactiekosten",
@@ -1228,7 +1329,8 @@
       "mandarin": "交易成本",
       "portuguese": "Custo da transação",
       "spanish": "Costo de la transacción",
-      "turkish": "İşlem Ücreti"
+      "turkish": "İşlem Ücreti",
+      "russian": "Стоимость транзакции"
     },
     "txnFee": {
       "dutch": "Transactiekosten",
@@ -1240,7 +1342,8 @@
       "mandarin": "手续费",
       "portuguese": "Taxa de transação",
       "spanish": "Tarifa de transacción",
-      "turkish": "İşlem Ücreti"
+      "turkish": "İşlem Ücreti",
+      "russian": "Комиссия за транзакцию"
     },
     "txnHistory": {
       "dutch": "Transactie Geschiedenis",
@@ -1252,7 +1355,8 @@
       "mandarin": "交易历史记录",
       "portuguese": "Histórico de transações",
       "spanish": "Historial de transacciones",
-      "turkish": "İşlem Geçmişi"
+      "turkish": "İşlem Geçmişi",
+      "russian": "История транзакций"
     },
     "txnState": {
       "dutch": "Transactiestaat",
@@ -1264,7 +1368,8 @@
       "mandarin": "交易状态",
       "portuguese": "Estado de transação",
       "spanish": "Estado de transacción",
-      "turkish": "İşlem Durumu"
+      "turkish": "İşlem Durumu",
+      "russian": "Состояние транзакции"
     },
     "type": {
       "dutch": "Type",
@@ -1276,7 +1381,8 @@
       "mandarin": "类型",
       "portuguese": "Tipo",
       "spanish": "Tipo",
-      "turkish": "Tip"
+      "turkish": "Tip",
+      "russian": "Тип"
     },
     "upTo": {
       "dutch": "Tot",
@@ -1288,7 +1394,8 @@
       "mandarin": "取决于",
       "portuguese": "Até",
       "spanish": "Hasta",
-      "turkish": "Kadar"
+      "turkish": "Kadar",
+      "russian": "До"
     },
     "value": {
       "dutch": "Waarde",
@@ -1300,7 +1407,8 @@
       "mandarin": "价值",
       "portuguese": "Valor",
       "spanish": "Valor",
-      "turkish": "Miktar"
+      "turkish": "Miktar",
+      "russian": "Значение"
     },
     "viewTransaction": {
       "dutch": "Bekijk transactie",
@@ -1312,7 +1420,8 @@
       "mandarin": "查看交易",
       "portuguese": "Visualizar transação",
       "spanish": "Ver transacción",
-      "turkish": "İşlemi Görüntüle"
+      "turkish": "İşlemi Görüntüle",
+      "russian": "Просмотреть транзакцию"
     },
     "yourNfts": {
       "dutch": "Uw NFT's",
@@ -1324,7 +1433,8 @@
       "mandarin": "你的nfts",
       "portuguese": "Seus NFTs",
       "spanish": "Tus NFTS",
-      "turkish": "Sizin NFT"
+      "turkish": "Sizin NFT",
+      "russian": "Ваши NFT"
     },
     "yourTokens": {
       "dutch": "Uw tokens",
@@ -1336,7 +1446,8 @@
       "mandarin": "你的令牌",
       "portuguese": "Seus tokens",
       "spanish": "Tus tokens",
-      "turkish": "Sizin Token"
+      "turkish": "Sizin Token",
+      "russian": "Ваши токены"
     },
     "tempApiDisabled": {
       "english": "Token and NFT information is temporarily unavailable. We are working to restore this functionality.",
@@ -1348,7 +1459,8 @@
       "mandarin": "代币和 NFT 信息暂时不可用。我们正在努力恢复此功能。",
       "portuguese": "As informações sobre tokens e NFTs estão temporariamente indisponíveis. Estamos a trabalhar para restaurar essa funcionalidade.",
       "spanish": "La información sobre tokens y NFT no está disponible temporalmente. Estamos trabajando para restablecer esta funcionalidad.",
-      "turkish": "Token ve NFT bilgileri geçici olarak kullanılamıyor. Bu işlevselliği geri yüklemek için çalışıyoruz."
+      "turkish": "Token ve NFT bilgileri geçici olarak kullanılamıyor. Bu işlevselliği geri yüklemek için çalışıyoruz.",
+      "russian": "Информация о токенах и NFT временно недоступна. Мы работаем над восстановлением этой функциональности."
     }
   },
   "qrCode": {
@@ -1362,7 +1474,8 @@
       "mandarin": "我的QR码",
       "portuguese": "Meu código QR",
       "spanish": "Mi código QR",
-      "turkish": "Benim QR kodum"
+      "turkish": "Benim QR kodum",
+      "russian": "Мой QR-код"
     }
   },
   "settings": {
@@ -1376,7 +1489,8 @@
       "mandarin": "帐户",
       "portuguese": "Conta",
       "spanish": "Cuenta",
-      "turkish": "Hesap"
+      "turkish": "Hesap",
+      "russian": "Аккаунт"
     },
     "addAccount": {
       "dutch": "Account toevoegen",
@@ -1388,7 +1502,8 @@
       "mandarin": "新增帐户",
       "portuguese": "Adicionar Conta",
       "spanish": "Añadir cuenta",
-      "turkish": "Hesap ekle"
+      "turkish": "Hesap ekle",
+      "russian": "Добавить аккаунт"
     },
     "addContact": {
       "dutch": "Voeg contact toe",
@@ -1400,7 +1515,8 @@
       "mandarin": "增加联系人",
       "portuguese": "Adicionar contato",
       "spanish": "Agregar contacto",
-      "turkish": "Kişi ekle"
+      "turkish": "Kişi ekle",
+      "russian": "Добавить контакт"
     },
     "addCustomNetwork": {
       "dutch": "Voeg een aangepast netwerk toe",
@@ -1412,7 +1528,8 @@
       "mandarin": "添加自定义网络",
       "portuguese": "Adicione rede personalizada",
       "spanish": "Agregar red personalizada",
-      "turkish": "Özel ağ ekle"
+      "turkish": "Özel ağ ekle",
+      "russian": "Добавить пользовательскую сеть"
     },
     "addNewContact": {
       "dutch": "Voeg nieuw contact toe",
@@ -1424,7 +1541,8 @@
       "mandarin": "添加新联系人",
       "portuguese": "Adicionar novo contato",
       "spanish": "Añadir nuevo contacto",
-      "turkish": "Yeni kişi ekle"
+      "turkish": "Yeni kişi ekle",
+      "russian": "Добавить новый контакт"
     },
     "address": {
       "dutch": "Adres",
@@ -1436,7 +1554,8 @@
       "mandarin": "地址",
       "portuguese": "Endereço",
       "spanish": "DIRECCIÓN",
-      "turkish": "Adres"
+      "turkish": "Adres",
+      "russian": "Адрес"
     },
     "appearance": {
       "dutch": "Verschijning",
@@ -1448,7 +1567,8 @@
       "mandarin": "外貌",
       "portuguese": "Aparência",
       "spanish": "Apariencia",
-      "turkish": "Görünüm"
+      "turkish": "Görünüm",
+      "russian": "Внешний вид"
     },
     "appearanceDesc": {
       "dutch": "Schakel de donkere modus in of uit",
@@ -1460,7 +1580,8 @@
       "mandarin": "启用或禁用黑暗模式",
       "portuguese": "Habilitar ou desativar o modo escuro",
       "spanish": "Habilitar o deshabilitar el modo oscuro",
-      "turkish": "Koyu modu etkinleştirmek veya devre dışı bırakmak"
+      "turkish": "Koyu modu etkinleştirmek veya devre dışı bırakmak",
+      "russian": "Включить или отключить темный режим"
     },
     "browserNotification": {
       "dutch": "Browsermeldingen",
@@ -1472,7 +1593,8 @@
       "mandarin": "浏览器通知",
       "portuguese": "Notificações do navegador",
       "spanish": "Notificaciones del navegador",
-      "turkish": "Tarayıcı bildirimleri"
+      "turkish": "Tarayıcı bildirimleri",
+      "russian": "Уведомления браузера"
     },
     "contactDesc": {
       "dutch": "Adresboek, contacten toevoegen",
@@ -1484,7 +1606,8 @@
       "mandarin": "地址簿，添加联系人",
       "portuguese": "Livro de endereços, adicione contatos",
       "spanish": "Libreta de direcciones, agregar contactos",
-      "turkish": "Adres defteri, kişileri ekle"
+      "turkish": "Adres defteri, kişileri ekle",
+      "russian": "Адресная книга, Добавить контакты"
     },
     "contacts": {
       "dutch": "Contacten",
@@ -1496,7 +1619,8 @@
       "mandarin": "联系人",
       "portuguese": "Contatos",
       "spanish": "Contactos",
-      "turkish": "Kişiler"
+      "turkish": "Kişiler",
+      "russian": "Контакты"
     },
     "copied": {
       "dutch": "Gekopieerd",
@@ -1508,7 +1632,8 @@
       "mandarin": "复制",
       "portuguese": "Copiado",
       "spanish": "Copiado",
-      "turkish": "Kopyalandı"
+      "turkish": "Kopyalandı",
+      "russian": "Скопировано"
     },
     "copy": {
       "dutch": "Kopiëren",
@@ -1520,7 +1645,8 @@
       "mandarin": "复制",
       "portuguese": "cópia de",
       "spanish": "Copiar",
-      "turkish": "Kopyala"
+      "turkish": "Kopyala",
+      "russian": "Копировать"
     },
     "copyAddress": {
       "dutch": "Kopieeradres",
@@ -1532,7 +1658,8 @@
       "mandarin": "复制地址",
       "portuguese": "Endereço de cópia",
       "spanish": "Dirección de copia",
-      "turkish": "Adresi kopyala"
+      "turkish": "Adresi kopyala",
+      "russian": "Скопировать адрес"
     },
     "copyPrivateKey": {
       "dutch": "Kopieer privésleutel",
@@ -1544,7 +1671,8 @@
       "mandarin": "复制私钥",
       "portuguese": "Copiar chave privada",
       "spanish": "Copiar clave privada",
-      "turkish": "Özel Anahtarı Kopyala"
+      "turkish": "Özel Anahtarı Kopyala",
+      "russian": "Скопировать приватный ключ"
     },
     "currency": {
       "dutch": "Munteenheid",
@@ -1556,7 +1684,8 @@
       "mandarin": "货币",
       "portuguese": "Moeda",
       "spanish": "Divisa",
-      "turkish": "Para birimi"
+      "turkish": "Para birimi",
+      "russian": "Валюта"
     },
     "custom": {
       "dutch": "Aangepast",
@@ -1568,7 +1697,8 @@
       "mandarin": "风俗",
       "portuguese": "Personalizado",
       "spanish": "Costumbre",
-      "turkish": "Gelenek"
+      "turkish": "Gelenek",
+      "russian": "Пользовательский"
     },
     "dark": {
       "dutch": "Donker",
@@ -1580,7 +1710,8 @@
       "mandarin": "黑暗的",
       "portuguese": "Escuro",
       "spanish": "Oscuro",
-      "turkish": "Koyu"
+      "turkish": "Koyu",
+      "russian": "Темный"
     },
     "defaultAccount": {
       "dutch": "Standaardaccount",
@@ -1592,7 +1723,8 @@
       "mandarin": "默认帐户",
       "portuguese": "Conta padrão",
       "spanish": "Cuenta predeterminada",
-      "turkish": "Varsayılan hesap"
+      "turkish": "Varsayılan hesap",
+      "russian": "Основной аккаунт"
     },
     "delete": {
       "dutch": "Verwijderen",
@@ -1604,7 +1736,8 @@
       "mandarin": "删除",
       "portuguese": "Excluir",
       "spanish": "Borrar",
-      "turkish": "Sil"
+      "turkish": "Sil",
+      "russian": "Удалить"
     },
     "devMsg": {
       "dutch": "Dit is een ontwikkelaarsinstelling en bedoeld voor testen en geavanceerd gebruik. Verander deze instellingen niet als u niet bekend bent met hun doel.",
@@ -1616,7 +1749,8 @@
       "mandarin": "这是开发人员设置，用于测试和高级用法。如果您不熟悉它们的目的，避免更改这些设置。",
       "portuguese": "Esta é uma configuração de desenvolvedor e destinada a testes e uso avançado. Evite alterar essas configurações se você não estiver familiarizado com o objetivo deles.",
       "spanish": "Esta es una configuración de desarrollador y destinada a pruebas y uso avanzado. Evite cambiar estas configuraciones si no está familiarizado con su propósito.",
-      "turkish": "Bu geliştirici ayarı ve test ve gelişmiş kullanım için tasarlanmıştır. Bu ayarları değiştirmeyi bilmiyorsanız, bunları değiştirmeyin."
+      "turkish": "Bu geliştirici ayarı ve test ve gelişmiş kullanım için tasarlanmıştır. Bu ayarları değiştirmeyi bilmiyorsanız, bunları değiştirmeyin.",
+      "russian": "Это настройка для разработчиков, предназначенная для тестирования и продвинутого использования. Избегайте изменения этих настроек, если вы не знакомы с их назначением."
     },
     "downloadSoftCopy": {
       "dutch": "Download Soft Copy (JSON)",
@@ -1628,7 +1762,8 @@
       "mandarin": "下载软拷贝（JSON）",
       "portuguese": "Download Soft Cópia (JSON)",
       "spanish": "Descargar una copia suave (JSON)",
-      "turkish": "Ince ince (JSON) indir"
+      "turkish": "Ince ince (JSON) indir",
+      "russian": "Скачать электронную копию (JSON)"
     },
     "edit": {
       "dutch": "Bewerking",
@@ -1640,7 +1775,8 @@
       "mandarin": "编辑",
       "portuguese": "Editar",
       "spanish": "Editar",
-      "turkish": "Düzenle"
+      "turkish": "Düzenle",
+      "russian": "Редактировать"
     },
     "editCustomNetwork": {
       "dutch": "Bewerk aangepast netwerk",
@@ -1652,7 +1788,8 @@
       "mandarin": "编辑自定义网络",
       "portuguese": "Editar rede personalizada",
       "spanish": "Editar red personalizada",
-      "turkish": "Özel ağ düzenle"
+      "turkish": "Özel ağ düzenle",
+      "russian": "Редактировать пользовательскую сеть"
     },
     "emailNotification": {
       "dutch": "E-mail notificaties",
@@ -1664,7 +1801,8 @@
       "mandarin": "电子邮件通知",
       "portuguese": "Notificações por e -mail",
       "spanish": "Notificaciónes de Correo Electrónico",
-      "turkish": "E-posta bildirimleri"
+      "turkish": "E-posta bildirimleri",
+      "russian": "Уведомления по электронной почте"
     },
     "enableEmailNotificationMsg": {
       "dutch": "Schakel dit in om alle e -mailmeldingen met betrekking tot transacties in uw Torus -portemonnee te krijgen.",
@@ -1676,7 +1814,8 @@
       "mandarin": "使其能够获取与您的Torus钱包中交易有关的所有电子邮件通知。",
       "portuguese": "Habilite isso para obter todas as notificações por e -mail relacionadas a transações na sua carteira de torus.",
       "spanish": "Habilite esto para obtener todas las notificaciones de correo electrónico relacionadas con las transacciones en su billetera Torus.",
-      "turkish": "Bu Torus cüzdanınızda işlemlerle ilgili tüm e-posta bildirimlerini almak için bu seçeneği etkinleştirin."
+      "turkish": "Bu Torus cüzdanınızda işlemlerle ilgili tüm e-posta bildirimlerini almak için bu seçeneği etkinleştirin.",
+      "russian": "Включите это, чтобы получать все уведомления по электронной почте, связанные с транзакциями в вашем кошельке Torus."
     },
     "enableInAppNotificationMsg": {
       "dutch": "Schakel dit in om alle in-app-meldingen met betrekking tot transacties in uw Torus-portemonnee te krijgen.",
@@ -1688,7 +1827,8 @@
       "mandarin": "使其能够获取与圆环钱包中交易有关的所有应用内通知。",
       "portuguese": "Habilite isso para obter todas as notificações no aplicativo relacionadas a transações em sua carteira de torus.",
       "spanish": "Permita que esto obtenga todas las notificaciones en la aplicación relacionadas con las transacciones en su billetera Torus.",
-      "turkish": "Bu Torus cüzdanınızda işlemlerle ilgili tüm uygulama içi bildirimlerini almak için bu seçeneği etkinleştirin."
+      "turkish": "Bu Torus cüzdanınızda işlemlerle ilgili tüm uygulama içi bildirimlerini almak için bu seçeneği etkinleştirin.",
+      "russian": "Включите это, чтобы получать все уведомления в приложении, связанные с транзакциями в вашем кошельке Torus."
     },
     "enableNetworksMsg": {
       "dutch": "Schakel testnetwerken in",
@@ -1700,7 +1840,8 @@
       "mandarin": "启用可以查看测试网络",
       "portuguese": "Ativar ver redes de teste",
       "spanish": "Habilitar para ver las redes de prueba",
-      "turkish": "Test ağlarını görmek için etkinleştirin"
+      "turkish": "Test ağlarını görmek için etkinleştirin",
+      "russian": "Включить возможность просмотра тестовых сетей"
     },
     "enableNotificationMsg": {
       "dutch": "Schakel dit in om browsermeldingen te krijgen met betrekking tot transacties in uw Torus -portemonnee.",
@@ -1712,7 +1853,8 @@
       "mandarin": "使其能够获取与圆环钱包中交易有关的浏览器通知。",
       "portuguese": "Habilite isso para obter notificações do navegador relacionadas a transações na carteira do Torus.",
       "spanish": "Permita que esto haga que las notificaciones del navegador sean relacionadas con las transacciones en su billetera Torus.",
-      "turkish": "Bu Torus cüzdanınızda işlemlerle ilgili tarayıcı bildirimlerini almak için bu seçeneği etkinleştirin."
+      "turkish": "Bu Torus cüzdanınızda işlemlerle ilgili tarayıcı bildirimlerini almak için bu seçeneği etkinleştirin.",
+      "russian": "Включите это, чтобы получать уведомления в браузере, связанные с транзакциями в вашем кошельке Torus."
     },
     "enterBlockExplorer": {
       "dutch": "Voer Block Explorer URL in (optioneel)",
@@ -1724,7 +1866,8 @@
       "mandarin": "输入Block Explorer URL（可选）",
       "portuguese": "Digite o URL do Block Explorer (opcional)",
       "spanish": "Ingrese a la URL de explorador de bloques (opcional)",
-      "turkish": "Blok Explorer URL giriniz (opsiyonel)"
+      "turkish": "Blok Explorer URL giriniz (opsiyonel)",
+      "russian": "Введите URL-адрес обозревателя блоков (необязательно)"
     },
     "enterChainId": {
       "dutch": "Voer ketting -ID in",
@@ -1736,7 +1879,8 @@
       "mandarin": "输入链ID",
       "portuguese": "Digite ID da corrente",
       "spanish": "Ingrese la identificación de la cadena",
-      "turkish": "Ket ID giriniz"
+      "turkish": "Ket ID giriniz",
+      "russian": "Введите ID цепочки"
     },
     "enterContactsName": {
       "dutch": "Voer de naam van Contact in",
@@ -1748,7 +1892,8 @@
       "mandarin": "输入联系人的姓名",
       "portuguese": "Digite o nome do contato",
       "spanish": "Ingrese el nombre del contacto",
-      "turkish": "Kişi ismi girin"
+      "turkish": "Kişi ismi girin",
+      "russian": "Введите имя контакта"
     },
     "enterEthAddress": {
       "dutch": "Voer het adres van ETH in",
@@ -1760,7 +1905,8 @@
       "mandarin": "输入ETH的地址",
       "portuguese": "Digite o endereço da ETH",
       "spanish": "Ingrese la dirección de ETH",
-      "turkish": "ETH adresini girin"
+      "turkish": "ETH adresini girin",
+      "russian": "Введите адрес ETH"
     },
     "enterNetworkName": {
       "dutch": "Voer de netwerknaam in",
@@ -1772,7 +1918,8 @@
       "mandarin": "输入网络名称",
       "portuguese": "Digite o nome da rede",
       "spanish": "Ingrese el nombre de la red",
-      "turkish": "Ağ adı giriniz"
+      "turkish": "Ağ adı giriniz",
+      "russian": "Введите название сети"
     },
     "enterRpc": {
       "dutch": "Voer RPC URL in",
@@ -1784,7 +1931,8 @@
       "mandarin": "输入RPC URL",
       "portuguese": "Digite RPC URL",
       "spanish": "Ingrese RPC URL",
-      "turkish": "RPC URL giriniz"
+      "turkish": "RPC URL giriniz",
+      "russian": "Введите URL RPC"
     },
     "enterSymbol": {
       "dutch": "Voer symbool in (optioneel)",
@@ -1796,7 +1944,8 @@
       "mandarin": "输入符号（可选）",
       "portuguese": "Digite o símbolo (opcional)",
       "spanish": "Ingrese el símbolo (opcional)",
-      "turkish": "Sembol giriniz (opsiyonel)"
+      "turkish": "Sembol giriniz (opsiyonel)",
+      "russian": "Введите символ (необязательно)"
     },
     "errors-invalid-password": {
       "dutch": "Moet ten minste 10 tekens bevatten. Ten minste één hoofdletter, één kleine letter, één cijfer",
@@ -1808,7 +1957,8 @@
       "mandarin": "必须至少包含10个字符。 至少一个大写字母，一个小写字母，一个数字",
       "portuguese": "Deve conter pelo menos 10 caracteres. Pelo menos uma letra maiúscula, uma letra minúscula, um número",
       "spanish": "Debe contener al menos 10 caracteres. Al menos una letra mayúscula, una letra minúscula, un número",
-      "turkish": "En az 10 karakter içermelidir. En az bir büyük harf, bir küçük harf ve bir sayı"
+      "turkish": "En az 10 karakter içermelidir. En az bir büyük harf, bir küçük harf ve bir sayı",
+      "russian": "Должен содержать не менее 10 символов. Как минимум одна заглавная буква, одна строчная буква, одна цифра."
     },
     "exportAaNoteDesc": {
       "dutch": "Voor extra beveiliging is deze EOA sleutel gekoppeld aan uw smart contract account voor beveiligingsdoeleinden.",
@@ -1820,7 +1970,8 @@
       "mandarin": "Smart contract account链接，以确保安全。",
       "portuguese": "Para maior segurança, esta chave EOA está vinculada ao seu smart contract account para fins de segurança.",
       "spanish": "Para mayor seguridad, esta clave EOA está vinculada a su smart contract account con fines de seguridad.",
-      "turkish": "Güvenliği artırmak için, bu EOA anahtarı güvenlik amacıyla smart contract account'nızla bağlanmıştır."
+      "turkish": "Güvenliği artırmak için, bu EOA anahtarı güvenlik amacıyla smart contract account'nızla bağlanmıştır.",
+      "russian": "Для дополнительной безопасности, этот ключ EOA связан с вашим аккаунтом умного контракта в целях безопасности."
     },
     "exportAaNoteTitle": {
       "dutch": "Dit is een Smart Contract Account.",
@@ -1832,7 +1983,8 @@
       "mandarin": "这是一个Smart Contract Account。",
       "portuguese": "Este é um Smart Contract Account.",
       "spanish": "Este es un Smart Contract Account.",
-      "turkish": "Bu, Smart Contract Account'dir."
+      "turkish": "Bu, Smart Contract Account'dir.",
+      "russian": "Это аккаунт на базе смарт-контракта."
     },
     "general": {
       "dutch": "Algemeen",
@@ -1844,7 +1996,8 @@
       "mandarin": "一般的",
       "portuguese": "Em geral",
       "spanish": "General",
-      "turkish": "Genel"
+      "turkish": "Genel",
+      "russian": "Главная"
     },
     "generalDesc": {
       "dutch": "Netwerk, taal, valuta enz.,",
@@ -1856,7 +2009,8 @@
       "mandarin": "网络，语言，货币等",
       "portuguese": "Rede, idioma, moeda etc.,",
       "spanish": "Red, idioma, moneda, etc.,",
-      "turkish": "Ağ, dil, para birimi vs."
+      "turkish": "Ağ, dil, para birimi vs.",
+      "russian": "Сеть, язык, валюта и т.д.,"
     },
     "hidePrivateKey": {
       "dutch": "Verberg de privésleutel",
@@ -1868,7 +2022,8 @@
       "mandarin": "隐藏私钥",
       "portuguese": "Ocultar a chave privada",
       "spanish": "Ocultar la llave privada",
-      "turkish": "Gizli anahtarı gizle"
+      "turkish": "Gizli anahtarı gizle",
+      "russian": "Скрыть приватный ключ"
     },
     "import": {
       "dutch": "Importeren",
@@ -1880,7 +2035,8 @@
       "mandarin": "进口",
       "portuguese": "Importar",
       "spanish": "Importar",
-      "turkish": "İçeri aktar"
+      "turkish": "İçeri aktar",
+      "russian": "Импорт"
     },
     "importAcc": {
       "dutch": "Importrekening",
@@ -1892,7 +2048,8 @@
       "mandarin": "导入帐户",
       "portuguese": "Conta de importação",
       "spanish": "Cuenta de importación",
-      "turkish": "Hesap içeri aktarma"
+      "turkish": "Hesap içeri aktarma",
+      "russian": "Импорт аккаунта"
     },
     "importError": {
       "dutch": "Er is iets misgegaan, controleer de consologogels",
@@ -1904,7 +2061,8 @@
       "mandarin": "出了问题，请检查控制台日志",
       "portuguese": "Algo deu errado, verifique os logs do console",
       "spanish": "Algo salió mal, por favor revise los registros de la consola",
-      "turkish": "Bir şeyler yanlış gitti, lütfen konsola günlüklerini kontrol edin"
+      "turkish": "Bir şeyler yanlış gitti, lütfen konsola günlüklerini kontrol edin",
+      "russian": "Что-то пошло не так, пожалуйста, проверьте журнал консоли."
     },
     "inAppNotification": {
       "dutch": "In-app-meldingen",
@@ -1916,7 +2074,8 @@
       "mandarin": "应用内通知",
       "portuguese": "Notificações no aplicativo",
       "spanish": "Notificaciones en la aplicación",
-      "turkish": "Uygulama içi bildirimler"
+      "turkish": "Uygulama içi bildirimler",
+      "russian": "Уведомления в приложении"
     },
     "inputPassword": {
       "dutch": "Voer het wachtwoord in",
@@ -1928,7 +2087,8 @@
       "mandarin": "请输入密码",
       "portuguese": "Insira a senha",
       "spanish": "Por favor ingrese la contraseña",
-      "turkish": "Lütfen şifreyi girin"
+      "turkish": "Lütfen şifreyi girin",
+      "russian": "Пожалуйста, введите пароль"
     },
     "inputPrivKey": {
       "dutch": "Invoer privésleutel",
@@ -1940,7 +2100,8 @@
       "mandarin": "输入私钥",
       "portuguese": "Insira a chave privada",
       "spanish": "Ingreso clave privada",
-      "turkish": "Gizli anahtarı gir"
+      "turkish": "Gizli anahtarı gir",
+      "russian": "Введите приватный ключ"
     },
     "invalidHex": {
       "dutch": "Ongeldige hexadecimale nummer.",
@@ -1952,7 +2113,8 @@
       "mandarin": "无效的十六进制数。",
       "portuguese": "Número hexadecimal inválido.",
       "spanish": "Número hexadecimal inválido.",
-      "turkish": "Geçersiz onaltılık sayı."
+      "turkish": "Geçersiz onaltılık sayı.",
+      "russian": "Недопустимое шестнадцатеричное число."
     },
     "language": {
       "dutch": "Taal",
@@ -1964,7 +2126,8 @@
       "mandarin": "语言",
       "portuguese": "Linguagem",
       "spanish": "Idioma",
-      "turkish": "Dil"
+      "turkish": "Dil",
+      "russian": "Язык"
     },
     "light": {
       "dutch": "Licht",
@@ -1976,7 +2139,8 @@
       "mandarin": "光",
       "portuguese": "Luz",
       "spanish": "Luz",
-      "turkish": "Aydınlık"
+      "turkish": "Aydınlık",
+      "russian": "Светлая"
     },
     "listOfContacts": {
       "dutch": "Lijst met contacten",
@@ -1988,7 +2152,8 @@
       "mandarin": "联系人列表",
       "portuguese": "Lista de contatos",
       "spanish": "Lista de contactos",
-      "turkish": "Kişiler listesi"
+      "turkish": "Kişiler listesi",
+      "russian": "Список контактов"
     },
     "network": {
       "dutch": "Netwerk",
@@ -2000,7 +2165,8 @@
       "mandarin": "网络",
       "portuguese": "Rede",
       "spanish": "Red",
-      "turkish": "Ağ"
+      "turkish": "Ağ",
+      "russian": "Сеть"
     },
     "networkAddFail": {
       "dutch": "Kan geen aangepast netwerk toevoegen",
@@ -2012,7 +2178,8 @@
       "mandarin": "无法添加自定义网络",
       "portuguese": "Não é possível adicionar rede personalizada",
       "spanish": "No se puede agregar una red personalizada",
-      "turkish": "Özel ağ eklenemedi"
+      "turkish": "Özel ağ eklenemedi",
+      "russian": "Невозможно добавить пользовательскую сеть"
     },
     "networkAddSuccess": {
       "dutch": "Succesvol aangepast netwerk toegevoegd",
@@ -2024,7 +2191,8 @@
       "mandarin": "成功添加自定义网络",
       "portuguese": "Rede personalizada adicionada com sucesso",
       "spanish": "Network personalizado agregado con éxito",
-      "turkish": "Özel ağ başarıyla eklendi"
+      "turkish": "Özel ağ başarıyla eklendi",
+      "russian": "Успешно добавлена пользовательская сеть"
     },
     "networkDeleteFail": {
       "dutch": "Kan het aangepaste netwerk niet verwijderen",
@@ -2036,7 +2204,8 @@
       "mandarin": "无法删除自定义网络",
       "portuguese": "Não é possível excluir rede personalizada",
       "spanish": "No se puede eliminar la red personalizada",
-      "turkish": "Özel ağ silinemedi"
+      "turkish": "Özel ağ silinemedi",
+      "russian": "Невозможно удалить пользовательскую сеть"
     },
     "networkDeleteSuccess": {
       "dutch": "Met succes verwijderd aangepast netwerk",
@@ -2048,7 +2217,8 @@
       "mandarin": "成功删除的自定义网络",
       "portuguese": "Excluído com sucesso Rede Custom",
       "spanish": "Eliminada con éxito la red personalizada",
-      "turkish": "Özel ağ başarıyla silindi"
+      "turkish": "Özel ağ başarıyla silindi",
+      "russian": "Успешно удалена пользовательская сеть"
     },
     "networkNameExists": {
       "dutch": "Netwerknaam bestaat al",
@@ -2060,7 +2230,8 @@
       "mandarin": "网络名称已经存在",
       "portuguese": "O nome da rede já existe",
       "spanish": "El nombre de la red ya existe",
-      "turkish": "Ağ adı zaten mevcut"
+      "turkish": "Ağ adı zaten mevcut",
+      "russian": "Имя сети уже существует"
     },
     "networkUpdateFail": {
       "dutch": "Kan geen aangepast netwerk toevoegen",
@@ -2072,7 +2243,8 @@
       "mandarin": "无法添加自定义网络",
       "portuguese": "Não é possível adicionar rede personalizada",
       "spanish": "No se puede agregar una red personalizada",
-      "turkish": "Özel ağ eklenemedi"
+      "turkish": "Özel ağ eklenemedi",
+      "russian": "Невозможно добавить пользовательскую сеть"
     },
     "networkUpdateSuccess": {
       "dutch": "Succesvol bijgewerkt aangepast netwerk",
@@ -2084,7 +2256,8 @@
       "mandarin": "成功更新了自定义网络",
       "portuguese": "Rede personalizada atualizada com sucesso",
       "spanish": "Red personalizada actualizada con éxito",
-      "turkish": "Özel ağ başarıyla güncellendi"
+      "turkish": "Özel ağ başarıyla güncellendi",
+      "russian": "Успешно обновлена пользовательская сеть"
     },
     "notification": {
       "dutch": "Meldingen",
@@ -2096,7 +2269,8 @@
       "mandarin": "通知",
       "portuguese": "Notificações",
       "spanish": "Notificaciones",
-      "turkish": "Bildirimler"
+      "turkish": "Bildirimler",
+      "russian": "Уведомления"
     },
     "notificationDesc": {
       "dutch": "Meldingen inschakelen en uitschakelen",
@@ -2108,7 +2282,8 @@
       "mandarin": "启用和禁用通知",
       "portuguese": "Ativar e desativar notificações",
       "spanish": "Habilitar y deshabilitar notificaciones",
-      "turkish": "Bildirimleri etkinleştirmek ve devre dışı bırakmak"
+      "turkish": "Bildirimleri etkinleştirmek ve devre dışı bırakmak",
+      "russian": "Включить и отключить уведомления"
     },
     "privKeyDesc": {
       "dutch": "Privésleutel (downloaden of kopiëren)",
@@ -2120,7 +2295,8 @@
       "mandarin": "私钥（下载或复制）",
       "portuguese": "Chave privada (download ou cópia)",
       "spanish": "Clave privada (descargar o copiar)",
-      "turkish": "Gizli anahtar (indir veya kopyala)"
+      "turkish": "Gizli anahtar (indir veya kopyala)",
+      "russian": "Приватный ключ (Скачать или скопировать)"
     },
     "privacyAndSecurity": {
       "dutch": "Privacy en beveiliging",
@@ -2132,7 +2308,8 @@
       "mandarin": "隐私和安全",
       "portuguese": "Privacidade e segurança",
       "spanish": "Privacidad y seguridad",
-      "turkish": "Gizlilik ve güvenlik"
+      "turkish": "Gizlilik ve güvenlik",
+      "russian": "Приватность и безопасность"
     },
     "privateKey": {
       "dutch": "Privésleutel",
@@ -2144,7 +2321,8 @@
       "mandarin": "私钥",
       "portuguese": "Chave privada",
       "spanish": "Llave privada",
-      "turkish": "Gizli anahtar"
+      "turkish": "Gizli anahtar",
+      "russian": "Приватный ключ"
     },
     "profile": {
       "dutch": "Beheer portefeuilles",
@@ -2156,7 +2334,8 @@
       "mandarin": "管理钱包",
       "portuguese": "Gerenciar carteiras",
       "spanish": "Administrar billeteras",
-      "turkish": "Cüzdanları yönet"
+      "turkish": "Cüzdanları yönet",
+      "russian": "Управление кошельками"
     },
     "profileDesc": {
       "dutch": "Standaard portemonnee, portemonnee enz. Importeren,",
@@ -2168,7 +2347,8 @@
       "mandarin": "默认钱包，导入钱包等，",
       "portuguese": "Carteira padrão, carteira de importação etc.,",
       "spanish": "Billetera predeterminada, billetera de importación, etc.,",
-      "turkish": "Varsayılan cüzdan, içe aktarma cüzdanı vs."
+      "turkish": "Varsayılan cüzdan, içe aktarma cüzdanı vs.",
+      "russian": "Стандартный кошелек, Импорт кошелька и т.д.,"
     },
     "recoveryKit": {
       "dutch": "Herstelkit",
@@ -2180,7 +2360,8 @@
       "mandarin": "恢复套件",
       "portuguese": "Kit de recuperação",
       "spanish": "Kit de recuperación",
-      "turkish": "Kurtarma Kiti"
+      "turkish": "Kurtarma Kiti",
+      "russian": "Набор для восстановления"
     },
     "save": {
       "dutch": "Redden",
@@ -2192,7 +2373,8 @@
       "mandarin": "节省",
       "portuguese": "Salvar",
       "spanish": "Ahorrar",
-      "turkish": "Kaydet"
+      "turkish": "Kaydet",
+      "russian": "Сохранить"
     },
     "selectDefaultCurrency": {
       "dutch": "Selecteer standaardvaluta",
@@ -2204,7 +2386,8 @@
       "mandarin": "选择默认货币",
       "portuguese": "Selecione a moeda padrão",
       "spanish": "Seleccionar moneda predeterminada",
-      "turkish": "Varsayılan para birimi seç"
+      "turkish": "Varsayılan para birimi seç",
+      "russian": "Выберите основную валюту"
     },
     "selectDefaultLang": {
       "dutch": "Selecteer Standaardtaal",
@@ -2216,7 +2399,8 @@
       "mandarin": "选择默认语言",
       "portuguese": "Selecione o idioma padrão",
       "spanish": "Seleccione el lenguaje predeterminado",
-      "turkish": "Varsayılan dil seç"
+      "turkish": "Varsayılan dil seç",
+      "russian": "Выбрать основной язык"
     },
     "selectDefaultNetwork": {
       "dutch": "Selecteer Standaardnetwerk",
@@ -2228,7 +2412,8 @@
       "mandarin": "选择默认网络",
       "portuguese": "Selecione rede padrão",
       "spanish": "Seleccione la red predeterminada",
-      "turkish": "Varsayılan ağı seçin"
+      "turkish": "Varsayılan ağı seçin",
+      "russian": "Выбрать сеть по умолчанию"
     },
     "selectImportType": {
       "dutch": "Selecteer het type import",
@@ -2240,7 +2425,8 @@
       "mandarin": "选择导入类型",
       "portuguese": "Selecione o tipo de importação",
       "spanish": "Seleccione Tipo de importación",
-      "turkish": "İçeri aktarma türü seç"
+      "turkish": "İçeri aktarma türü seç",
+      "russian": "Выберите тип импорта"
     },
     "showPrivateKey": {
       "dutch": "Toon privésleutel",
@@ -2252,7 +2438,8 @@
       "mandarin": "显示私钥",
       "portuguese": "Mostre chave privada",
       "spanish": "Mostrar llave privada",
-      "turkish": "Gizli anahtarı göster"
+      "turkish": "Gizli anahtarı göster",
+      "russian": "Показать приватный ключ"
     },
     "showQr": {
       "dutch": "Toon QR",
@@ -2264,7 +2451,8 @@
       "mandarin": "显示QR",
       "portuguese": "Mostrar QR",
       "spanish": "Mostrar QR",
-      "turkish": "QR'yi göster"
+      "turkish": "QR'yi göster",
+      "russian": "Показать QR"
     },
     "switchAccount": {
       "dutch": "Verwissel van profiel",
@@ -2276,7 +2464,8 @@
       "mandarin": "开关帐户",
       "portuguese": "Mudar de conta",
       "spanish": "Cambiar cuenta",
-      "turkish": "Hesap değiştir"
+      "turkish": "Hesap değiştir",
+      "russian": "Сменить учетную запись"
     },
     "switchNetwork": {
       "dutch": "Wisselnetwerk",
@@ -2288,7 +2477,8 @@
       "mandarin": "开关网络",
       "portuguese": "Switch Network",
       "spanish": "Cambiar de red",
-      "turkish": "Ağ değiştir"
+      "turkish": "Ağ değiştir",
+      "russian": "Сменить сеть"
     },
     "system": {
       "dutch": "Systeem",
@@ -2300,7 +2490,8 @@
       "mandarin": "系统",
       "portuguese": "Sistema",
       "spanish": "Sistema",
-      "turkish": "Sistem"
+      "turkish": "Sistem",
+      "russian": "Система"
     },
     "testNetworks": {
       "dutch": "Testnetwerken",
@@ -2312,7 +2503,8 @@
       "mandarin": "测试网络",
       "portuguese": "Redes de teste",
       "spanish": "Redes de prueba",
-      "turkish": "Test ağları"
+      "turkish": "Test ağları",
+      "russian": "Тестовые сети"
     },
     "yourAcc": {
       "dutch": "Andere accounts",
@@ -2324,7 +2516,8 @@
       "mandarin": "其他帐户",
       "portuguese": "Outras contas",
       "spanish": "Otras cuentas",
-      "turkish": "Diğer hesaplar"
+      "turkish": "Diğer hesaplar",
+      "russian": "Другие аккаунты"
     }
   },
   "widget": {
@@ -2338,7 +2531,8 @@
       "mandarin": "打开钱包",
       "portuguese": "Carteira aberta",
       "spanish": "Billetera abierta",
-      "turkish": "Açık cüzdan"
+      "turkish": "Açık cüzdan",
+      "russian": "Открыть кошелек"
     },
     "walletBalance": {
       "dutch": "Portemonnee",
@@ -2350,7 +2544,8 @@
       "mandarin": "钱包平衡",
       "portuguese": "Balanço da carteira",
       "spanish": "Equilibrio de billetera",
-      "turkish": "Cüzdan bakiyesi"
+      "turkish": "Cüzdan bakiyesi",
+      "russian": "Баланс кошелька"
     }
   }
 }

--- a/Wallet-service-locale/locales-swap.json
+++ b/Wallet-service-locale/locales-swap.json
@@ -10,7 +10,8 @@
       "mandarin": "高级选项",
       "portuguese": "Opções avançadas",
       "spanish": "Opciones avanzadas",
-      "turkish": "Gelişmiş Seçenekler"
+      "turkish": "Gelişmiş Seçenekler",
+      "russian": "Расширенные параметры"
     },
     "apply": {
       "dutch": "Toepassen",
@@ -22,7 +23,8 @@
       "mandarin": "申请",
       "portuguese": "Aplicar",
       "spanish": "Aplicar",
-      "turkish": "Uygula"
+      "turkish": "Uygula",
+      "russian": "Применить"
     },
     "approve-swap": {
       "dutch": "Goedkeuren en ruilen",
@@ -34,7 +36,8 @@
       "mandarin": "批准和交换",
       "portuguese": "Aprovar e trocar",
       "spanish": "Aprobar e intercambiar",
-      "turkish": "Onayla ve Değiştir"
+      "turkish": "Onayla ve Değiştir",
+      "russian": "Одобрить и обменять"
     },
     "approving-token": {
       "dutch": "Overdracht van token goedkeuren",
@@ -46,7 +49,8 @@
       "mandarin": "批准token转移",
       "portuguese": "Aprovando transferência de token",
       "spanish": "Aprobando la transferencia de token",
-      "turkish": "Token aktarımı onaylanıyor"
+      "turkish": "Token aktarımı onaylanıyor",
+      "russian": "Подтверждение перевода токена"
     },
     "balance": {
       "dutch": "Evenwicht",
@@ -58,7 +62,8 @@
       "mandarin": "平衡",
       "portuguese": "Equilíbrio",
       "spanish": "Balance",
-      "turkish": "Denge"
+      "turkish": "Denge",
+      "russian": "Баланс"
     },
     "cancel": {
       "dutch": "Annuleren",
@@ -70,7 +75,8 @@
       "mandarin": "取消",
       "portuguese": "Cancelar",
       "spanish": "Cancelar",
-      "turkish": "İptal Et"
+      "turkish": "İptal Et",
+      "russian": "Отменить"
     },
     "confirm": {
       "dutch": "Bevestigen",
@@ -82,7 +88,8 @@
       "mandarin": "确认",
       "portuguese": "confirme",
       "spanish": "Confirmar",
-      "turkish": "Onayla"
+      "turkish": "Onayla",
+      "russian": "Подтвердить"
     },
     "confirmSwapTxn": {
       "dutch": "Bevestig swap -transactie",
@@ -94,7 +101,8 @@
       "mandarin": "确认交易交易",
       "portuguese": "Confirme a transação de troca",
       "spanish": "Confirmar la transacción de intercambio",
-      "turkish": "Değişimi Onayla"
+      "turkish": "Değişimi Onayla",
+      "russian": "Подтвердить транзакцию обмена"
     },
     "errorInvalidAddress": {
       "dutch": "Ongeldig adres",
@@ -106,7 +114,8 @@
       "mandarin": "地址无效",
       "portuguese": "Endereço inválido",
       "spanish": "Dirección no válida",
-      "turkish": "Geçersiz adres"
+      "turkish": "Geçersiz adres",
+      "russian": "Недействительный адрес"
     },
     "errorSelectToken": {
       "dutch": "Selecteer een token",
@@ -118,7 +127,8 @@
       "mandarin": "请选择一个代币",
       "portuguese": "Selecione um token",
       "spanish": "Por favor seleccione una ficha",
-      "turkish": "Lütfen bir belirteç seçin"
+      "turkish": "Lütfen bir belirteç seçin",
+      "russian": "Пожалуйста, выберите токен"
     },
     "errorTokenAmount": {
       "dutch": "Voer een bedrag in",
@@ -130,7 +140,8 @@
       "mandarin": "输入金额",
       "portuguese": "Insira um valor",
       "spanish": "Introduce una cantidad",
-      "turkish": "Bir tutar girin"
+      "turkish": "Bir tutar girin",
+      "russian": "Введите сумму"
     },
     "failedFetchingQuote": {
       "dutch": "Fout bij het ophalen van de prijs",
@@ -142,7 +153,8 @@
       "mandarin": "获取价格失败",
       "portuguese": "Erro ao obter o preço",
       "spanish": "Error al obtener el precio",
-      "turkish": "Fiyat alınamadı"
+      "turkish": "Fiyat alınamadı",
+      "russian": "Не удалось получить котировку"
     },
     "failedSwapDesc": {
       "dutch": "Er is een fout opgetreden tijdens het verwerken van de swap",
@@ -154,7 +166,8 @@
       "mandarin": "处理交换时发生错误",
       "portuguese": "Ocorreu um erro ao processar a troca",
       "spanish": "Se produjo un error al procesar el intercambio.",
-      "turkish": "Takas işlenirken bir hata oluştu"
+      "turkish": "Takas işlenirken bir hata oluştu",
+      "russian": "Ошибка при обработке обмена"
     },
     "failedSwapTitle": {
       "dutch": "Uw ruilverzoek kan niet worden verwerkt",
@@ -166,7 +179,8 @@
       "mandarin": "无法处理您的交换请求",
       "portuguese": "Sua solicitação de troca não pode ser processada",
       "spanish": "Su solicitud de intercambio no se puede procesar",
-      "turkish": "Takas talebiniz işleme alınamıyor"
+      "turkish": "Takas talebiniz işleme alınamıyor",
+      "russian": "Ваш запрос на обмен не может быть обработан"
     },
     "fetchingPrice": {
       "dutch": "Beste prijs ophalen",
@@ -178,7 +192,8 @@
       "mandarin": "获取最优惠价格",
       "portuguese": "Buscando o melhor preço",
       "spanish": "Obteniendo el mejor precio",
-      "turkish": "En iyi fiyat getiriliyor"
+      "turkish": "En iyi fiyat getiriliyor",
+      "russian": "Получение лучшей цены"
     },
     "for": {
       "dutch": "Voor",
@@ -190,7 +205,8 @@
       "mandarin": "为了",
       "portuguese": "Para",
       "spanish": "Para",
-      "turkish": "İçin"
+      "turkish": "İçin",
+      "russian": "Для"
     },
     "from": {
       "dutch": "Van:",
@@ -202,7 +218,8 @@
       "mandarin": "从：",
       "portuguese": "De:",
       "spanish": "De:",
-      "turkish": "Şuna:"
+      "turkish": "Şuna:",
+      "russian": "От:"
     },
     "fromAddress": {
       "dutch": "Van portemonnee-adres:",
@@ -214,7 +231,8 @@
       "mandarin": "来自钱包地址：",
       "portuguese": "Do endereço da carteira:",
       "spanish": "Desde la dirección de la billetera:",
-      "turkish": "Cüzdan adresinden:"
+      "turkish": "Cüzdan adresinden:",
+      "russian": "С адреса кошелька:"
     },
     "gasLimit": {
       "dutch": "Gasgrens",
@@ -226,7 +244,8 @@
       "mandarin": "气限",
       "portuguese": "Limite de gás",
       "spanish": "Límite de gas",
-      "turkish": "Jener Limiti"
+      "turkish": "Jener Limiti",
+      "russian": "Лимит газа"
     },
     "max": {
       "dutch": "Max",
@@ -238,7 +257,8 @@
       "mandarin": "最大限度",
       "portuguese": "Máx.",
       "spanish": "máx.",
-      "turkish": "Maksimum"
+      "turkish": "Maksimum",
+      "russian": "Макс."
     },
     "maxPriorityFee": {
       "dutch": "Maximale prioriteitskosten",
@@ -250,7 +270,8 @@
       "mandarin": "最大优先费",
       "portuguese": "Taxa prioritária máxima",
       "spanish": "Tarifa de prioridad máxima",
-      "turkish": "Maksimum Öncelik Ücreti"
+      "turkish": "Maksimum Öncelik Ücreti",
+      "russian": "Максимальный приоритетный сбор"
     },
     "maxSlippage": {
       "dutch": "Maximale slip",
@@ -262,7 +283,8 @@
       "mandarin": "最大滑点",
       "portuguese": "Deslizamento máximo",
       "spanish": "Deslizamiento máximo",
-      "turkish": "Maksimum Kayma"
+      "turkish": "Maksimum Kayma",
+      "russian": "Максимальное проскальзывание"
     },
     "maxTxnFee": {
       "dutch": "Max transactiekosten",
@@ -274,7 +296,8 @@
       "mandarin": "最大交易费",
       "portuguese": "Taxa de transação máxima",
       "spanish": "Tarifa de transacción máxima",
-      "turkish": "Maksimum İşlem Ücreti"
+      "turkish": "Maksimum İşlem Ücreti",
+      "russian": "Максимальная комиссия за транзакцию"
     },
     "minutes": {
       "dutch": "notulen",
@@ -286,7 +309,8 @@
       "mandarin": "分钟",
       "portuguese": "minutos",
       "spanish": "minutos",
-      "turkish": "dakika"
+      "turkish": "dakika",
+      "russian": "минуты"
     },
     "networkFee": {
       "dutch": "Netwerkkosten",
@@ -298,7 +322,8 @@
       "mandarin": "网络费",
       "portuguese": "Taxa de rede",
       "spanish": "Tarifa de red",
-      "turkish": "Ağ Ücreti"
+      "turkish": "Ağ Ücreti",
+      "russian": "Сетевой сбор"
     },
     "previewSwap": {
       "dutch": "Voorbeeld wisselen",
@@ -310,7 +335,8 @@
       "mandarin": "预览交换",
       "portuguese": "Pré-visualização da troca",
       "spanish": "Intercambio de vista previa",
-      "turkish": "Önizleme Değiştirme"
+      "turkish": "Önizleme Değiştirme",
+      "russian": "Предварительный просмотр обмена"
     },
     "price": {
       "dutch": "Prijs",
@@ -322,7 +348,8 @@
       "mandarin": "价格",
       "portuguese": "Preço",
       "spanish": "Precio",
-      "turkish": "Fiyat"
+      "turkish": "Fiyat",
+      "russian": "Цена"
     },
     "priceImpact": {
       "dutch": "Prijsimpact",
@@ -334,7 +361,8 @@
       "mandarin": "价格影响",
       "portuguese": "Impacto no preço",
       "spanish": "Impacto en el precio",
-      "turkish": "Fiyat Etkisi"
+      "turkish": "Fiyat Etkisi",
+      "russian": "Влияние на цену"
     },
     "processIn": {
       "dutch": "Verwerken",
@@ -346,7 +374,8 @@
       "mandarin": "过程中",
       "portuguese": "Processo em",
       "spanish": "Procesar",
-      "turkish": "İşlem"
+      "turkish": "İşlem",
+      "russian": "Обработать"
     },
     "reviewOrder": {
       "dutch": "Bekijk de ruilorder",
@@ -358,7 +387,8 @@
       "mandarin": "查看掉期订单",
       "portuguese": "Revise o pedido de troca",
       "spanish": "Revisar orden de intercambio",
-      "turkish": "Takas Siparişini İnceleyin"
+      "turkish": "Takas Siparişini İnceleyin",
+      "russian": "Просмотреть заказ на обмен"
     },
     "searchToken": {
       "dutch": "Zoek door {0} tokens",
@@ -370,7 +400,8 @@
       "mandarin": "搜索 {0} 个代币",
       "portuguese": "Pesquise {0} tokens",
       "spanish": "Busca entre {0} tokens",
-      "turkish": "{0} token arasında arama yapın"
+      "turkish": "{0} token arasında arama yapın",
+      "russian": "Поиск по {0} токенам"
     },
     "selectAToken": {
       "dutch": "Selecteer een token",
@@ -382,7 +413,8 @@
       "mandarin": "选择一个代币",
       "portuguese": "Selecione um token",
       "spanish": "Seleccione una ficha",
-      "turkish": "Bir belirteç seçin"
+      "turkish": "Bir belirteç seçin",
+      "russian": "Выберите токен"
     },
     "selectToken": {
       "dutch": "Selecteer token",
@@ -394,7 +426,8 @@
       "mandarin": "选择令牌",
       "portuguese": "Selecione token",
       "spanish": "Seleccionar token",
-      "turkish": "Token seçin"
+      "turkish": "Token seçin",
+      "russian": "Выбрать токен"
     },
     "sendToAddress": {
       "dutch": "Stuur geld naar een ander portemonnee-adres",
@@ -406,7 +439,8 @@
       "mandarin": "将资金发送到另一个钱包地址",
       "portuguese": "Envie fundos para outro endereço de carteira",
       "spanish": "Enviar fondos a otra dirección de billetera",
-      "turkish": "Parayı başka bir cüzdan adresine gönderin"
+      "turkish": "Parayı başka bir cüzdan adresine gönderin",
+      "russian": "Отправить средства на другой адрес кошелька"
     },
     "slippageTolerance": {
       "dutch": "Sliptolerantie",
@@ -418,7 +452,8 @@
       "mandarin": "滑移容差",
       "portuguese": "Tolerância ao deslizamento",
       "spanish": "Tolerancia al deslizamiento",
-      "turkish": "Kayma Toleransı"
+      "turkish": "Kayma Toleransı",
+      "russian": "Допуск проскальзывания"
     },
     "swap": {
       "dutch": "Ruil",
@@ -430,7 +465,8 @@
       "mandarin": "交换",
       "portuguese": "Trocar",
       "spanish": "Intercambio",
-      "turkish": "Takas"
+      "turkish": "Takas",
+      "russian": "Обмен"
     },
     "swapSuccess": {
       "dutch": "Wissel succes!",
@@ -442,7 +478,8 @@
       "mandarin": "兑换成功！",
       "portuguese": "Sucesso na troca!",
       "spanish": "¡Intercambia éxito!",
-      "turkish": "Başarıyı değiştir!"
+      "turkish": "Başarıyı değiştir!",
+      "russian": "Обмен выполнен успешно!"
     },
     "swapSuccessDetails": {
       "dutch": "Uw ruilverzoek is succesvol verwerkt en afgerond.",
@@ -454,7 +491,8 @@
       "mandarin": "您的交换请求已成功处理并完成。",
       "portuguese": "Sua solicitação de troca foi processada e concluída com sucesso.",
       "spanish": "Su solicitud de intercambio fue procesada y completada exitosamente.",
-      "turkish": "Takas talebiniz işleme alındı ​​ve başarıyla tamamlandı."
+      "turkish": "Takas talebiniz işleme alındı ​​ve başarıyla tamamlandı.",
+      "russian": "Ваш запрос на обмен был успешно выполнен."
     },
     "swapping-token": {
       "dutch": "Token ruilen",
@@ -466,7 +504,8 @@
       "mandarin": "交换token",
       "portuguese": "Trocando token",
       "spanish": "Intercambiar token",
-      "turkish": "Değiştirme token"
+      "turkish": "Değiştirme token",
+      "russian": "Обмен токена"
     },
     "to": {
       "dutch": "Naar:",
@@ -478,7 +517,8 @@
       "mandarin": "到：",
       "portuguese": "Para:",
       "spanish": "A:",
-      "turkish": "İçin:"
+      "turkish": "İçin:",
+      "russian": "На:"
     },
     "toAddress": {
       "dutch": "Naar portemonnee-adres:",
@@ -490,7 +530,8 @@
       "mandarin": "至钱包地址：",
       "portuguese": "Para o endereço da carteira:",
       "spanish": "A la dirección de la billetera:",
-      "turkish": "Cüzdan adresine:"
+      "turkish": "Cüzdan adresine:",
+      "russian": "На адрес кошелька:"
     },
     "tokens": {
       "dutch": "Munten",
@@ -502,7 +543,8 @@
       "mandarin": "令牌",
       "portuguese": "Tokens",
       "spanish": "Tokens",
-      "turkish": "Token"
+      "turkish": "Token",
+      "russian": "Токены"
     },
     "transactionDeadline": {
       "dutch": "Transactiedeadline",
@@ -514,7 +556,8 @@
       "mandarin": "交易截止日期",
       "portuguese": "Prazo de transação",
       "spanish": "Fecha límite de transacción",
-      "turkish": "İşlem Son Tarihi"
+      "turkish": "İşlem Son Tarihi",
+      "russian": "Срок выполнения транзакции"
     },
     "txnCost": {
       "dutch": "Transactiekosten",
@@ -526,7 +569,8 @@
       "mandarin": "交易成本",
       "portuguese": "Custo da transação",
       "spanish": "Costo de la transacción",
-      "turkish": "İşlem Ücreti"
+      "turkish": "İşlem Ücreti",
+      "russian": "Стоимость транзакции"
     },
     "txnFee": {
       "dutch": "Transactiekosten",
@@ -538,7 +582,8 @@
       "mandarin": "手续费",
       "portuguese": "Taxa de transação",
       "spanish": "Tarifa de transacción",
-      "turkish": "İşlem Ücreti"
+      "turkish": "İşlem Ücreti",
+      "russian": "Комиссия за транзакцию"
     },
     "useMax": {
       "dutch": "Gebruik Max",
@@ -550,7 +595,8 @@
       "mandarin": "使用最大",
       "portuguese": "Use max",
       "spanish": "Usar max",
-      "turkish": "Maksimum kullanmak"
+      "turkish": "Maksimum kullanmak",
+      "russian": "Использовать максимум"
     },
     "value": {
       "dutch": "Waarde",
@@ -562,7 +608,8 @@
       "mandarin": "价值",
       "portuguese": "Valor",
       "spanish": "Valor",
-      "turkish": "Miktar"
+      "turkish": "Miktar",
+      "russian": "Значение"
     },
     "viewTransaction": {
       "dutch": "Transactie bekijken",
@@ -574,7 +621,8 @@
       "mandarin": "查看交易",
       "portuguese": "Ver transação",
       "spanish": "Ver transacción",
-      "turkish": "İşlemi Görüntüle"
+      "turkish": "İşlemi Görüntüle",
+      "russian": "Просмотреть транзакцию"
     },
     "youPay": {
       "dutch": "Jij betaalt",
@@ -586,7 +634,8 @@
       "mandarin": "你付钱",
       "portuguese": "Você paga",
       "spanish": "tu pagas",
-      "turkish": "Sen öde"
+      "turkish": "Sen öde",
+      "russian": "Вы платите"
     },
     "youReceive": {
       "dutch": "Jij ontvangt",
@@ -598,7 +647,8 @@
       "mandarin": "您收到",
       "portuguese": "Você recebe",
       "spanish": "tu recibes",
-      "turkish": "Alırsın"
+      "turkish": "Alırsın",
+      "russian": "Вы получаете"
     },
     "yourExchange": {
       "dutch": "Uw uitwisseling",
@@ -610,7 +660,8 @@
       "mandarin": "您的交流",
       "portuguese": "Sua troca",
       "spanish": "Tu intercambio",
-      "turkish": "Senin Değişim"
+      "turkish": "Senin Değişim",
+      "russian": "Ваш обмен"
     },
     "slippageToleranceTooltip": {
       "dutch": "Uw transactie wordt niet voltooid als de prijs boven dit percentage komt.",
@@ -622,7 +673,8 @@
       "mandarin": "如果价格超出此百分比，您的交易将无法完成。",
       "portuguese": "Sua transação não será concluída se o preço ultrapassar essa porcentagem.",
       "spanish": "Su transacción no se completará si el precio supera este porcentaje.",
-      "turkish": "Fiyatın bu yüzdeyi aşması durumunda işleminiz tamamlanmayacaktır."
+      "turkish": "Fiyatın bu yüzdeyi aşması durumunda işleminiz tamamlanmayacaktır.",
+      "russian": "Ваша транзакция не будет завершена, если цена выйдет за пределы этого процента."
     },
     "txnDeadlineTooltip": {
       "dutch": "De transactie wordt geannuleerd als deze langer dan deze tijdslimiet in behandeling blijft.",
@@ -634,7 +686,8 @@
       "mandarin": "如果交易等待时间超过此时间限制，交易将被取消。",
       "portuguese": "A transação será cancelada se permanecer pendente por mais tempo que esse prazo.",
       "spanish": "La transacción se cancelará si permanece pendiente más tiempo que este límite de tiempo.",
-      "turkish": "Bu süre sınırından daha uzun süre beklemede kalması durumunda işlem iptal edilecektir."
+      "turkish": "Bu süre sınırından daha uzun süre beklemede kalması durumunda işlem iptal edilecektir.",
+      "russian": "Транзакция будет отменена, если она останется в ожидании дольше этого временного ограничения."
     }
   }
 }

--- a/Wallet-service-locale/locales-swap.json
+++ b/Wallet-service-locale/locales-swap.json
@@ -323,7 +323,7 @@
       "portuguese": "Taxa de rede",
       "spanish": "Tarifa de red",
       "turkish": "Ağ Ücreti",
-      "russian": "Сетевой сбор"
+      "russian": "Комиссия сети"
     },
     "previewSwap": {
       "dutch": "Voorbeeld wisselen",
@@ -440,7 +440,7 @@
       "portuguese": "Envie fundos para outro endereço de carteira",
       "spanish": "Enviar fondos a otra dirección de billetera",
       "turkish": "Parayı başka bir cüzdan adresine gönderin",
-      "russian": "Отправить средства на другой адрес кошелька"
+      "russian": "Отправить средства на другой кошелек"
     },
     "slippageTolerance": {
       "dutch": "Sliptolerantie",

--- a/Wallet-service-locale/locales-wallet-frontend.json
+++ b/Wallet-service-locale/locales-wallet-frontend.json
@@ -10,7 +10,8 @@
       "mandarin": "活动",
       "portuguese": "Atividade",
       "spanish": "Actividad",
-      "turkish": "Etkinlik"
+      "turkish": "Etkinlik",
+      "russian": "Активность"
     },
     "addChainText": {
       "dutch": "Sta {0} toe om nieuw netwerk toe te voegen {1}",
@@ -22,7 +23,8 @@
       "mandarin": "允许{0}添加新网络{1}。",
       "portuguese": "Permita {0} adicionar nova rede {1}",
       "spanish": "Permitir {0} agregar nueva red {1}",
-      "turkish": "{0} yeni ağ {1} ekleme izni ver"
+      "turkish": "{0} yeni ağ {1} ekleme izni ver",
+      "russian": "Позволить {0} добавить новую сеть {1}"
     },
     "advanced": {
       "dutch": "Geavanceerd",
@@ -34,7 +36,8 @@
       "mandarin": "先进的",
       "portuguese": "Avançado",
       "spanish": "Avanzado",
-      "turkish": "Gelişmiş"
+      "turkish": "Gelişmiş",
+      "russian": "Дополнительно"
     },
     "allow": {
       "dutch": "Toestaan",
@@ -46,7 +49,8 @@
       "mandarin": "允许",
       "portuguese": "Permitir",
       "spanish": "Permitir",
-      "turkish": "İzin ver"
+      "turkish": "İzin ver",
+      "russian": "Разрешить"
     },
     "allowOnBehalf": {
       "dutch": "Sta $ {0} toe om namens u $ {1} uit te geven",
@@ -58,7 +62,8 @@
       "mandarin": "允许$​​ {0}代表您花费$ {1}",
       "portuguese": "Deixe $ {0} gastar $ {1} em seu nome",
       "spanish": "Permitir $ {0} para gastar $ {1} en su nombre",
-      "turkish": "$ {0} adına $ {1} harcamak için izin ver"
+      "turkish": "$ {0} adına $ {1} harcamak için izin ver",
+      "russian": "Позволить ${0} потратить ${1} от вашего имени"
     },
     "amountGasFee": {
       "dutch": "Bedrag + gaskosten",
@@ -70,7 +75,8 @@
       "mandarin": "金额 +汽油费",
       "portuguese": "Valor + taxa de gás",
       "spanish": "Cantidad + tarifa de gas",
-      "turkish": "Tutar + gas ücreti"
+      "turkish": "Tutar + gas ücreti",
+      "russian": "Сумма + комиссия за газ"
     },
     "amountPlusNetworkFee": {
       "dutch": "Bedrag + netwerkkosten",
@@ -82,7 +88,8 @@
       "mandarin": "金额 + 网络费用",
       "portuguese": "Valor + taxa de rede",
       "spanish": "Cantidad + tarifa de red",
-      "turkish": "Tutar + ağ ücreti"
+      "turkish": "Tutar + ağ ücreti",
+      "russian": "Сумма + плата сети"
     },
     "approve": {
       "dutch": "Goedkeuren",
@@ -94,7 +101,8 @@
       "mandarin": "批准",
       "portuguese": "Aprovar",
       "spanish": "Aprobar",
-      "turkish": "Onayla"
+      "turkish": "Onayla",
+      "russian": "Одобрить"
     },
     "balance": {
       "dutch": "Evenwicht",
@@ -106,7 +114,8 @@
       "mandarin": "平衡",
       "portuguese": "Equilíbrio",
       "spanish": "Balance",
-      "turkish": "Denge"
+      "turkish": "Denge",
+      "russian": "Баланс"
     },
     "buySell": {
       "dutch": "Kopen verkopen",
@@ -118,7 +127,8 @@
       "mandarin": "买卖",
       "portuguese": "Compra venda",
       "spanish": "Compra venta",
-      "turkish": "Alış veriş"
+      "turkish": "Alış veriş",
+      "russian": "Купить/Продать"
     },
     "buySellToken": {
       "dutch": "Koop/verkooptoken",
@@ -130,7 +140,8 @@
       "mandarin": "买/出售令牌",
       "portuguese": "Comprar/vender token",
       "spanish": "Comprar/vender token",
-      "turkish": "Token satın al/sat"
+      "turkish": "Token satın al/sat",
+      "russian": "Купить/Продать токен"
     },
     "chainId": {
       "dutch": "Keten -ID",
@@ -142,7 +153,8 @@
       "mandarin": "连锁ID",
       "portuguese": "ID da cadeia",
       "spanish": "ID de cadena",
-      "turkish": "Kırılım ID"
+      "turkish": "Kırılım ID",
+      "russian": "ID сети"
     },
     "contractDeployment": {
       "dutch": "Contractimplementatie",
@@ -154,7 +166,8 @@
       "mandarin": "合同部署",
       "portuguese": "Implantação do contrato",
       "spanish": "Despliegue de contrato",
-      "turkish": "Sözleşme Dağıtımı"
+      "turkish": "Sözleşme Dağıtımı",
+      "russian": "Развертывание контракта"
     },
     "contractInteraction": {
       "dutch": "Contractinteractie",
@@ -166,7 +179,8 @@
       "mandarin": "合同互动",
       "portuguese": "Interação do contrato",
       "spanish": "Interacción por contrato",
-      "turkish": "Sözleşme Etkileşimi"
+      "turkish": "Sözleşme Etkileşimi",
+      "russian": "Взаимодействие с контрактом"
     },
     "currencySymbol": {
       "dutch": "Symbool van munteenheid",
@@ -178,7 +192,8 @@
       "mandarin": "货币符号",
       "portuguese": "Símbolo da moeda",
       "spanish": "Símbolo de moneda",
-      "turkish": "Para Birimi Sembolü"
+      "turkish": "Para Birimi Sembolü",
+      "russian": "Символ валюты"
     },
     "currentNetwork": {
       "dutch": "Huidig ​​netwerk",
@@ -190,7 +205,8 @@
       "mandarin": "当前网络",
       "portuguese": "Rede atual",
       "spanish": "Red actual",
-      "turkish": "Mevcut ağ"
+      "turkish": "Mevcut ağ",
+      "russian": "Текущая сеть"
     },
     "decryptDescription": {
       "dutch": "{0} wil dit bericht lezen om uw actie te voltooien",
@@ -202,7 +218,8 @@
       "mandarin": "{0}想阅读此消息以完成您的动作",
       "portuguese": "{0} gostaria de ler esta mensagem para concluir sua ação",
       "spanish": "{0} le gustaría leer este mensaje para completar su acción",
-      "turkish": "{0} bu mesajı okumak için tamamlanacak eylemi tamamlamak için bu mesajı okumak istiyor"
+      "turkish": "{0} bu mesajı okumak için tamamlanacak eylemi tamamlamak için bu mesajı okumak istiyor",
+      "russian": "{0} хочет прочитать это сообщение, чтобы завершить ваше действие"
     },
     "decryptKeyText": {
       "dutch": "Sta {0} toe om dit bericht te lezen om uw actie te voltooien",
@@ -214,7 +231,8 @@
       "mandarin": "允许{0}阅读此消息以完成您的操作。",
       "portuguese": "Permitam que {0} leia esta mensagem para concluir sua ação",
       "spanish": "Permitir {0} leer este mensaje para completar su acción",
-      "turkish": "{0} bu iletiyi okumak için izin ver"
+      "turkish": "{0} bu iletiyi okumak için izin ver",
+      "russian": "Разрешить {0} прочитать это сообщение для завершения вашего действия"
     },
     "decryptionRequest": {
       "dutch": "Decoderingverzoek",
@@ -226,7 +244,8 @@
       "mandarin": "解密请求",
       "portuguese": "Solicitação de descriptografia",
       "spanish": "Solicitud de descifrado",
-      "turkish": "Şifre çözme isteği"
+      "turkish": "Şifre çözme isteği",
+      "russian": "Запрос на расшифровку"
     },
     "details": {
       "dutch": "Details",
@@ -238,7 +257,8 @@
       "mandarin": "细节",
       "portuguese": "Detalhes",
       "spanish": "Detalles",
-      "turkish": "Detaylar"
+      "turkish": "Detaylar",
+      "russian": "Детали"
     },
     "editGasFee": {
       "dutch": "Gaskosten bewerken",
@@ -250,7 +270,8 @@
       "mandarin": "编辑汽油费",
       "portuguese": "Editar taxa de gás",
       "spanish": "Editar tarifa de gasolina",
-      "turkish": "Gas ücretini düzenle"
+      "turkish": "Gas ücretini düzenle",
+      "russian": "Изменить комиссию за газ"
     },
     "editPriority": {
       "dutch": "Prioriteit bewerken",
@@ -262,7 +283,8 @@
       "mandarin": "编辑优先级",
       "portuguese": "Editar prioridade",
       "spanish": "Editar prioridad",
-      "turkish": "Önceliği Düzenle"
+      "turkish": "Önceliği Düzenle",
+      "russian": "Изменить приоритет"
     },
     "email": {
       "dutch": "E-mail",
@@ -274,7 +296,8 @@
       "mandarin": "电子邮件",
       "portuguese": "E-mail",
       "spanish": "Correo electrónico",
-      "turkish": "E-posta"
+      "turkish": "E-posta",
+      "russian": "Электронная почта"
     },
     "encryptKeyText": {
       "dutch": "Sta {0} toe om gecodeerde berichten voor u samen te stellen",
@@ -286,7 +309,8 @@
       "mandarin": "允许{0}为您撰写加密消息。",
       "portuguese": "Permita que {0} componha mensagens criptografadas para você",
       "spanish": "Permitir {0} componer mensajes cifrados para usted",
-      "turkish": "{0} şifreli iletilerinizi oluşturmak için izin ver"
+      "turkish": "{0} şifreli iletilerinizi oluşturmak için izin ver",
+      "russian": "Разрешить {0} составлять зашифрованные сообщения для вас"
     },
     "encryptionDescription": {
       "dutch": "{0} zou uw publieke coderingssleutel willen. Door toestemming te geven, kan deze site gecodeerde berichten aan u samenstellen.",
@@ -298,7 +322,8 @@
       "mandarin": "{0}想要您的公共加密密钥。通过同意，此站点将能够向您撰写加密消息。",
       "portuguese": "{0} gostaria da sua chave de criptografia pública. Por consentimento, este site poderá compor mensagens criptografadas para você.",
       "spanish": "{0} le gustaría su clave de cifrado público. Al consentir, este sitio podrá componerle mensajes cifrados.",
-      "turkish": "{0} sizin şifreleme anahtarınızı istiyor. Kabul ederek, bu site sizinle şifrelenmiş mesajlar oluşturabilir."
+      "turkish": "{0} sizin şifreleme anahtarınızı istiyor. Kabul ederek, bu site sizinle şifrelenmiş mesajlar oluşturabilir.",
+      "russian": "{0} хочет получить ваш публичный ключ шифрования. С вашего согласия сайт сможет составлять для вас зашифрованные сообщения."
     },
     "errorEstimatingBalanceChanges": {
       "dutch": "Er is een fout opgetreden bij het schatten van de balansveranderingen",
@@ -310,7 +335,8 @@
       "mandarin": "估计余额变化时发生错误",
       "portuguese": "Ocorreu um erro ao estimar as alterações de saldo",
       "spanish": "Se produjo un error al estimar los cambios de saldo",
-      "turkish": "Bakiye değişikliklerini tahminirken bir hata oluştu"
+      "turkish": "Bakiye değişikliklerini tahminırken bir hata oluştu",
+      "russian": "При оценке изменений баланса произошла ошибка"
     },
     "estimatedGasFee": {
       "dutch": "Geschatte gaskosten",
@@ -322,7 +348,8 @@
       "mandarin": "估计的汽油费",
       "portuguese": "Taxa estimada de gás",
       "spanish": "Tarifa de gas estimada",
-      "turkish": "Tahmini Gas Ücreti"
+      "turkish": "Tahmini Gas Ücreti",
+      "russian": "Оценочная комиссия за газ"
     },
     "estimatedBalanceChanges": {
       "dutch": "Geschatte balansveranderingen",
@@ -334,7 +361,8 @@
       "mandarin": "估计余额变化",
       "portuguese": "Alterações estimadas de saldo",
       "spanish": "Cambios estimados de saldo",
-      "turkish": "Tahmini Bakiye Değişiklikleri"
+      "turkish": "Tahmini Bakiye Değişiklikleri",
+      "russian": "Оценочные изменения баланса"
     },
     "estimatedNetworkFee": {
       "dutch": "Geschatte netwerkkosten",
@@ -346,7 +374,8 @@
       "mandarin": "估计网络费用",
       "portuguese": "Taxa estimada de rede",
       "spanish": "Tarifa de red estimada",
-      "turkish": "Tahmini Ağ Ücreti"
+      "turkish": "Tahmini Ağ Ücreti",
+      "russian": "Оценочная плата за сеть"
     },
     "from": {
       "dutch": "Van:",
@@ -358,7 +387,8 @@
       "mandarin": "从：",
       "portuguese": "De:",
       "spanish": "De:",
-      "turkish": "Şuna:"
+      "turkish": "Şuna:",
+      "russian": "От:"
     },
     "hexData": {
       "dutch": "HEX -gegevens",
@@ -370,7 +400,8 @@
       "mandarin": "十六进制数据",
       "portuguese": "Dados hexadecimais",
       "spanish": "Datos hexadecimales",
-      "turkish": "Onaltılık Veri"
+      "turkish": "Onaltılık Veri",
+      "russian": "Hex данные"
     },
     "hideDetails": {
       "dutch": "Verberg details",
@@ -382,7 +413,8 @@
       "mandarin": "隐藏细节",
       "portuguese": "Detalhes ocultos",
       "spanish": "Ocultar detalles",
-      "turkish": "Ayrıntıları gizle"
+      "turkish": "Ayrıntıları gizle",
+      "russian": "Скрыть детали"
     },
     "home": {
       "dutch": "Thuis",
@@ -394,7 +426,8 @@
       "mandarin": "家",
       "portuguese": "Lar",
       "spanish": "Hogar",
-      "turkish": "Ev"
+      "turkish": "Ev",
+      "russian": "Главная"
     },
     "insufficientBalance": {
       "dutch": "Onvoldoende balans",
@@ -406,7 +439,8 @@
       "mandarin": "平衡不足",
       "portuguese": "Saldo insuficiente",
       "spanish": "Saldo insuficiente",
-      "turkish": "Yetersiz Bakiye"
+      "turkish": "Yetersiz Bakiye",
+      "russian": "Недостаточно средств"
     },
     "invalidGasLimitErr": {
       "dutch": "Ongeldige gaslimiet",
@@ -418,7 +452,8 @@
       "mandarin": "无效的气体限制",
       "portuguese": "Limite de gás inválido",
       "spanish": "Límite de gas no válido",
-      "turkish": "Gas limiti geçersiz"
+      "turkish": "Gas limiti geçersiz",
+      "russian": "Недопустимый лимит газа"
     },
     "invalidGasPriceErr": {
       "dutch": "Ongeldige gasprijs",
@@ -430,7 +465,8 @@
       "mandarin": "无效的气价",
       "portuguese": "Preço inválido de gás",
       "spanish": "Precio de gas no válido",
-      "turkish": "Gas fiyatı geçersiz"
+      "turkish": "Gas fiyatı geçersiz",
+      "russian": "Недопустимая цена газа"
     },
     "invalidMaxFeeErr": {
       "dutch": "Ongeldige maximale prioriteitskosten",
@@ -442,7 +478,8 @@
       "mandarin": "最高优先费用无效",
       "portuguese": "Taxa prioritária máxima inválida",
       "spanish": "Tarifa de prioridad máxima no válida",
-      "turkish": "Maksimum öncelik ücreti geçersiz"
+      "turkish": "Maksimum öncelik ücreti geçersiz",
+      "russian": "Недопустимая максимальная приоритетная плата"
     },
     "invalidMaxTxnFeeErr": {
       "dutch": "Ongeldige max transactiekosten",
@@ -454,7 +491,8 @@
       "mandarin": "无效的最大交易费",
       "portuguese": "Taxa de transação máxima inválida",
       "spanish": "Tarifa de transacción máxima no válida",
-      "turkish": "Maksimum işlem ücreti geçersiz"
+      "turkish": "Maksimum işlem ücreti geçersiz",
+      "russian": "Недопустимая максимальная комиссия транзакции"
     },
     "invalidNonceErr": {
       "dutch": "Ongeldige nonce",
@@ -466,7 +504,8 @@
       "mandarin": "无效的nonce",
       "portuguese": "Nonce inválido",
       "spanish": "Nonce inválido",
-      "turkish": "Nonce geçersiz"
+      "turkish": "Nonce geçersiz",
+      "russian": "Недопустимый nonce"
     },
     "isSmartAccount": {
       "dutch": "Dit is een Smart Contract Account",
@@ -478,7 +517,8 @@
       "mandarin": "这是一个智能合约账户",
       "portuguese": "Este é um contrato inteligente",
       "spanish": "Este es un contrato inteligente",
-      "turkish": "Bu, bir akıllı sözleşme hesabıdır"
+      "turkish": "Bu, bir akıllı sözleşme hesabıdır",
+      "russian": "Это учетная запись умного контракта"
     },
     "login": {
       "dutch": "Log in",
@@ -490,7 +530,8 @@
       "mandarin": "登录",
       "portuguese": "Conecte-se",
       "spanish": "Acceso",
-      "turkish": "Giriş yap"
+      "turkish": "Giriş yap",
+      "russian": "Войти"
     },
     "loginContinue": {
       "dutch": "Doorgaan met {0}",
@@ -502,7 +543,8 @@
       "mandarin": "继续{0}",
       "portuguese": "Continuar com {0}",
       "spanish": "Continuar con {0}",
-      "turkish": "{0} ile devam et"
+      "turkish": "{0} ile devam et",
+      "russian": "Продолжить с {0}"
     },
     "loginEmail": {
       "dutch": "Log in met e -mail",
@@ -514,7 +556,8 @@
       "mandarin": "使用电子邮件登录",
       "portuguese": "Faça login com email",
       "spanish": "Iniciar sesión con el correo electrónico",
-      "turkish": "E-posta ile giriş yap"
+      "turkey": "E-posta ile giriş yap",
+      "russian": "Войти с электронной почтой"
     },
     "logout": {
       "dutch": "Uitloggen",
@@ -526,7 +569,8 @@
       "mandarin": "登出",
       "portuguese": "Sair",
       "spanish": "Cerrar sesión",
-      "turkish": "Çıkış yap"
+      "turkish": "Çıkış yap",
+      "russian": "Выйти"
     },
     "message": {
       "dutch": "Bericht",
@@ -538,7 +582,8 @@
       "mandarin": "信息",
       "portuguese": "Mensagem",
       "spanish": "Mensaje",
-      "turkish": "İleti"
+      "turkish": "İleti",
+      "russian": "Сообщение"
     },
     "moreDetails": {
       "dutch": "Meer details",
@@ -550,7 +595,8 @@
       "mandarin": "更多细节",
       "portuguese": "Mais detalhes",
       "spanish": "Más detalles",
-      "turkish": "Daha fazla ayrıntı"
+      "turkish": "Daha fazla ayrıntı",
+      "russian": "Подробнее"
     },
     "network": {
       "dutch": "Netwerk",
@@ -562,7 +608,8 @@
       "mandarin": "网络",
       "portuguese": "Rede",
       "spanish": "Red",
-      "turkish": "Ağ"
+      "turkish": "Ağ",
+      "russian": "Сеть"
     },
     "networkName": {
       "dutch": "Netwerknaam",
@@ -574,7 +621,8 @@
       "mandarin": "网络名字",
       "portuguese": "Nome da rede",
       "spanish": "Nombre de red",
-      "turkish": "Ağ adı"
+      "turkish": "Ağ adı",
+      "russian": "Имя сети"
     },
     "networkUrl": {
       "dutch": "Netwerk -URL",
@@ -586,7 +634,8 @@
       "mandarin": "网络URL",
       "portuguese": "URL da rede",
       "spanish": "URL de red",
-      "turkish": "Ağ URL"
+      "turkish": "Ağ URL",
+      "russian": "URL сети"
     },
     "newChain": {
       "dutch": "Nieuwe keten",
@@ -598,7 +647,8 @@
       "mandarin": "新链",
       "portuguese": "Nova cadeia",
       "spanish": "Nueva cadena",
-      "turkish": "Yeni Ket"
+      "turkish": "Yeni Ket",
+      "russian": "Новая цепочка"
     },
     "newChainId": {
       "dutch": "Nieuwe ketting -ID",
@@ -610,7 +660,8 @@
       "mandarin": "新连锁ID",
       "portuguese": "Novo ID da cadeia",
       "spanish": "Nueva identificación de cadena",
-      "turkish": "Yeni Ket ID"
+      "turkish": "Yeni Ket ID",
+      "russian": "Новый ID цепочки"
     },
     "nftDetails": {
       "dutch": "NFT -details",
@@ -622,7 +673,8 @@
       "mandarin": "NFT详细信息",
       "portuguese": "Detalhes da NFT",
       "spanish": "Detalles NFT",
-      "turkish": "NFT Detayları"
+      "turkish": "NFT Detayları",
+      "russian": "Детали NFT"
     },
     "paymentTxn": {
       "dutch": "Betalingstransactie",
@@ -634,7 +686,8 @@
       "mandarin": "付款交易",
       "portuguese": "Operação de pagamento",
       "spanish": "Transaccion de pago",
-      "turkish": "Ödeme İşlemi"
+      "turkish": "Ödeme İşlemi",
+      "russian": "Платёжная транзакция"
     },
     "permission": {
       "dutch": "Toestemming",
@@ -646,7 +699,8 @@
       "mandarin": "允许",
       "portuguese": "Permissão",
       "spanish": "Permiso",
-      "turkish": "İzin"
+      "turkish": "İzin",
+      "russian": "Разрешение"
     },
     "popupAlertMsg": {
       "dutch": "De browser wordt niet ondersteund; Probeer het opnieuw in een andere browser.",
@@ -658,7 +712,8 @@
       "mandarin": "不支持浏览器；请在另一个浏览器中重试。",
       "portuguese": "O navegador não é suportado; Por favor, tente novamente em outro navegador.",
       "spanish": "El navegador no es compatible; Vuelva a intentar en otro navegador.",
-      "turkish": "Tarayıcınız desteklenmiyor; Lütfen başka bir tarayıcıda yeniden deneyin."
+      "turkish": "Tarayıcınız desteklenmiyor; Lütfen başka bir tarayıcıda yeniden deneyin.",
+      "russian": "Браузер не поддерживается; попробуйте в другом браузере."
     },
     "popupBlock": {
       "dutch": "Pop-up geblokkeerd",
@@ -670,7 +725,8 @@
       "mandarin": "弹出被阻止",
       "portuguese": "Pop-up bloqueado",
       "spanish": "Ventana emergente bloqueada",
-      "turkish": "Açılan pencere engellendi"
+      "turkish": "Açılan pencere engellendi",
+      "russian": "Всплывающее окно заблокировано"
     },
     "popupBlockConfirm": {
       "dutch": "Start pagina voor nu",
@@ -682,7 +738,8 @@
       "mandarin": "现在启动页面",
       "portuguese": "Página de lançamento para agora",
       "spanish": "Página de lanzamiento por ahora",
-      "turkish": "Şimdi sayfa başlat"
+      "turkish": "Şimdi sayfa başlat",
+      "russian": "Запустить страницу сейчас"
     },
     "popupBlockDesc": {
       "dutch": "De pagina kan mogelijk niet openen vanwege een pop -up blocker. Als u een pop -up blocker gebruikt, overweeg dan om deze in de toekomst voor deze site uit te schakelen om toegang te krijgen tot het venster.",
@@ -694,7 +751,8 @@
       "mandarin": "由于弹出阻滞剂，该页面可能无法打开。如果您使用的是弹出式阻滞剂，请考虑将来将其禁用此站点以访问窗口。",
       "portuguese": "A página pode não conseguir abrir devido a um bloqueador pop -up. Se você estiver usando um bloqueador pop -up, considere desativá -lo para este site no futuro para acessar a janela.",
       "spanish": "La página puede no poder abrir debido a un bloqueador emergente. Si está utilizando un bloqueador emergente, considere deshabilitarlo para este sitio en el futuro para acceder a la ventana.",
-      "turkish": "Sayfa, açılan pencere engelleyicisinin nedeniyle açılamayabilir. Blokeiciyi kullanmıyorsanız, bu siteyi gelecekte devre dışı bırakarak pencereye erişim sağlayabilirsiniz."
+      "turkish": "Sayfa, açılan pencere engelleyicisinin nedeniyle açılamayabilir. Blokeiciyi kullanmıyorsanız, bu siteyi gelecekte devre dışı bırakarak pencereye erişim sağlayabilirsiniz.",
+      "russian": "Страница может не открыться из-за блокировщика всплывающих окон. Если вы используете его, отключите для этого сайта, чтобы получить доступ к окну."
     },
     "reject": {
       "dutch": "Afwijzen",
@@ -706,7 +764,8 @@
       "mandarin": "拒绝",
       "portuguese": "Rejeitar",
       "spanish": "Rechazar",
-      "turkish": "Reddet"
+      "turkish": "Reddet",
+      "russian": "Отклонить"
     },
     "requestEncryptionKey": {
       "dutch": "Verzoek coderingssleutel",
@@ -718,7 +777,8 @@
       "mandarin": "请求加密密钥",
       "portuguese": "Chave de criptografia de solicitação",
       "spanish": "Solicitar la clave de cifrado",
-      "turkish": "Şifreleme anahtarını iste"
+      "turkish": "Şifreleme anahtarını iste",
+      "russian": "Запросить ключ шифрования"
     },
     "requestedFrom": {
       "dutch": "Gevraagd van",
@@ -730,7 +790,8 @@
       "mandarin": "请求",
       "portuguese": "Solicitado de",
       "spanish": "Solicitado de",
-      "turkish": "İstek"
+      "turkish": "İstek",
+      "russian": "Запрошено от"
     },
     "retry": {
       "dutch": "Opnieuw proberen",
@@ -742,7 +803,8 @@
       "mandarin": "重试",
       "portuguese": "Tente novamente",
       "spanish": "Rever",
-      "turkish": "Tekrar Dene"
+      "turkish": "Tekrar Dene",
+      "russian": "Повторить"
     },
     "safeTransferFrom": {
       "dutch": "Veilige overdracht van",
@@ -754,7 +816,8 @@
       "mandarin": "安全转移",
       "portuguese": "Transferência segura de",
       "spanish": "Transferencia segura de",
-      "turkish": "Güvenli Transfer From"
+      "turkish": "Güvenli Transfer From",
+      "russian": "Безопасный перевод от"
     },
     "save": {
       "dutch": "Redden",
@@ -766,7 +829,8 @@
       "mandarin": "节省",
       "portuguese": "Salvar",
       "spanish": "Ahorrar",
-      "turkish": "Kaydet"
+      "turkish": "Kaydet",
+      "russian": "Сохранить"
     },
     "send": {
       "dutch": "Versturen",
@@ -778,7 +842,8 @@
       "mandarin": "发送",
       "portuguese": "Enviar",
       "spanish": "Enviar",
-      "turkish": "Gönder"
+      "turkish": "Gönder",
+      "russian": "Отправить"
     },
     "sending": {
       "dutch": "Bezig met verzenden",
@@ -790,7 +855,8 @@
       "mandarin": "发送",
       "portuguese": "Envio",
       "spanish": "Enviando",
-      "turkish": "Gönderiliyor"
+      "turkish": "Gönderiliyor",
+      "russian": "Отправка"
     },
     "sentEther": {
       "dutch": "Verzonden ether",
@@ -802,7 +868,8 @@
       "mandarin": "发送以太",
       "portuguese": "Éter enviado",
       "spanish": "Enviado éter",
-      "turkish": "Eter gönderildi"
+      "turkish": "Eter gönderildi",
+      "russian": "Отправлено Ether"
     },
     "setApprovalForAll": {
       "dutch": "Stel goedkeuring in voor iedereen",
@@ -814,7 +881,8 @@
       "mandarin": "设定所有人的批准",
       "portuguese": "Defina aprovação para todos",
       "spanish": "Establecer aprobación para todos",
-      "turkish": "Tüm Onayını Ayarla"
+      "turkish": "Tüm Onayını Ayarla",
+      "russian": "Установить разрешение для всех"
     },
     "settings": {
       "dutch": "Instellingen",
@@ -826,7 +894,8 @@
       "mandarin": "设置",
       "portuguese": "Configurações",
       "spanish": "Ajustes",
-      "turkish": "Ayarlar"
+      "turkish": "Ayarlar",
+      "russian": "Настройки"
     },
     "sign": {
       "dutch": "Teken",
@@ -838,7 +907,8 @@
       "mandarin": "符号",
       "portuguese": "Sinal",
       "spanish": "Firmar",
-      "turkish": "İmzala"
+      "turkish": "İmzala",
+      "russian": "Подписать"
     },
     "signIn": {
       "dutch": "Aanmelden",
@@ -850,7 +920,8 @@
       "mandarin": "登入",
       "portuguese": "Entrar",
       "spanish": "Iniciar sesión",
-      "turkish": "Oturum aç"
+      "turkish": "Oturum aç",
+      "russian": "Войти"
     },
     "signInDescription": {
       "dutch": "Uw blockchain -portemonnee op één klik",
@@ -862,7 +933,8 @@
       "mandarin": "您的区块链钱包一键",
       "portuguese": "Sua carteira blockchain em um clique",
       "spanish": "Su billetera blockchain en un solo clic",
-      "turkish": "Takımınızın blok zinciri cüzdanına bir tıkla"
+      "turkish": "Takımınızın blok zinciri cüzdanına bir tıkla",
+      "russian": "Ваш кошелёк блокчейна в один клик"
     },
     "signMessage": {
       "dutch": "Aanmeldbericht",
@@ -874,7 +946,8 @@
       "mandarin": "标志消息",
       "portuguese": "Assinar mensagem",
       "spanish": "Mensaje de firma",
-      "turkish": "İmza iletisi"
+      "turkish": "İmza iletisi",
+      "russian": "Подписать сообщение"
     },
     "signatureDescription": {
       "dutch": "Onderteken dit bericht alleen als u de inhoud volledig begrijpt en de aanvraagsite vertrouwt.",
@@ -886,7 +959,8 @@
       "mandarin": "仅当您完全了解内容并信任请求网站时才签署此消息。",
       "portuguese": "Assine apenas esta mensagem se você entender completamente o conteúdo e confiar no site solicitante.",
       "spanish": "Solo firme este mensaje si comprende completamente el contenido y confía en el sitio solicitante.",
-      "turkish": "Bu mesajı tam olarak anlamak ve istekte bulunan sitenin güvenilir olduğunu kabul ederken bu mesajı imzalamak için sadece bu mesajı imzalamak istiyorsanız imzalayın."
+      "turkish": "Bu mesajı tam olarak anlamak ve istekte bulunan sitenin güvenilir olduğunu kabul ederken bu mesajı imzalamak için sadece bu mesajı imzalamak istiyorsanız imzalayın.",
+      "russian": "Подписывайте это сообщение только если вы полностью понимаете содержимое и доверяете запрашивающему сайту."
     },
     "signatureRequest": {
       "dutch": "Handtekeningverzoek",
@@ -898,7 +972,8 @@
       "mandarin": "签名请求",
       "portuguese": "Solicitação de assinatura",
       "spanish": "Solicitud de firma",
-      "turkish": "İmzalama isteği"
+      "turkish": "İmzalama isteği",
+      "russian": "Запрос подписи"
     },
     "socialPolicy": {
       "dutch": "We slaan geen gegevens op die verband houden met uw sociale logins.",
@@ -910,7 +985,8 @@
       "mandarin": "我们不存储与您的社交登录相关的任何数据。",
       "portuguese": "Não armazenamos nenhum dado relacionado ao seu login por rede social.",
       "spanish": "No almacenamos ningún dato relacionado con sus inicios de sesión sociales.",
-      "turkish": "Biz hepsini sosyal oturum açma ile ilgili herhangi bir veriyi saklamıyoruz."
+      "turkish": "Biz hepsini sosyal oturum açma ile ilgili herhangi bir veriyi saklamıyoruz.",
+      "russian": "Мы не храним никаких данных, связанных с вашими социальными входами."
     },
     "socialViewLess": {
       "dutch": "Minder bekijken",
@@ -922,7 +998,8 @@
       "mandarin": "少查看",
       "portuguese": "Ver menos",
       "spanish": "Ver menos",
-      "turkish": "Daha az göster"
+      "turkish": "Daha az göster",
+      "russian": "Показать меньше"
     },
     "socialViewMore": {
       "dutch": "Bekijk meer",
@@ -934,7 +1011,8 @@
       "mandarin": "查看更多",
       "portuguese": "Veja mais",
       "spanish": "Ver más",
-      "turkish": "Daha fazla göster"
+      "turkish": "Daha fazla göster",
+      "russian": "Показать больше"
     },
     "swap": {
       "dutch": "Ruil",
@@ -946,7 +1024,8 @@
       "mandarin": "交换",
       "portuguese": "Trocar",
       "spanish": "Intercambio",
-      "turkish": "Takas"
+      "turkish": "Takas",
+      "russian": "Обменять"
     },
     "switchChainText": {
       "dutch": "Sta {0} toe om uw netwerk te wijzigen in {1}",
@@ -958,7 +1037,8 @@
       "mandarin": "允许{0}将您的网络更改为{1}。",
       "portuguese": "Permita que {0} altere sua rede para {1}",
       "spanish": "Permitir {0} cambiar su red a {1}",
-      "turkish": "{0} {1} ağınıza erişim izni ver"
+      "turkish": "{0} {1} ağınıza erişim izni ver",
+      "russian": "Разрешить {0} изменить вашу сеть на {1}"
     },
     "to": {
       "dutch": "Naar:",
@@ -970,7 +1050,8 @@
       "mandarin": "到：",
       "portuguese": "Para:",
       "spanish": "A:",
-      "turkish": "İçin:"
+      "turkish": "İçin:",
+      "russian": "Кому:"
     },
     "tokenDetails": {
       "dutch": "Token -details",
@@ -982,7 +1063,8 @@
       "mandarin": "令牌细节",
       "portuguese": "Detalhes do token",
       "spanish": "Detalles del token",
-      "turkish": "Token Detayları"
+      "turkish": "Token Detayları",
+      "russian": "Детали токена"
     },
     "topUpGasCredit": {
       "dutch": "Vul gaskrediet aan",
@@ -994,7 +1076,8 @@
       "mandarin": "充气汽油信用",
       "portuguese": "Top up Gas Credit",
       "spanish": "Recargar crédito de gas",
-      "turkish": "Gaz kredisi yükle"
+      "turkish": "Gaz kredisi yükle",
+      "russian": "Пополнить газовый кредит"
     },
     "topupWallet": {
       "dutch": "Topup -portemonnee",
@@ -1006,7 +1089,8 @@
       "mandarin": "托图钱包",
       "portuguese": "Carteira de recarga",
       "spanish": "Billetera",
-      "turkish": "Portföy"
+      "turkish": "Portföy",
+      "russian": "Пополнить кошелёк"
     },
     "total": {
       "dutch": "Totaal",
@@ -1018,7 +1102,8 @@
       "mandarin": "全部的",
       "portuguese": "Total",
       "spanish": "Total",
-      "turkish": "Toplam"
+      "turkish": "Toplam",
+      "russian": "Итого"
     },
     "transaction": {
       "dutch": "Transactie",
@@ -1030,7 +1115,8 @@
       "mandarin": "交易",
       "portuguese": "Transação",
       "spanish": "Transacción",
-      "turkish": "İşlem"
+      "turkish": "İşlem",
+      "russian": "Транзакция"
     },
     "transfer": {
       "dutch": "Overdracht",
@@ -1042,7 +1128,8 @@
       "mandarin": "转移",
       "portuguese": "Transferir",
       "spanish": "Transferir",
-      "turkish": "Transfer"
+      "turkish": "Transfer",
+      "russian": "Перевести"
     },
     "transferFrom": {
       "dutch": "Overbrengen van",
@@ -1054,7 +1141,8 @@
       "mandarin": "从转移",
       "portuguese": "Transferir de",
       "spanish": "Transferido de",
-      "turkish": "Transfer From"
+      "turkish": "Transfer From",
+      "russian": "Перевести из"
     },
     "transferToken": {
       "dutch": "Overdracht token",
@@ -1066,7 +1154,8 @@
       "mandarin": "转移令牌",
       "portuguese": "Transferir token",
       "spanish": "Token de transferencia",
-      "turkish": "Token transferi"
+      "turkish": "Token transferi",
+      "russian": "Перевести токен"
     },
     "txnRequest": {
       "dutch": "Transactieverzoek",
@@ -1078,7 +1167,8 @@
       "mandarin": "交易请求",
       "portuguese": "Solicitação de transação",
       "spanish": "Solicitud de transacción",
-      "turkish": "İşlem İsteği"
+      "turkish": "İşlem İsteği",
+      "russian": "Запрос транзакции"
     },
     "type": {
       "dutch": "Type",
@@ -1090,7 +1180,8 @@
       "mandarin": "类型",
       "portuguese": "Tipo",
       "spanish": "Tipo",
-      "turkish": "Tür"
+      "turkish": "Tür",
+      "russian": "Тип"
     },
     "validMaxFeeErr": {
       "dutch": "Max -vergoeding moet groter zijn dan basiskosten + prioriteitskosten",
@@ -1102,7 +1193,8 @@
       "mandarin": "最高费用必须大于基本费用 +优先费",
       "portuguese": "A taxa máxima deve ser maior que a taxa básica + taxa de prioridade",
       "spanish": "La tarifa máxima debe ser mayor que la tarifa base + tarifa prioritaria",
-      "turkish": "Maksimum ücret en fazla temel ücret + öncelik ücret olmalıdır"
+      "turkish": "Maksimum ücret en fazla temel ücret + öncelik ücret olmalıdır",
+      "russian": "Максимальная комиссия должна быть больше базовой комиссии + приоритетной комиссии"
     },
     "walletAddress": {
       "dutch": "Portemonnee",
@@ -1114,7 +1206,8 @@
       "mandarin": "钱包地址",
       "portuguese": "Endereço da carteira",
       "spanish": "Dirección de la billetera",
-      "turkish": "Cüzdan adresi"
+      "turkish": "Cüzdan adresi",
+      "russian": "Адрес кошелька"
     },
     "walletConnect": {
       "dutch": "Portemonnee verbindt",
@@ -1126,7 +1219,8 @@
       "mandarin": "钱包连接",
       "portuguese": "Carteira Connect",
       "spanish": "Billetera conectar",
-      "turkish": "Cüzdanı bağla"
+      "turkish": "Cüzdanı bağla",
+      "russian": "Подключение кошелька"
     },
     "wasmBasedDeploy": {
       "dutch": "Wasme gebaseerde implementatie",
@@ -1138,7 +1232,8 @@
       "mandarin": "基于WASM的部署",
       "portuguese": "Implantação baseada em WASM",
       "spanish": "Despliegue basado en WASM",
-      "turkish": "WASM Tabanlı Dağıtım"
+      "turkish": "WASM Tabanlı Dağıtım",
+      "russian": "Развертывание на основе WASM"
     },
     "youSend": {
       "dutch": "Jij stuurt",
@@ -1150,7 +1245,8 @@
       "mandarin": "您发送",
       "portuguese": "Você envia",
       "spanish": "Usted envía",
-      "turkish": "Sen sen"
+      "turkish": "Sen sen",
+      "russian": "Вы отправляете"
     }
   }
 }

--- a/Wallet-service-locale/locales-wallet-frontend.json
+++ b/Wallet-service-locale/locales-wallet-frontend.json
@@ -349,7 +349,7 @@
       "portuguese": "Taxa estimada de gás",
       "spanish": "Tarifa de gas estimada",
       "turkish": "Tahmini Gas Ücreti",
-      "russian": "Оценочная комиссия за газ"
+      "russian": "Примерная комиссия за газ"
     },
     "estimatedBalanceChanges": {
       "dutch": "Geschatte balansveranderingen",
@@ -362,7 +362,7 @@
       "portuguese": "Alterações estimadas de saldo",
       "spanish": "Cambios estimados de saldo",
       "turkish": "Tahmini Bakiye Değişiklikleri",
-      "russian": "Оценочные изменения баланса"
+      "russian": "Примерное изменение баланса"
     },
     "estimatedNetworkFee": {
       "dutch": "Geschatte netwerkkosten",
@@ -375,7 +375,7 @@
       "portuguese": "Taxa estimada de rede",
       "spanish": "Tarifa de red estimada",
       "turkish": "Tahmini Ağ Ücreti",
-      "russian": "Оценочная плата за сеть"
+      "russian": "Примерная комиссия сети"
     },
     "from": {
       "dutch": "Van:",
@@ -466,7 +466,7 @@
       "portuguese": "Preço inválido de gás",
       "spanish": "Precio de gas no válido",
       "turkish": "Gas fiyatı geçersiz",
-      "russian": "Недопустимая цена газа"
+      "russian": "Недопустимая цена за газ"
     },
     "invalidMaxFeeErr": {
       "dutch": "Ongeldige maximale prioriteitskosten",
@@ -479,7 +479,7 @@
       "portuguese": "Taxa prioritária máxima inválida",
       "spanish": "Tarifa de prioridad máxima no válida",
       "turkish": "Maksimum öncelik ücreti geçersiz",
-      "russian": "Недопустимая максимальная приоритетная плата"
+      "russian": "Недопустимая максимальная приоритетная цена"
     },
     "invalidMaxTxnFeeErr": {
       "dutch": "Ongeldige max transactiekosten",
@@ -518,7 +518,7 @@
       "portuguese": "Este é um contrato inteligente",
       "spanish": "Este es un contrato inteligente",
       "turkish": "Bu, bir akıllı sözleşme hesabıdır",
-      "russian": "Это учетная запись умного контракта"
+      "russian": "Это аккаунт на базе смарт-контракта"
     },
     "login": {
       "dutch": "Log in",
@@ -986,7 +986,7 @@
       "portuguese": "Não armazenamos nenhum dado relacionado ao seu login por rede social.",
       "spanish": "No almacenamos ningún dato relacionado con sus inicios de sesión sociales.",
       "turkish": "Biz hepsini sosyal oturum açma ile ilgili herhangi bir veriyi saklamıyoruz.",
-      "russian": "Мы не храним никаких данных, связанных с вашими социальными входами."
+      "russian": "Мы не храним никаких данных, связанных с вашими соцсетями."
     },
     "socialViewLess": {
       "dutch": "Minder bekijken",

--- a/Wallet-service-locale/locales-walletconnect.json
+++ b/Wallet-service-locale/locales-walletconnect.json
@@ -10,7 +10,8 @@
       "mandarin": "连接到应用程序",
       "portuguese": "Conectar ao aplicativo",
       "spanish": "Conectarse a la aplicación",
-      "turkish": "Bağlan uygulamaya"
+      "turkish": "Bağlan uygulamaya",
+      "russian": "Подключиться к приложению"
     },
     "heading2": {
       "dutch": "Bezoek de toepassingssite",
@@ -22,7 +23,8 @@
       "mandarin": "访问申请站点",
       "portuguese": "Visite site de inscrição",
       "spanish": "Visite el sitio de solicitud",
-      "turkish": "Bağlantı sitesine git"
+      "turkish": "Bağlantı sitesine git",
+      "russian": "Посетить сайт приложения"
     },
     "heading3": {
       "dutch": "Selecteer WalletConnect",
@@ -34,7 +36,8 @@
       "mandarin": "选择WalletConnect",
       "portuguese": "Selecione WalleTConnect",
       "spanish": "Seleccionar WalletConnect",
-      "turkish": "WalletConnect'i seçin"
+      "turkish": "WalletConnect'i seçin",
+      "russian": "Выберите WalletConnect"
     },
     "heading4": {
       "dutch": "Klik op 'Kopiëren naar klembord'",
@@ -46,7 +49,8 @@
       "mandarin": "单击“复制到剪贴板”",
       "portuguese": "Clique em 'Copiar para a área de transferência'",
       "spanish": "Haga clic en 'Copiar al portapapeles'",
-      "turkish": "'Panoya' düğmesine tıklayın"
+      "turkish": "'Panoya' düğmesine tıklayın",
+      "russian": "Нажмите «Копировать в буфер обмена»"
     },
     "heading5": {
       "dutch": "Plak de QR -link hieronder",
@@ -58,7 +62,8 @@
       "mandarin": "粘贴QR链接下面",
       "portuguese": "Cole o link QR abaixo",
       "spanish": "Pegar el enlace QR a continuación",
-      "turkish": "QR bağlantısını aşağıya yapıştırın"
+      "turkish": "QR bağlantısını aşağıya yapıştırın",
+      "russian": "Вставьте QR-ссылку ниже"
     },
     "heading6": {
       "dutch": "Accepteer de algemene voorwaarden",
@@ -70,7 +75,8 @@
       "mandarin": "接受条款和条件",
       "portuguese": "Aceita termos e Condições",
       "spanish": "Aceptar terminos y condiciones",
-      "turkish": "Kullanım Şartlarını kabul edin"
+      "turkish": "Kullanım Şartlarını kabul edin",
+      "russian": "Примите условия и положения"
     },
     "heading7": {
       "dutch": "Autoriseer een aanvraag",
@@ -82,7 +88,8 @@
       "mandarin": "授权申请",
       "portuguese": "Autorize Aplicação",
       "spanish": "Autorizar la aplicación",
-      "turkish": "Başvuru onaylayın"
+      "turkish": "Başvuru onaylayın",
+      "russian": "Авторизовать приложение"
     },
     "heading8": {
       "dutch": "Jullie zijn er klaar voor!",
@@ -94,7 +101,8 @@
       "mandarin": "你们都设定了！",
       "portuguese": "Estás pronto!",
       "spanish": "¡Estas listo!",
-      "turkish": "Hazır ol!"
+      "turkish": "Hazır ol!",
+      "russian": "Все готово!"
     },
     "subHeading1": {
       "dutch": "Toegang tot de Web3 -markt in enkele stappen",
@@ -106,7 +114,8 @@
       "mandarin": "通过几个步骤访问Web3市场",
       "portuguese": "Acesse o Web3 Marketplace em algumas etapas",
       "spanish": "Acceda al mercado Web3 en unos pocos pasos",
-      "turkish": "Web3 mağazasını birkaç adımda erişin"
+      "turkish": "Web3 mağazasını birkaç adımda erişin",
+      "russian": "Доступ к маркетплейсу Web3 в несколько шагов"
     },
     "subHeading2": {
       "dutch": "Ga naar de toepassing die WalletConnect heeft",
@@ -118,7 +127,8 @@
       "mandarin": "转到具有WalletConnect的应用程序",
       "portuguese": "Vá para a aplicação que tenha WalletConnect",
       "spanish": "Ir a la aplicación que tiene WalletConnect",
-      "turkish": "Uygulamadaki WalletConnect ile bağlantılı bir uygulamaya git"
+      "turkish": "Uygulamadaki WalletConnect ile bağlantılı bir uygulamaya git",
+      "russian": "Перейдите в приложение с WalletConnect"
     },
     "subHeading3": {
       "dutch": "Uit de lijst met portefeuilles op toepassing",
@@ -130,7 +140,8 @@
       "mandarin": "从应用程序的钱包列表中",
       "portuguese": "Da lista de carteiras na aplicação",
       "spanish": "De la lista de billeteras en la aplicación",
-      "turkish": "Uygulamadaki portföyler listesinden"
+      "turkish": "Uygulamadaki portföyler listesinden",
+      "russian": "Из списка кошельков в приложении"
     },
     "subHeading4": {
       "dutch": "Gelegen onder de QR -code",
@@ -142,7 +153,8 @@
       "mandarin": "位于QR码下方",
       "portuguese": "Localizado abaixo do código QR",
       "spanish": "Ubicado debajo del código QR",
-      "turkish": "QR kodu altında"
+      "turkish": "QR kodu altında",
+      "russian": "Расположено под QR-кодом"
     },
     "subHeading5": {
       "dutch": "Of scan de QR -code rechtstreeks",
@@ -154,7 +166,8 @@
       "mandarin": "或直接扫描QR码",
       "portuguese": "Ou digitalize o código QR diretamente",
       "spanish": "O escanear el código QR directamente",
-      "turkish": "Veya QR kodunu doğrudan tarayın"
+      "turkish": "Veya QR kodunu doğrudan tarayın",
+      "russian": "Или отсканируйте QR-код напрямую"
     },
     "subHeading6": {
       "dutch": "Keer terug naar de aanvraag om te accepteren en te ondertekenen",
@@ -166,7 +179,8 @@
       "mandarin": "返回申请接受和签名",
       "portuguese": "Retorne ao aplicativo para aceitar e assinar",
       "spanish": "Volver a la solicitud para aceptar y firmar",
-      "turkish": "Uygulamaya dönerek onaylayın ve imzalayın"
+      "turkish": "Uygulamaya dönerek onaylayın ve imzalayın",
+      "russian": "Вернитесь в приложение, чтобы принять и подписать"
     },
     "subHeading7": {
       "dutch": "Goedkeuren het bericht van de aanvraag om door te gaan",
@@ -178,7 +192,8 @@
       "mandarin": "批准申请的消息继续",
       "portuguese": "Aprovar a mensagem do aplicativo para continuar",
       "spanish": "Aprobar el mensaje de la aplicación para continuar",
-      "turkish": "Uygulamanın iletisini onaylayarak devam edin"
+      "turkish": "Uygulamanın iletisini onaylayarak devam edin",
+      "russian": "Одобрите сообщение приложения для продолжения"
     },
     "subHeading8": {
       "dutch": "Keer terug naar de aanvraag om te beginnen met verkennen!",
@@ -190,7 +205,8 @@
       "mandarin": "返回应用程序开始探索！",
       "portuguese": "Volte ao aplicativo para começar a explorar!",
       "spanish": "¡Regrese a la aplicación para comenzar a explorar!",
-      "turkish": "Uygulamaya dönerek keşfetmek için başlayın!"
+      "turkish": "Uygulamaya dönerek keşfetmek için başlayın!",
+      "russian": "Вернитесь в приложение, чтобы начать исследовать!"
     }
   },
   "error": {
@@ -204,7 +220,8 @@
       "mandarin": "相机已经在使用吗？",
       "portuguese": "A câmera já está em uso?",
       "spanish": "¿La cámara ya está en uso?",
-      "turkish": "Kamera zaten kullanılıyor mu?"
+      "turkish": "Kamera zaten kullanılıyor mu?",
+      "russian": "Камера уже используется?"
     },
     "grantCameraPermission": {
       "dutch": "U moet toestemming van de camera toegang geven",
@@ -216,7 +233,8 @@
       "mandarin": "您需要授予相机访问权限",
       "portuguese": "Você precisa conceder permissão de acesso à câmera",
       "spanish": "Necesita otorgar permiso de acceso a la cámara",
-      "turkish": "Kamera erişim izni verilmesi gerekiyor"
+      "turkish": "Kamera erişim izni verilmesi gerekiyor",
+      "russian": "Вам нужно предоставить разрешение на доступ к камере"
     },
     "installedCameraErr": {
       "dutch": "Geïnstalleerde camera's zijn niet geschikt",
@@ -228,7 +246,8 @@
       "mandarin": "安装的摄像头不合适",
       "portuguese": "Câmeras instaladas não são adequadas",
       "spanish": "Las cámaras instaladas no son adecuadas",
-      "turkish": "Yüklü kamera uygun değil"
+      "turkish": "Yüklü kamera uygun değil",
+      "russian": "Установленные камеры не подходят"
     },
     "invalidUrl": {
       "dutch": "Ongeldige portemonnee verbind url",
@@ -240,7 +259,8 @@
       "mandarin": "无效的钱包连接URL",
       "portuguese": "Carteira inválida URL de conexão",
       "spanish": "URL de conexión de billetera no válida",
-      "turkish": "Hatalı bir cüzdan bağlantısı URL"
+      "turkish": "Hatalı bir cüzdan bağlantısı URL",
+      "russian": "Неверный URL подключения кошелька"
     },
     "noCamera": {
       "dutch": "Geen camera op dit apparaat",
@@ -252,7 +272,8 @@
       "mandarin": "该设备上没有相机",
       "portuguese": "Nenhuma câmera neste dispositivo",
       "spanish": "No hay cámara en este dispositivo",
-      "turkish": "Bu cihazda kamera yok"
+      "turkish": "Bu cihazda kamera yok",
+      "russian": "На этом устройстве нет камеры"
     },
     "qrReaderErr": {
       "dutch": "QR Reader Fout",
@@ -264,7 +285,8 @@
       "mandarin": "QR阅读器错误",
       "portuguese": "Erro do leitor QR",
       "spanish": "Error del lector QR",
-      "turkish": "QR Okuyucu Hatası"
+      "turkish": "QR Okuyucu Hatası",
+      "russian": "Ошибка считывателя QR"
     },
     "secureContext": {
       "dutch": "Veilige context vereist (https, localhost)",
@@ -276,7 +298,8 @@
       "mandarin": "需要的安全上下文（HTTPS，Localhost）",
       "portuguese": "Contexto seguro necessário (https, localhost)",
       "spanish": "Contexto seguro requerido (https, localhost)",
-      "turkish": "Güvenli bağlam gerekli (HTTPS, localhost)"
+      "turkish": "Güvenli bağlam gerekli (HTTPS, localhost)",
+      "russian": "Требуется безопасный контекст (HTTPS, localhost)"
     },
     "streamErr": {
       "dutch": "Stream API niet ondersteund",
@@ -288,7 +311,8 @@
       "mandarin": "流不支持的流API",
       "portuguese": "API de fluxo não suportada",
       "spanish": "API de transmisión no es compatible",
-      "turkish": "Stream API desteklenmiyor"
+      "turkish": "Stream API desteklenmiyor",
+      "russian": "API потоков не поддерживается"
     },
     "v1Deprecated": {
       "dutch": "V1 is verouderd",
@@ -300,7 +324,8 @@
       "mandarin": "V1被弃用",
       "portuguese": "v1 está preguiçoso",
       "spanish": "V1 está en desuso",
-      "turkish": "V1 kullanımdan kaldırıldı"
+      "turkish": "V1 kullanımdan kaldırıldı",
+      "russian": "v1 устарел"
     },
     "wcInit": {
       "dutch": "Er ging iets mis tijdens de initialisatie.",
@@ -312,7 +337,8 @@
       "mandarin": "初始化期间出了问题。",
       "portuguese": "Algo deu errado durante a inicialização.",
       "spanish": "Algo salió mal durante la inicialización.",
-      "turkish": "Başlatma sırasında bir şeyler ters gitti."
+      "turkish": "Başlatma sırasında bir şeyler ters gitti.",
+      "russian": "Что-то пошло не так при инициализации."
     }
   },
   "walletConnect": {
@@ -326,7 +352,8 @@
       "mandarin": "连接",
       "portuguese": "Conectar",
       "spanish": "Conectar",
-      "turkish": "Bağlan"
+      "turkish": "Bağlan",
+      "russian": "Подключиться"
     },
     "connected": {
       "dutch": "Verbonden",
@@ -338,7 +365,8 @@
       "mandarin": "连接的",
       "portuguese": "Conectado",
       "spanish": "Conectado",
-      "turkish": "Bağlı"
+      "turkish": "Bağlı",
+      "russian": "Подключено"
     },
     "connectedApplications": {
       "dutch": "Verbonden toepassingen",
@@ -350,7 +378,8 @@
       "mandarin": "连接的应用程序",
       "portuguese": "Aplicações conectadas",
       "spanish": "Aplicaciones conectadas",
-      "turkish": "Bağlı uygulamalar"
+      "turkish": "Bağlı uygulamalar",
+      "russian": "Подключенные приложения"
     },
     "connectedSuccess": {
       "dutch": "Succesvol verbonden",
@@ -362,7 +391,8 @@
       "mandarin": "成功连接",
       "portuguese": "Conectado com sucesso",
       "spanish": "Conectado con éxito",
-      "turkish": "Bağlantı başarıyla yapıldı"
+      "turkish": "Bağlantı başarıyla yapıldı",
+      "russian": "Успешно подключено"
     },
     "connectedWithWalletConnect": {
       "dutch": "Verbonden met WalletConnect",
@@ -374,7 +404,8 @@
       "mandarin": "与WalletConnect连接",
       "portuguese": "Conectado com WalletConnect",
       "spanish": "Conectado con WalletConnect",
-      "turkish": "WalletConnect ile bağlı"
+      "turkish": "WalletConnect ile bağlı",
+      "russian": "Подключено через WalletConnect"
     },
     "disConnect": {
       "dutch": "Loskoppelen",
@@ -386,7 +417,8 @@
       "mandarin": "断开",
       "portuguese": "desconectar",
       "spanish": "Desconectar",
-      "turkish": "Bağlantıyı kes"
+      "turkish": "Bağlantıyı kes",
+      "russian": "Отключиться"
     },
     "hideGuide": {
       "dutch": "Gids verbergen",
@@ -398,7 +430,8 @@
       "mandarin": "隐藏指南",
       "portuguese": "Ocultar guia",
       "spanish": "Ocultar guía",
-      "turkish": "Rehberi gizle"
+      "turkish": "Rehberi gizle",
+      "russian": "Скрыть руководство"
     },
     "maxAppConnected": {
       "dutch": "Maximale toepassingen verbonden",
@@ -410,7 +443,8 @@
       "mandarin": "连接的最大应用",
       "portuguese": "Aplicações máximas conectadas",
       "spanish": "Aplicaciones máximas conectadas",
-      "turkish": "Bağlı uygulama maksimum"
+      "turkish": "Bağlı uygulama maksimum",
+      "russian": "Максимальное количество подключенных приложений"
     },
     "pasteQrLinkHere": {
       "dutch": "Plak hier de QR -link",
@@ -422,7 +456,8 @@
       "mandarin": "粘贴QR链接在这里",
       "portuguese": "Cole o link QR aqui",
       "spanish": "Pegar el enlace QR aquí",
-      "turkish": "QR bağlantısını buraya yapıştırın"
+      "turkish": "QR bağlantısını buraya yapıştırın",
+      "russian": "Вставьте QR-ссылку сюда"
     },
     "pasteWalletConnect": {
       "dutch": "Plak WalletConnect QR -link hieronder",
@@ -434,7 +469,8 @@
       "mandarin": "粘贴WalletConnect QR链接下面",
       "portuguese": "Cole o link QR WalletConnect abaixo",
       "spanish": "Pegar el enlace QR de WalletConnect a continuación",
-      "turkish": "WalletConnect QR bağlantısını aşağıda yapıştırın"
+      "turkish": "WalletConnect QR bağlantısını aşağıda yapıştırın",
+      "russian": "Вставьте ниже QR-ссылку WalletConnect"
     },
     "showGuide": {
       "dutch": "Toon gids",
@@ -446,7 +482,8 @@
       "mandarin": "展示指南",
       "portuguese": "Mostrar Guia",
       "spanish": "Mostrar Guía",
-      "turkish": "Rehberi göster"
+      "turkish": "Rehberi göster",
+      "russian": "Показать руководство"
     },
     "takeMeTo": {
       "dutch": "Breng me naar",
@@ -458,7 +495,8 @@
       "mandarin": "带我去",
       "portuguese": "Leva me para",
       "spanish": "Ir a",
-      "turkish": "Bana bana"
+      "turkish": "Bana bana",
+      "russian": "Отправить меня к"
     }
   }
 }

--- a/Web3Auth-locale/locale-common.json
+++ b/Web3Auth-locale/locale-common.json
@@ -10,7 +10,8 @@
       "mandarin": "验证您的{{adapter}}帐户以继续",
       "portuguese": "Verifique a sua conta {{adapter}} para continuar",
       "spanish": "Verifica tu cuenta {{adapter}} para continuar",
-      "turkish": "Devam etmek için {{adapter}} hesabınızı doğrula"
+      "turkish": "Devam etmek için {{adapter}} hesabınızı doğrula",
+      "russian": "Подтвердите ваш аккаунт {{adapter}}, чтобы продолжить"
     },
     "adapter-loader.message1": {
       "dutch": "Verifieer uw {{adapter}}",
@@ -22,7 +23,8 @@
       "mandarin": "在您的{{adapter}}上验证",
       "portuguese": "Verifique o(a) seu/sua {{adapter}}",
       "spanish": "Verifique su {{adapter}}",
-      "turkish": "{{adapter}} doğrula"
+      "turkish": "{{adapter}} doğrula",
+      "russian": "Подтвердите ваш {{adapter}}"
     },
     "adapter-loader.message2": {
       "dutch": "account om door te gaan",
@@ -34,7 +36,8 @@
       "mandarin": "帐号继续",
       "portuguese": "conta para continuar",
       "spanish": "cuenta para continuar",
-      "turkish": "devam edecek hesap"
+      "turkish": "devam edecek hesap",
+      "russian": "аккаунт, чтобы продолжить"
     },
     "allChains": {
       "dutch": "Alle ketens",
@@ -46,7 +49,8 @@
       "mandarin": "所有链",
       "portuguese": "Todas as cadeias",
       "spanish": "Todas las cadenas",
-      "turkish": "Tüm zincirler"
+      "turkish": "Tüm zincirler",
+      "russian": "Все цепочки"
     },
     "connect-wallet.more-wallets": {
       "dutch": "Meer portemonnees",
@@ -58,7 +62,8 @@
       "mandarin": "查看更多钱包",
       "portuguese": "Mais carteiras",
       "spanish": "Más carteras",
-      "turkish": "Daha fazla cüzdan"
+      "turkish": "Daha fazla cüzdan",
+      "russian": "Другие кошельки"
     },
     "connectYourWallet": {
       "dutch": "Uw portemonnee verbinden",
@@ -70,7 +75,8 @@
       "mandarin": "连接您的钱包",
       "portuguese": "Conecte seu portefeuille",
       "spanish": "Conecte su portefeuille",
-      "turkish": "Cüzdanınızı bağlayın"
+      "turkish": "Cüzdanınızı bağlayın",
+      "russian": "Подключите ваш кошелек"
     },
     "errors-invalid-email": {
       "dutch": "Ongeldig e-mailadres",
@@ -82,7 +88,8 @@
       "mandarin": "无效的电子邮件",
       "portuguese": "E-mail inválido",
       "spanish": "Correo electrónico no válido",
-      "turkish": "Geçersiz E-posta"
+      "turkish": "Geçersiz E-posta",
+      "russian": "Неверный адрес электронной почты"
     },
     "errors-invalid-number": {
       "dutch": "Ongeldig telefoonnummer",
@@ -94,7 +101,8 @@
       "mandarin": "电话号码无效",
       "portuguese": "Número de telefone inválido",
       "spanish": "Número de teléfono no válido",
-      "turkish": "Geçersiz Telefon Numarası"
+      "turkish": "Geçersiz Telefon Numarası",
+      "russian": "Неверный номер телефона"
     },
     "errors-invalid-number-email": {
       "dutch": "Ongeldig e-mailadres of telefoonnummer",
@@ -106,7 +114,8 @@
       "mandarin": "无效的电子邮件或电话号码",
       "portuguese": "Email ou número de telefone inválido",
       "spanish": "Correo electrónico o número de teléfono no válido",
-      "turkish": "Geçersiz E-posta veya Telefon Numarası"
+      "turkish": "Geçersiz E-posta veya Telefon Numarası",
+      "russian": "Неверный адрес электронной почты или номер телефона"
     },
     "errors-required": {
       "dutch": "Vereist",
@@ -118,7 +127,8 @@
       "mandarin": "必填",
       "portuguese": "Obrigatório",
       "spanish": "Campo obligatorio",
-      "turkish": "Zorunlu"
+      "turkish": "Zorunlu",
+      "russian": "Обязательно"
     },
     "external.all-wallets": {
       "dutch": "Alle portemonnees",
@@ -130,7 +140,8 @@
       "mandarin": "所有钱包",
       "portuguese": "Todas as carteiras",
       "spanish": "Todas las billeteras",
-      "turkish": "Tüm cüzdanlar"
+      "turkish": "Tüm cüzdanlar",
+      "russian": "Все кошельки"
     },
     "external.back": {
       "dutch": "Terug",
@@ -142,7 +153,8 @@
       "mandarin": "返回",
       "portuguese": "Voltar",
       "spanish": "Atrás",
-      "turkish": "Geri"
+      "turkish": "Geri",
+      "russian": "Назад"
     },
     "external.connect": {
       "dutch": "Ga verder met een portemonnee",
@@ -152,9 +164,10 @@
       "japanese": "ウォレットを続ける",
       "korean": "지갑으로 계속하기",
       "mandarin": "继续使用钱包",
-      "portuguese": "Continuar com uma carteira",
+      "portuguese": "Continuar com carteira",
       "spanish": "Conectar con la billetera",
-      "turkish": "Cüzdanla devam et"
+      "turkish": "Cüzdanla devam et",
+      "russian": "Продолжить с кошельком"
     },
     "external.connect-wallet": {
       "dutch": "Verbinden met portemonnee",
@@ -166,7 +179,8 @@
       "mandarin": "连接钱包",
       "portuguese": "Conectar carteira",
       "spanish": "Conectar billetera",
-      "turkish": "Cüzdanı Bağla"
+      "turkish": "Cüzdanı Bağla",
+      "russian": "Подключить кошелек"
     },
     "external.continue": {
       "dutch": "Ga verder met externe portemonnee",
@@ -178,7 +192,8 @@
       "mandarin": "继续使用外部钱包",
       "portuguese": "Continuar com carteira externa",
       "spanish": "Continuar con billetera externa",
-      "turkish": "Harici cüzdanla devam et"
+      "turkish": "Harici cüzdanla devam et",
+      "russian": "Продолжить с внешним кошельком"
     },
     "external.continue-custom": {
       "dutch": "Doorgaan met {{wallet}}",
@@ -190,7 +205,8 @@
       "mandarin": "继续使用{{wallet}}",
       "portuguese": "Continue com o {{wallet}}",
       "spanish": "Continuar con {{wallet}}",
-      "turkish": "{{wallet}} ile devam et"
+      "turkish": "{{wallet}} ile devam et",
+      "russian": "Продолжить с {{wallet}}"
     },
     "external.dont-have": {
       "dutch": "Heb niet",
@@ -202,7 +218,8 @@
       "mandarin": "没有",
       "portuguese": "Não tem",
       "spanish": "No tiene",
-      "turkish": "Yok"
+      "turkish": "Yok",
+      "russian": "Нет"
     },
     "external.get": {
       "dutch": "Krijgen",
@@ -214,7 +231,8 @@
       "mandarin": "获取",
       "portuguese": "Obter",
       "spanish": "Obtener",
-      "turkish": "Al"
+      "turkish": "Al",
+      "russian": "Получить"
     },
     "external.get-wallet": {
       "dutch": "Portemonnee krijgen",
@@ -226,7 +244,8 @@
       "mandarin": "获取钱包",
       "portuguese": "Obter carteira",
       "spanish": "Obtener billetera",
-      "turkish": "Cüzdan Al"
+      "turkish": "Cüzdan Al",
+      "russian": "Получить кошелек"
     },
     "external.install-browser-extension": {
       "dutch": "{{browser}}-extensie installeren",
@@ -237,7 +256,8 @@
       "mandarin": "安装{{browser}}扩展",
       "portuguese": "Instalar extensão {{browser}}",
       "spanish": "Instalar extensión {{browser}}",
-      "turkish": "{{browser}} uzantısını yükle"
+      "turkish": "{{browser}} uzantısını yükle",
+      "russian": "Установите расширение {{browser}}"
     },
     "external.install-mobile-app": {
       "dutch": "Installeer {{os}}-app",
@@ -248,7 +268,8 @@
       "mandarin": "安装{{os}}应用",
       "portuguese": "Instalar aplicativo {{os}}",
       "spanish": "Instalar aplicación {{os}}",
-      "turkish": "{{os}} uygulamasını yükle"
+      "turkish": "{{os}} uygulamasını yükle",
+      "russian": "Установите приложение {{os}}"
     },
     "external.installed": {
       "dutch": "Geïnstalleerd",
@@ -260,7 +281,8 @@
       "mandarin": "已安装",
       "portuguese": "Instalado",
       "spanish": "Instalado",
-      "turkish": "Yüklendi"
+      "turkish": "Yüklendi",
+      "russian": "Установлено"
     },
     "external.no-wallets-found": {
       "dutch": "Geen portefeuilles gevonden",
@@ -272,7 +294,8 @@
       "mandarin": "没有找到钱包",
       "portuguese": "Nenhuma carteira encontrada",
       "spanish": "No se encontraron billeteras",
-      "turkish": "Cüzdan bulunamadı"
+      "turkish": "Cüzdan bulunamadı",
+      "russian": "Кошельки не найдены"
     },
     "external.search-subtext": {
       "dutch": "Probeer in plaats daarvan te zoeken",
@@ -284,7 +307,8 @@
       "mandarin": "尝试改为搜索",
       "portuguese": "Tente pesquisar",
       "spanish": "Intenta buscar en su lugar",
-      "turkish": "Bunun yerine aramayı deneyin"
+      "turkish": "Bunun yerine aramayı deneyin",
+      "russian": "Попробуйте поиск"
     },
     "external.search-text": {
       "dutch": "Ziet u uw portemonnee niet?",
@@ -296,7 +320,8 @@
       "mandarin": "没看到你的钱包吗？",
       "portuguese": "Não vê sua carteira?",
       "spanish": "¿No ves tu billetera?",
-      "turkish": "Cüzdanınızı görmüyor musunuz?"
+      "turkish": "Cüzdanınızı görmüyor musunuz?",
+      "russian": "Не видите ваш кошелек?"
     },
     "external.search-wallet": {
       "dutch": "Zoeken door {{count}} portemonnees...",
@@ -308,7 +333,8 @@
       "mandarin": "搜索{{count}}个钱包...",
       "portuguese": "Pesquisar através de {{count}} carteiras...",
       "spanish": "Buscar a través de {{count}} billeteras...",
-      "turkish": "{{count}} cüzdan ara..."
+      "turkish": "{{count}} cüzdan ara...",
+      "russian": "Поиск среди {{count}} кошельков..."
     },
     "external.select-chain": {
       "dutch": "Ketting selecteren",
@@ -320,7 +346,8 @@
       "mandarin": "选择链",
       "portuguese": "Selecionar cadeia",
       "spanish": "Seleccionar cadena",
-      "turkish": "Zincir seç"
+      "turkish": "Zincir seç",
+      "russian": "Выберите цепочку"
     },
     "external.select-chain-description": {
       "dutch": "Deze {{wallet}} portemonnee ondersteunt meerdere ketens. Selecteer welke ketting u wilt verbinden",
@@ -332,7 +359,8 @@
       "mandarin": "这个 {{wallet}} 钱包支持多种链。选择您想要连接的链",
       "portuguese": "Este {{wallet}} carteira suporta várias cadeias. Selecione a cadeia que você gostaria de conectar",
       "spanish": "Este {{wallet}} billetera soporta varias cadenas. Seleccione la cadena que desea conectar",
-      "turkish": "Bu {{wallet}} cüzdan birden fazla zincir destekler. İstediğiniz zinciri seçin"
+      "turkish": "Bu {{wallet}} cüzdan birden fazla zincir destekler. İstediğiniz zinciri seçin",
+      "russian": "Этот кошелек {{wallet}} поддерживает несколько цепочек. Выберите цепочку для подключения"
     },
     "external.title": {
       "dutch": "Externe portemonnee",
@@ -344,7 +372,8 @@
       "mandarin": "外部钱包",
       "portuguese": "Carteira Externa",
       "spanish": "Billetera Externa",
-      "turkish": "Harici Cüzdan"
+      "turkish": "Harici Cüzdan",
+      "russian": "Внешний кошелек"
     },
     "external.walletconnect-connect": {
       "dutch": "Verbinden",
@@ -356,7 +385,8 @@
       "mandarin": "连接",
       "portuguese": "Conectar",
       "spanish": "Conectar",
-      "turkish": "Bağla"
+      "turkish": "Bağla",
+      "russian": "Подключить"
     },
     "external.walletconnect-copy": {
       "dutch": "Scan de QR-code met een WalletConnect-compatibele portemonnee of klik op de QR-code om de link naar je klembord te kopiëren.",
@@ -368,7 +398,8 @@
       "mandarin": "使用支持 WalletConnect 的钱包扫描 QR 码或点击复制链接",
       "portuguese": "Digitalize o código QR com uma carteira compatível com WalletConnect ou clique para copiar o link",
       "spanish": "Escanee el código QR con una billetera compatible con WalletConnect o haga clic para copiar el enlace",
-      "turkish": "WalletConnect destekli bir cüzdanla QR kodu tarayın veya bağlantıyı kopyalayın"
+      "turkish": "WalletConnect destekli bir cüzdanla QR kodu tarayın veya bağlantıyı kopyalayın",
+      "russian": "Отсканируйте QR-код кошельком, поддерживающим WalletConnect, или нажмите, чтобы скопировать ссылку"
     },
     "external.walletconnect-subtitle": {
       "dutch": "Scan de QR-code met een WalletConnect-compatibele portemonnee",
@@ -380,7 +411,8 @@
       "mandarin": "使用兼容 WalletConnect 的钱包扫描 QR 码",
       "portuguese": "Digitalize o código QR com uma carteira compatível com WalletConnect",
       "spanish": "Escanear el código QR con una billetera compatible con WalletConnect",
-      "turkish": "QR kodunu WalletConnect uyumlu bir cüzdanla tarayın"
+      "turkish": "QR kodunu WalletConnect uyumlu bir cüzdanla tarayın",
+      "russian": "Отсканируйте QR-код совместимым с WalletConnect кошельком"
     },
     "footer.and": {
       "dutch": "en",
@@ -392,7 +424,8 @@
       "mandarin": "和",
       "portuguese": "e",
       "spanish": "y",
-      "turkish": "ve"
+      "turkish": "ve",
+      "russian": "и"
     },
     "footer.by-signing-in": {
       "dutch": "Door in te loggen, gaat u akkoord met onze",
@@ -404,7 +437,8 @@
       "mandarin": "登录即表示您同意我们的",
       "portuguese": "Ao se conectar, você concorda com nossos",
       "spanish": "Al iniciar sesión, acepta nuestros",
-      "turkish": "Giriş yapmak, bizimle ilgili şartları kabul ettiğiniz anlamına gelir."
+      "turkish": "Giriş yapmak, bizimle ilgili şartları kabul ettiğiniz anlamına gelir.",
+      "russian": "Войдя, вы соглашаетесь с нашими"
     },
     "footer.message": {
       "dutch": "Zelfbeheerde login door",
@@ -416,7 +450,8 @@
       "mandarin": "自托管登录由",
       "portuguese": "Login de autocustódia por",
       "spanish": "Inicio de sesión con autocustodia por",
-      "turkish": "Öz-yönetimli giriş yapan:"
+      "turkish": "Öz-yönetimli giriş yapan:",
+      "russian": "Самостоятельный вход через"
     },
     "footer.message-new": {
       "dutch": "Zelfkusten via",
@@ -428,7 +463,8 @@
       "mandarin": "自我castody通过",
       "portuguese": "Autoconfiança via",
       "spanish": "Autocustodia a través de",
-      "turkish": "Kendi kendine velayet"
+      "turkish": "Kendi kendine velayet",
+      "russian": "Самостоятельное хранение через"
     },
     "footer.policy": {
       "dutch": "Privacybeleid",
@@ -440,7 +476,8 @@
       "mandarin": "隐私政策",
       "portuguese": "Política de Privacidade",
       "spanish": "Política de privacidad",
-      "turkish": "Gizlilik Politikası"
+      "turkish": "Gizlilik Politikası",
+      "russian": "Политика конфиденциальности"
     },
     "footer.privacy-policy": {
       "dutch": "Privacy Policy",
@@ -452,7 +489,8 @@
       "mandarin": "隐私政策",
       "portuguese": "Política de privacidade",
       "spanish": "Política de privacidad",
-      "turkish": "Gizlilik Politikası"
+      "turkish": "Gizlilik Politikası",
+      "russian": "Политика конфиденциальности"
     },
     "footer.terms": {
       "dutch": "Gebruiksvoorwaarden",
@@ -464,7 +502,8 @@
       "mandarin": "使用条款",
       "portuguese": "Termos de Uso",
       "spanish": "Términos de Uso",
-      "turkish": "Kullanım Şartları"
+      "turkish": "Kullanım Şartları",
+      "russian": "Условия использования"
     },
     "footer.terms-of-service": {
       "dutch": "Gebruiksvoorwaarden",
@@ -476,7 +515,8 @@
       "mandarin": "使用条款",
       "portuguese": "Termos de uso",
       "spanish": "Términos de uso",
-      "turkish": "Kullanım Şartları"
+      "turkish": "Kullanım Şartları",
+      "russian": "Условия обслуживания"
     },
     "footer.terms-service": {
       "dutch": "Gebruiksvoorwaarden",
@@ -488,19 +528,21 @@
       "mandarin": "服务条款",
       "portuguese": "Termos de Serviço",
       "spanish": "Términos de servicio",
-      "turkish": "Hizmet Şartları"
+      "turkish": "Hizmet Şartları",
+      "russian": "Условия обслуживания"
     },
     "footer.version": {
       "dutch": "Versie",
       "english": "Version",
       "french": "Version",
-      "german": "Versión",
+      "german": "Versión",
       "japanese": "バージョン",
       "korean": "버전",
       "mandarin": "版本",
       "portuguese": "Versão",
       "spanish": "Versión",
-      "turkish": "Versiyon"
+      "turkish": "Versiyon",
+      "russian": "Версия"
     },
     "getWallet": {
       "dutch": "Portemonnee ophalen",
@@ -512,7 +554,8 @@
       "mandarin": "获取钱包",
       "portuguese": "Obter carteira",
       "spanish": "Obtener billetera",
-      "turkish": "Cüzdanı al"
+      "turkish": "Cüzdanı al",
+      "russian": "Получить кошелек"
     },
     "header-subtitle": {
       "dutch": "Selecteer een van de volgende opties om door te gaan",
@@ -524,7 +567,8 @@
       "mandarin": "选择以下选项以继续",
       "portuguese": "Selecione uma das seguintes opções para continuar",
       "spanish": "Seleccione una de las siguientes opciones para continuar",
-      "turkish": "Devam etmek için seçeneklerden birini işaretle"
+      "turkish": "Devam etmek için seçeneklerden birini işaretle",
+      "russian": "Выберите один из следующих вариантов, чтобы продолжить"
     },
     "header-subtitle-name": {
       "dutch": "Uw {{appName}}-portemonnee met één klik",
@@ -536,7 +580,8 @@
       "mandarin": "一键点击您的 {{appName}} 钱包",
       "portuguese": "Sua carteira {{appName}} com um clique",
       "spanish": "Su billetera {{appName}} con un solo clic",
-      "turkish": "Tek tıklama ile {{appName}} cüzdanınız"
+      "turkish": "Tek tıklama ile {{appName}} cüzdanınız",
+      "russian": "Ваш кошелек {{appName}} в один клик"
     },
     "header-subtitle-new": {
       "dutch": "Uw blockchain-portemonnee met één klik",
@@ -548,7 +593,8 @@
       "mandarin": "一键点击您的区块链钱包",
       "portuguese": "Sua carteira de blockchain com um clique",
       "spanish": "Su billetera blockchain con un solo clic",
-      "turkish": "Tek tıklama ile blockchain cüzdanınız"
+      "turkish": "Tek tıklama ile blockchain cüzdanınız",
+      "russian": "Ваш блокчейн-кошелек в один клик"
     },
     "header-title": {
       "dutch": "Aanmelden",
@@ -560,7 +606,8 @@
       "mandarin": "登录",
       "portuguese": "Entrar",
       "spanish": "Iniciar sesión",
-      "turkish": "Giriş yap"
+      "turkish": "Giriş yap",
+      "russian": "Войти"
     },
     "header-tooltip-desc": {
       "dutch": "De portemonnee dient als een account om uw digitale activa op de blockchain op te slaan en te beheren.",
@@ -572,7 +619,8 @@
       "mandarin": "钱包作为一个账户用于在区块链上存储和管理您的数字资产。",
       "portuguese": "A carteira serve como uma conta para armazenar e gerenciar seus ativos digitais na blockchain.",
       "spanish": "La billetera sirve como una cuenta para almacenar y administrar sus activos digitales en la blockchain.",
-      "turkish": "Cüzdan, dijital varlıklarınızı blockchain'de saklama ve yönetme görevi görür."
+      "turkish": "Cüzdan, dijital varlıklarınızı blockchain'de saklama ve yönetme görevi görür.",
+      "russian": "Кошелек служит аккаунтом для хранения и управления цифровыми активами в блокчейне."
     },
     "header-tooltip-title": {
       "dutch": "Portemonnee",
@@ -584,7 +632,8 @@
       "mandarin": "钱包",
       "portuguese": "Carteira",
       "spanish": "Billetera",
-      "turkish": "Cüzdan"
+      "turkish": "Cüzdan",
+      "russian": "Кошелек"
     },
     "network.add-request": {
       "dutch": "Deze site vraagt om een netwerk toe te voegen",
@@ -596,7 +645,8 @@
       "mandarin": "此站点正在请求添加网络",
       "portuguese": "Este site está solicitando adicionar uma rede",
       "spanish": "Este sitio está solicitando agregar una red",
-      "turkish": "Bu site bir ağ eklemek istiyor"
+      "turkish": "Bu site bir ağ eklemek istiyor",
+      "russian": "Этот сайт запрашивает добавление сети"
     },
     "network.cancel": {
       "dutch": "Annuleren",
@@ -608,7 +658,8 @@
       "mandarin": "取消",
       "portuguese": "Cancelar",
       "spanish": "Cancelar",
-      "turkish": "İptal"
+      "turkish": "İptal",
+      "russian": "Отмена"
     },
     "network.from": {
       "dutch": "Van",
@@ -620,7 +671,8 @@
       "mandarin": "从",
       "portuguese": "De",
       "spanish": "De",
-      "turkish": "Nereden"
+      "turkish": "Nereden",
+      "russian": "От"
     },
     "network.proceed": {
       "dutch": "Doorgaan",
@@ -632,7 +684,8 @@
       "mandarin": "继续",
       "portuguese": "Prosseguir",
       "spanish": "Continuar",
-      "turkish": "Devam"
+      "turkish": "Devam",
+      "russian": "Продолжить"
     },
     "network.switch-request": {
       "dutch": "Deze site vraagt om over te schakelen naar een ander netwerk",
@@ -644,7 +697,8 @@
       "mandarin": "此站点正在请求切换网络",
       "portuguese": "Este site está solicitando trocar de rede",
       "spanish": "Este sitio está solicitando cambiar de red",
-      "turkish": "Bu site ağ değiştirmeyi talep ediyor"
+      "turkish": "Bu site ağ değiştirmeyi talep ediyor",
+      "russian": "Этот сайт запрашивает переключение сети"
     },
     "network.to": {
       "dutch": "Naar",
@@ -656,7 +710,8 @@
       "mandarin": "至",
       "portuguese": "Para",
       "spanish": "A",
-      "turkish": "Nereye"
+      "turkish": "Nereye",
+      "russian": "К"
     },
     "otp.email-subtext": {
       "dutch": "Voer de 6-cijferige verificatiecode in",
@@ -668,7 +723,8 @@
       "mandarin": "请输入6位验证码",
       "portuguese": "Por favor, insira o código de verificação de 6 dígitos",
       "spanish": "Por favor, ingrese el código de verificación de 6 dígitos",
-      "turkish": "6 haneli doğrulama kodunu giriniz"
+      "turkish": "6 haneli doğrulama kodunu giriniz",
+      "russian": "Пожалуйста, введите 6-значный код подтверждения"
     },
     "otp.email-subtext-example": {
       "dutch": "{{email}} adres is verstuurd",
@@ -680,7 +736,8 @@
       "mandarin": "{{email}} 发送的",
       "portuguese": "que foi enviado para o seu email {{email}}",
       "spanish": "que fue enviado a su email {{email}}",
-      "turkish": "{{email}} adresine gönderildi"
+      "turkish": "{{email}} adresine gönderildi",
+      "russian": "который был отправлен на вашу почту {{email}}"
     },
     "otp.email-title": {
       "dutch": "Email Verificatie",
@@ -692,7 +749,8 @@
       "mandarin": "电子邮件验证",
       "portuguese": "Verificação de email",
       "spanish": "Verificación de email",
-      "turkish": "Email Doğrulama"
+      "turkish": "Email Doğrulama",
+      "russian": "Проверка электронной почты"
     },
     "otp.mobile-subtext": {
       "dutch": "OTP Verificatie",
@@ -704,7 +762,8 @@
       "mandarin": "输入 OTP 验证",
       "portuguese": "Verifique o OTP enviado para",
       "spanish": "Verificación OTP",
-      "turkish": "OTP Doğrulama"
+      "turkish": "OTP Doğrulama",
+      "russian": "Введите OTP, отправленный на"
     },
     "otp.mobile-title": {
       "dutch": "OTP Verificatie",
@@ -716,7 +775,8 @@
       "mandarin": "OTP 验证",
       "portuguese": "Verificação OTP",
       "spanish": "Verificación OTP",
-      "turkish": "OTP Doğrulama"
+      "turkish": "OTP Doğrulama",
+      "russian": "Проверка OTP"
     },
     "otp.success": {
       "dutch": "U bent verbonden met uw account!",
@@ -728,7 +788,8 @@
       "mandarin": "您已连接到您的帐户！",
       "portuguese": "Você está conectado ao seu conta!",
       "spanish": "¡Estás conectado a tu cuenta!",
-      "turkish": "Hesabınıza bağlandınız!"
+      "turkish": "Hesabınıza bağlandınız!",
+      "russian": "Вы вошли в аккаунт!"
     },
     "passkey.add": {
       "dutch": "Passkey toevoegen",
@@ -740,19 +801,21 @@
       "mandarin": "添加Passkey",
       "portuguese": "Adicionar Passkey",
       "spanish": "Añadir Passkey",
-      "turkish": "Passkey ekle"
+      "turkish": "Passkey ekle",
+      "russian": "Добавить Passkey"
     },
     "passkey.haveExisting": {
       "dutch": "Heeft u een bestaande passkey?",
       "english": "Have an existing passkey?",
-      "french": "Vous disposez déjà d'un passkey ?",
+      "french": "Vous disposez déjà d'un passkey ?",
       "german": "Haben Sie bereits einen passkey?",
       "japanese": "既存の passkey をお持ちですか?",
       "korean": "기존 passkey가 있나요?",
       "mandarin": "已有 passkey 吗？",
       "portuguese": "Você já possui um passkey?",
       "spanish": "¿Tiene un passkey existente?",
-      "turkish": "Mevcut bir passkey'ınız mı var?"
+      "turkish": "Mevcut bir passkey'ınız mı var?",
+      "russian": "У вас уже есть passkey?"
     },
     "passkey.learn-more": {
       "dutch": "Kom meer te weten",
@@ -764,7 +827,8 @@
       "mandarin": "了解更多",
       "portuguese": "Saber mais",
       "spanish": "Aprende más",
-      "turkish": "Daha fazla bilgi edin"
+      "turkish": "Daha fazla bilgi edin",
+      "russian": "Узнать больше"
     },
     "passkey.or": {
       "dutch": "of",
@@ -776,7 +840,8 @@
       "mandarin": "或者",
       "portuguese": "ou",
       "spanish": "o",
-      "turkish": "veya"
+      "turkish": "veya",
+      "russian": "или"
     },
     "passkey.register-desc": {
       "dutch": "Met passkeys kunt u uw identiteit verifiëren via uw gezicht, vingerafdruk of beveiligingssleutels.",
@@ -788,7 +853,8 @@
       "mandarin": "使用passkeys，您可以通过面部、指纹或安全密钥验证您的身份。",
       "portuguese": "Com passkeys, você pode verificar sua identidade por meio de seu rosto, impressão digital ou chaves de segurança.",
       "spanish": "Con passkeys, puedes verificar tu identidad a través de tu rostro, huella digital o claves de seguridad.",
-      "turkish": "passkeys ile kimliğinizi yüzünüz, parmak iziniz veya güvenlik anahtarlarınız aracılığıyla doğrulayabilirsiniz."
+      "turkish": "passkeys ile kimliğinizi yüzünüz, parmak iziniz veya güvenlik anahtarlarınız aracılığıyla doğrulayabilirsiniz.",
+      "russian": "С помощью passkeys вы можете подтвердить свою личность по лицу, отпечатку пальца или ключам безопасности."
     },
     "passkey.register-title": {
       "dutch": "Registreer Passkey",
@@ -800,7 +866,8 @@
       "mandarin": "注册Passkey",
       "portuguese": "Registre-se Passkey",
       "spanish": "Registrarse Passkey",
-      "turkish": "Passkey'ı kaydedin"
+      "turkish": "Passkey'ı kaydedin",
+      "russian": "Зарегистрировать Passkey"
     },
     "passkey.use": {
       "dutch": "Ik heb een passkey",
@@ -812,7 +879,8 @@
       "mandarin": "我有一个Passkey",
       "portuguese": "Eu tenho uma passkey",
       "spanish": "Tengo una Passkey",
-      "turkish": "Bir passkey'im var"
+      "turkish": "Bir passkey'im var",
+      "russian": "У меня есть passkey"
     },
     "passwordless.title": {
       "dutch": "Doorgaan met {{title}}",
@@ -824,7 +892,8 @@
       "mandarin": "继续使用 {{title}}",
       "portuguese": "Continuar com {{title}}",
       "spanish": "Continuar con {{title}}",
-      "turkish": "{{title}} ile devam et"
+      "turkish": "{{title}} ile devam et",
+      "russian": "Продолжить с {{title}}"
     },
     "popup.phone-body": {
       "dutch": "Uw landcode wordt automatisch gedetecteerd, maar als u een telefoonnummer uit een ander land gebruikt, moet u handmatig de juiste landcode invoeren.",
@@ -836,7 +905,8 @@
       "mandarin": "您的国家代码将自动检测到，但如果您使用其他国家/地区的电话号码，您需要手动输入正确的国家代码。",
       "portuguese": "O código do seu país será detectado automaticamente, mas se estiver usando um número de telefone de um país diferente, você precisará inserir manualmente o código correto do país.",
       "spanish": "Su código de país se detectará automáticamente, pero si está utilizando un número de teléfono de otro país, deberá ingresar manualmente el código de país correcto.",
-      "turkish": "Ülke kodunuz otomatik olarak algılanacaktır, ancak farklı bir ülkeden bir telefon numarası kullanıyorsanız, doğru ülke kodunu manuel olarak girmeniz gerekir."
+      "turkish": "Ülke kodunuz otomatik olarak algılanacaktır, ancak farklı bir ülkeden bir telefon numarası kullanıyorsanız, doğru ülke kodunu manuel olarak girmeniz gerekir.",
+      "russian": "Код вашей страны будет определён автоматически, но если вы используете номер из другой страны, вам нужно вручную ввести правильный код страны."
     },
     "popup.phone-header": {
       "dutch": "Telefoonnummer en landcode",
@@ -848,7 +918,8 @@
       "mandarin": "电话号码和国家代码",
       "portuguese": "Número de telefone e código do país",
       "spanish": "Número de teléfono y código de país",
-      "turkish": "Telefon numarası ve ülke kodu"
+      "turkish": "Telefon numarası ve ülke kodu",
+      "russian": "Номер телефона и код страны"
     },
     "post-loading.connected": {
       "dutch": "U bent verbonden met uw account",
@@ -860,7 +931,8 @@
       "mandarin": "您与您的帐户有联系",
       "portuguese": "Você está conectado com sua conta",
       "spanish": "Estás conectado con tu cuenta",
-      "turkish": "Hesabınızla bağlandınız"
+      "turkish": "Hesabınızla bağlandınız",
+      "russian": "Вы подключены к своему аккаунту"
     },
     "post-loading.something-wrong": {
       "dutch": "Er is iets fout gegaan!",
@@ -872,7 +944,8 @@
       "mandarin": "出了些问题！",
       "portuguese": "Algo deu errado!",
       "spanish": "¡Algo salió mal!",
-      "turkish": "Bir şeyler ters gitti!"
+      "turkish": "Bir şeyler ters gitti!",
+      "russian": "Что-то пошло не так!"
     },
     "resendCode": {
       "dutch": "Code opnieuw verzenden",
@@ -884,7 +957,8 @@
       "mandarin": "重新发送代码",
       "portuguese": "Reenviar código",
       "spanish": "Reenviar código",
-      "turkish": "Kodu tekrar gönder"
+      "turkish": "Kodu tekrar gönder",
+      "russian": "Отправить код повторно"
     },
     "resendTimer": {
       "dutch": " Opnieuw verzenden in {{timer}} seconden",
@@ -896,7 +970,8 @@
       "mandarin": " {{timer}} 秒后重新发送",
       "portuguese": " Reenviar em {{timer}} segundos",
       "spanish": " Reenviar en {{timer}} segundos",
-      "turkish": " {{timer}} saniye sonra tekrar gönder"
+      "turkish": " {{timer}} saniye sonra tekrar gönder",
+      "russian": " Повторно отправить через {{timer}} секунд"
     },
     "social.continue": {
       "dutch": "Doorgaan met",
@@ -908,7 +983,8 @@
       "mandarin": "继续",
       "portuguese": "Continuar com",
       "spanish": "Continuar con",
-      "turkish": "Devam et: "
+      "turkish": "Devam et: ",
+      "russian": "Продолжить с"
     },
     "social.continueCustom": {
       "dutch": "Doorgaan met {{adapter}}",
@@ -920,7 +996,8 @@
       "mandarin": "继续使用{{adapter}}",
       "portuguese": "Continue com o {{adapter}}",
       "spanish": "Continuar con {{adapter}}",
-      "turkish": "{{adapter}} ile devam et"
+      "turkish": "{{adapter}} ile devam et",
+      "russian": "Продолжить с {{adapter}}"
     },
     "social.email": {
       "dutch": "E-mail",
@@ -932,7 +1009,8 @@
       "mandarin": "电子邮件",
       "portuguese": "Email",
       "spanish": "Correo electrónico",
-      "turkish": "E-posta"
+      "turkish": "E-posta",
+      "russian": "Электронная почта"
     },
     "social.email-continue": {
       "dutch": "Doorgaan met e-mail",
@@ -944,7 +1022,8 @@
       "mandarin": "继续使用电子邮件",
       "portuguese": "Continuar com email",
       "spanish": "Continuar con correo electrónico",
-      "turkish": "E-posta ile devam et"
+      "turkish": "E-posta ile devam et",
+      "russian": "Продолжить с электронной почтой"
     },
     "social.email-new": {
       "dutch": "naam@voorbeeld.com",
@@ -956,7 +1035,8 @@
       "mandarin": "name@example.com",
       "portuguese": "nome@exemplo.com",
       "spanish": "nombre@ejemplo.com",
-      "turkish": "isim@ornek.com"
+      "turkish": "isim@ornek.com",
+      "russian": "имя@пример.com"
     },
     "social.passwordless-cta": {
       "dutch": "Doorgaan",
@@ -968,7 +1048,8 @@
       "mandarin": "继续",
       "portuguese": "Continuar",
       "spanish": "Continuar",
-      "turkish": "Devam et"
+      "turkish": "Devam et",
+      "russian": "Продолжить"
     },
     "social.passwordless-login": {
       "dutch": "Log in",
@@ -980,7 +1061,8 @@
       "mandarin": "登录",
       "portuguese": "Conecte-se",
       "spanish": "Acceso",
-      "turkish": "Giriş yapmak"
+      "turkish": "Giriş yapmak",
+      "russian": "Вход"
     },
     "social.passwordless-title": {
       "dutch": "E-mail/Telefoon",
@@ -992,7 +1074,8 @@
       "mandarin": "电子邮件/电话",
       "portuguese": "Email/Telefone",
       "spanish": "Email/Teléfono",
-      "turkish": "E-posta/Telefon"
+      "turkish": "E-posta/Telefon",
+      "russian": "Эл. почта/Телефон"
     },
     "social.phone": {
       "dutch": "Telefoon",
@@ -1004,7 +1087,8 @@
       "mandarin": "电话",
       "portuguese": "Telefone",
       "spanish": "Teléfono",
-      "turkish": "Telefon"
+      "turkish": "Telefon",
+      "russian": "Телефон"
     },
     "social.policy": {
       "dutch": "We slaan geen gegevens op die verband houden met uw sociale logins.",
@@ -1016,7 +1100,8 @@
       "mandarin": "我们不存储与您的社交登录相关的任何数据。",
       "portuguese": "Não armazenamos nenhum dado relacionado ao seu login por rede social.",
       "spanish": "No almacenamos ningún dato relacionado con sus inicios de sesión sociales.",
-      "turkish": "Sosyal medya girişlerinizle ilgili hiçbir veriyi saklamıyoruz."
+      "turkish": "Sosyal medya girişlerinizle ilgili hiçbir veriyi saklamıyoruz.",
+      "russian": "Мы не храним данные, связанные с вашими социальными входами."
     },
     "social.sign-in": {
       "dutch": "Inloggen",
@@ -1028,7 +1113,8 @@
       "mandarin": "登录",
       "portuguese": "Entrar",
       "spanish": "Iniciar sesión",
-      "turkish": "Giriş yap"
+      "turkish": "Giriş yap",
+      "russian": "Войти"
     },
     "social.sms": {
       "dutch": "Mobiel",
@@ -1040,7 +1126,8 @@
       "mandarin": "移动",
       "portuguese": "Móvel",
       "spanish": "Móvil",
-      "turkish": "Mobil Telefon"
+      "turkish": "Mobil Telefon",
+      "russian": "Мобильный"
     },
     "social.sms-continue": {
       "dutch": "Doorgaan met mobiel",
@@ -1052,7 +1139,8 @@
       "mandarin": "继续使用移动设备",
       "portuguese": "Continuar com o celular",
       "spanish": "Continuar con móvil",
-      "turkish": "Telefon ile devam et"
+      "turkish": "Telefon ile devam et",
+      "russian": "Продолжить с мобильного"
     },
     "social.sms-invalid-number": {
       "dutch": "Ongeldig telefoonnummer",
@@ -1064,7 +1152,8 @@
       "mandarin": "无效的电话号码",
       "portuguese": "Número de telefone inválido",
       "spanish": "Número de teléfono inválido",
-      "turkish": "Geçersiz telefon numarası"
+      "turkish": "Geçersiz telefon numarası",
+      "russian": "Неверный номер телефона"
     },
     "social.sms-placeholder-text": {
       "dutch": "Bijv.:",
@@ -1076,7 +1165,8 @@
       "mandarin": "例如：",
       "portuguese": "Por exemplo:",
       "spanish": "Por ej.:",
-      "turkish": "Örneğin:"
+      "turkish": "Örneğin:",
+      "russian": "Напр.:"
     },
     "social.view-less": {
       "dutch": "Minder bekijken",
@@ -1088,7 +1178,8 @@
       "mandarin": "少查看",
       "portuguese": "Ver menos",
       "spanish": "Ver menos",
-      "turkish": "Daha az görüntüle"
+      "turkish": "Daha az görüntüle",
+      "russian": "Показать меньше"
     },
     "social.view-less-socials": {
       "dutch": "Bekijk minder socials",
@@ -1100,7 +1191,8 @@
       "mandarin": "查看更少socials",
       "portuguese": "Ver menos socials",
       "spanish": "Ver menos socials",
-      "turkish": "Daha az socials görüntüle"
+      "turkish": "Daha az socials görüntüle",
+      "russian": "Показать меньше соцсетей"
     },
     "social.view-more": {
       "dutch": "Meer bekijken",
@@ -1112,7 +1204,8 @@
       "mandarin": "查看更多",
       "portuguese": "Ver mais",
       "spanish": "Ver más",
-      "turkish": "Daha fazla görüntüle"
+      "turkish": "Daha fazla görüntüle",
+      "russian": "Показать больше"
     },
     "social.view-more-socials": {
       "dutch": "Bekijk meer socials",
@@ -1124,7 +1217,8 @@
       "mandarin": "查看更多socials",
       "portuguese": "Ver mais socials",
       "spanish": "Ver más socials",
-      "turkish": "Daha fazlasını görüntüle socials"
+      "turkish": "Daha fazlasını görüntüle socials",
+      "russian": "Показать больше соцсетей"
     }
   },
   "passwordless": {
@@ -1132,13 +1226,14 @@
       "dutch": "Ongeldige verificatielink of link verlopen",
       "english": "Invalid verification link or link expired",
       "french": "Lien de vérification invalide ou lien expiré",
-      "german": "Ungültiger Überprüfungsverbindung oder Link ist abgelaufen",
+      "german": "Ungültiger Überprüfungsverbindung of Link ist abgelaufen",
       "japanese": "無効な検証リンクまたはリンクが期限切れになりました",
       "korean": "유효하지 않은 인증 링크이거나 링크가 만료되었습니다",
       "mandarin": "无效的验证链接或链接已过期",
       "portuguese": "Link de verificação inválido ou link expirado",
-      "spanish": "El enlace o el enlace de verificación ha expirado",
-      "turkish": "Hatalı ya da süresi geçmiş doğrulama linki"
+      "spanish": "Enlace de verificación inválido o expirado",
+      "turkish": "Hatalı doğrulama linki veya linkin süresi dolmuş",
+      "russian": "Неверная ссылка для проверки или ссылка истекла"
     },
     "error-invalid-origin": {
       "dutch": "Er is iets misgegaan, foutcode: E002",
@@ -1150,7 +1245,8 @@
       "mandarin": "出问题了, 错误代码: E002",
       "portuguese": "Algo deu errado, código de erro: E002",
       "spanish": "Algo salió mal, código de error: E002",
-      "turkish": "Bir şeyler ters gitti, hata kodu: E002"
+      "turkish": "Bir şeyler ters gitti, hata kodu: E002",
+      "russian": "Что-то пошло не так, код ошибки: E002"
     },
     "error-invalid-otp": {
       "dutch": "Ongeldige OTP, probeer het opnieuw",
@@ -1162,7 +1258,8 @@
       "mandarin": "无效的OTP，请重试",
       "portuguese": "OTP inválido, por favor tente novamente",
       "spanish": "OTP no válido, intente nuevamente",
-      "turkish": "Hatalı OTP, lütfen tekrar deneyin."
+      "turkish": "Hatalı OTP, lütfen tekrar deneyin.",
+      "russian": "Неверный OTP, пожалуйста, попробуйте снова"
     },
     "error-invalid-params": {
       "dutch": "Ontbrekende of ongeldige parameters",
@@ -1174,7 +1271,8 @@
       "mandarin": "缺失或无效参数",
       "portuguese": "Parâmetros ausentes ou inválidos",
       "spanish": "Parámetros faltantes o no válidos",
-      "turkish": "Eksik ya da hatalı parametreler var."
+      "turkish": "Eksik ya da hatalı parametreler var.",
+      "russian": "Отсутствуют или недействительны параметры."
     },
     "error-max-retry-limit-reached": {
       "dutch": "U heeft de limiet voor verkeerde pogingen bereikt. Start de stroom opnieuw om de verificatie te voltooien.",
@@ -1186,7 +1284,8 @@
       "mandarin": "您已经达到了错误的尝试的极限。请再次重新启动流程以完成验证。",
       "portuguese": "Você atingiu o limite para tentativas erradas. Reinicie o fluxo novamente para concluir a verificação.",
       "spanish": "Has alcanzado el límite para intentos incorrectos. Reinicie el proceso para completar la verificación.",
-      "turkish": "Hatalı deneme limitine ulaştınız. Doğrulamayı tamamlamak için lütfen akışı baştan başlatın."
+      "turkish": "Hatalı deneme limitine ulaştınız. Doğrulamayı tamamlamak için lütfen akışı baştan başlatın.",
+      "russian": "Вы достигли лимита неверных попыток. Пожалуйста, перезапустите процесс, чтобы завершить проверку."
     },
     "error-new-link-generated-heading": {
       "dutch": "Nieuwe verificatielink gegenereerd",
@@ -1198,7 +1297,8 @@
       "mandarin": "生成的新验证链接",
       "portuguese": "Novo link de verificação gerado",
       "spanish": "Nuevo enlace de verificación generado",
-      "turkish": "Yeni doğrulama linki oluşturuldu."
+      "turkish": "Yeni doğrulama linki oluşturuldu.",
+      "russian": "Создана новая ссылка для проверки"
     },
     "error-no-mail-generated": {
       "dutch": "Geen e-mail gegenereerd. Start eerst de wachtwoordloze flow.",
@@ -1210,7 +1310,8 @@
       "mandarin": "没有生成邮件。请先启动无密码流。",
       "portuguese": "Nenhum correio gerado. Inicie o fluxo sem senha primeiro.",
       "spanish": "No se generó el correo. Inicie primero el proceso sin contraseña.",
-      "turkish": "E-posta oluşturulmadı. Lütfen önce şifresiz akışı başlatın."
+      "turkish": "E-posta oluşturulmadı. Lütfen önce şifresiz akışı başlatın.",
+      "russian": "Письмо не было создано. Пожалуйста, сначала запустите безпарольный поток."
     },
     "error-no-sms-generated": {
       "dutch": "Geen OTP gegenereerd. Start eerst de wachtwoordloze flow.",
@@ -1222,7 +1323,8 @@
       "mandarin": "没有生成OTP。请先启动无密码流。",
       "portuguese": "Nenhum OTP gerado. Inicie o fluxo sem senha primeiro.",
       "spanish": "No se generó OTP. Inicie primero el proceso sin contraseña.",
-      "turkish": "OTP oluşturulmadı. Lütfen önce şifresiz akışı başlatın."
+      "turkish": "OTP oluşturulmadı. Lütfen önce şifresiz akışı başlatın.",
+      "russian": "OTP не был создан. Пожалуйста, сначала запустите безпарольный поток."
     },
     "error-otp-expired": {
       "dutch": "OTP verlopen",
@@ -1234,7 +1336,8 @@
       "mandarin": "OTP过期",
       "portuguese": "OTP expirou",
       "spanish": "OTP expiró",
-      "turkish": "OTP'nin süresi geçti."
+      "turkish": "OTP'nin süresi geçti.",
+      "russian": "OTP истек"
     },
     "error-plan-limit-reached": {
       "dutch": "E411. Limiet bereikt",
@@ -1246,7 +1349,8 @@
       "mandarin": "E411. 限制已达到",
       "portuguese": "E411. Limite atingido",
       "spanish": "E411. Límite alcanzado",
-      "turkish": "E411. Sınır aşıldı"
+      "turkish": "E411. Sınır aşıldı",
+      "russian": "E411. Достигнут предел"
     },
     "error-recaptcha-verification-failed": {
       "dutch": "Er is iets misgegaan tijdens het verifiëren. Probeer het opnieuw door de pagina te laden.",
@@ -1258,7 +1362,8 @@
       "mandarin": "Captcha 验证失败。请再试一次。",
       "portuguese": "A verificação Captcha falhou. Por favor, tente novamente.",
       "spanish": "La verificación de Captcha ha fallado. Por favor, inténtelo de nuevo.",
-      "turkish": "Captcha doğrulama hatası. Lütfen tekrar deneyin."
+      "turkish": "Captcha doğrulama hatası. Lütfen tekrar deneyin.",
+      "russian": "Проверка Captcha не удалась. Пожалуйста, попробуйте снова."
     },
     "error-sending-sms-failed": {
       "dutch": "Er is een fout opgetreden bij het verzenden van een sms. Probeer het opnieuw.",
@@ -1267,10 +1372,11 @@
       "german": "Es gab einen Fehler beim Senden einer SMS. Bitte versuche es erneut.",
       "japanese": "SMSの送信エラーがありました。もう一度やり直してください。",
       "korean": "SMS 전송 중 오류가 발생했습니다. 다시 시도해 주세요.",
-      "mandarin": "发送短信的错误。请再试一遍。",
+      "mandarin": "发送短信时出错。请再试一次。",
       "portuguese": "Houve um erro de envio de um SMS. Por favor, tente novamente.",
       "spanish": "Hubo un error al enviar el SMS. Inténtalo de nuevo.",
-      "turkish": "SMS gönderilirken bir hata oldu. Lütfen tekrar deneyin."
+      "turkish": "SMS gönderilirken bir hata oldu. Lütfen tekrar deneyin.",
+      "russian": "Ошибка при отправке SMS. Пожалуйста, попробуйте снова."
     },
     "something-wrong-error": {
       "dutch": "Er is iets misgegaan",
@@ -1282,7 +1388,8 @@
       "mandarin": "出问题了",
       "portuguese": "Algo deu errado",
       "spanish": "Algo salió mal",
-      "turkish": "Bir şeyler ters gitti"
+      "turkish": "Bir şeyler ters gitti",
+      "russian": "Что-то пошло не так"
     }
   }
 }

--- a/Web3Auth-locale/locale-common.json
+++ b/Web3Auth-locale/locale-common.json
@@ -347,7 +347,7 @@
       "portuguese": "Selecionar cadeia",
       "spanish": "Seleccionar cadena",
       "turkish": "Zincir seç",
-      "russian": "Выберите цепочку"
+      "russian": "Выберите сеть"
     },
     "external.select-chain-description": {
       "dutch": "Deze {{wallet}} portemonnee ondersteunt meerdere ketens. Selecteer welke ketting u wilt verbinden",
@@ -360,7 +360,7 @@
       "portuguese": "Este {{wallet}} carteira suporta várias cadeias. Selecione a cadeia que você gostaria de conectar",
       "spanish": "Este {{wallet}} billetera soporta varias cadenas. Seleccione la cadena que desea conectar",
       "turkish": "Bu {{wallet}} cüzdan birden fazla zincir destekler. İstediğiniz zinciri seçin",
-      "russian": "Этот кошелек {{wallet}} поддерживает несколько цепочек. Выберите цепочку для подключения"
+      "russian": "Этот кошелек {{wallet}} поддерживает несколько сетей. Выберите сеть для подключения"
     },
     "external.title": {
       "dutch": "Externe portemonnee",

--- a/Web3Auth-locale/locale-common.json
+++ b/Web3Auth-locale/locale-common.json
@@ -10,8 +10,7 @@
       "mandarin": "验证您的{{adapter}}帐户以继续",
       "portuguese": "Verifique a sua conta {{adapter}} para continuar",
       "spanish": "Verifica tu cuenta {{adapter}} para continuar",
-      "turkish": "Devam etmek için {{adapter}} hesabınızı doğrula",
-      "russian": "Подтвердите ваш аккаунт {{adapter}}, чтобы продолжить"
+      "turkish": "Devam etmek için {{adapter}} hesabınızı doğrula"
     },
     "adapter-loader.message1": {
       "dutch": "Verifieer uw {{adapter}}",
@@ -23,8 +22,7 @@
       "mandarin": "在您的{{adapter}}上验证",
       "portuguese": "Verifique o(a) seu/sua {{adapter}}",
       "spanish": "Verifique su {{adapter}}",
-      "turkish": "{{adapter}} doğrula",
-      "russian": "Подтвердите ваш {{adapter}}"
+      "turkish": "{{adapter}} doğrula"
     },
     "adapter-loader.message2": {
       "dutch": "account om door te gaan",
@@ -36,8 +34,7 @@
       "mandarin": "帐号继续",
       "portuguese": "conta para continuar",
       "spanish": "cuenta para continuar",
-      "turkish": "devam edecek hesap",
-      "russian": "аккаунт, чтобы продолжить"
+      "turkish": "devam edecek hesap"
     },
     "allChains": {
       "dutch": "Alle ketens",
@@ -49,8 +46,7 @@
       "mandarin": "所有链",
       "portuguese": "Todas as cadeias",
       "spanish": "Todas las cadenas",
-      "turkish": "Tüm zincirler",
-      "russian": "Все цепочки"
+      "turkish": "Tüm zincirler"
     },
     "connect-wallet.more-wallets": {
       "dutch": "Meer portemonnees",
@@ -62,8 +58,7 @@
       "mandarin": "查看更多钱包",
       "portuguese": "Mais carteiras",
       "spanish": "Más carteras",
-      "turkish": "Daha fazla cüzdan",
-      "russian": "Другие кошельки"
+      "turkish": "Daha fazla cüzdan"
     },
     "connectYourWallet": {
       "dutch": "Uw portemonnee verbinden",
@@ -75,8 +70,7 @@
       "mandarin": "连接您的钱包",
       "portuguese": "Conecte seu portefeuille",
       "spanish": "Conecte su portefeuille",
-      "turkish": "Cüzdanınızı bağlayın",
-      "russian": "Подключите ваш кошелек"
+      "turkish": "Cüzdanınızı bağlayın"
     },
     "errors-invalid-email": {
       "dutch": "Ongeldig e-mailadres",
@@ -88,8 +82,7 @@
       "mandarin": "无效的电子邮件",
       "portuguese": "E-mail inválido",
       "spanish": "Correo electrónico no válido",
-      "turkish": "Geçersiz E-posta",
-      "russian": "Неверный адрес электронной почты"
+      "turkish": "Geçersiz E-posta"
     },
     "errors-invalid-number": {
       "dutch": "Ongeldig telefoonnummer",
@@ -101,8 +94,7 @@
       "mandarin": "电话号码无效",
       "portuguese": "Número de telefone inválido",
       "spanish": "Número de teléfono no válido",
-      "turkish": "Geçersiz Telefon Numarası",
-      "russian": "Неверный номер телефона"
+      "turkish": "Geçersiz Telefon Numarası"
     },
     "errors-invalid-number-email": {
       "dutch": "Ongeldig e-mailadres of telefoonnummer",
@@ -114,8 +106,7 @@
       "mandarin": "无效的电子邮件或电话号码",
       "portuguese": "Email ou número de telefone inválido",
       "spanish": "Correo electrónico o número de teléfono no válido",
-      "turkish": "Geçersiz E-posta veya Telefon Numarası",
-      "russian": "Неверный адрес электронной почты или номер телефона"
+      "turkish": "Geçersiz E-posta veya Telefon Numarası"
     },
     "errors-required": {
       "dutch": "Vereist",
@@ -127,8 +118,7 @@
       "mandarin": "必填",
       "portuguese": "Obrigatório",
       "spanish": "Campo obligatorio",
-      "turkish": "Zorunlu",
-      "russian": "Обязательно"
+      "turkish": "Zorunlu"
     },
     "external.all-wallets": {
       "dutch": "Alle portemonnees",
@@ -140,8 +130,7 @@
       "mandarin": "所有钱包",
       "portuguese": "Todas as carteiras",
       "spanish": "Todas las billeteras",
-      "turkish": "Tüm cüzdanlar",
-      "russian": "Все кошельки"
+      "turkish": "Tüm cüzdanlar"
     },
     "external.back": {
       "dutch": "Terug",
@@ -153,8 +142,7 @@
       "mandarin": "返回",
       "portuguese": "Voltar",
       "spanish": "Atrás",
-      "turkish": "Geri",
-      "russian": "Назад"
+      "turkish": "Geri"
     },
     "external.connect": {
       "dutch": "Ga verder met een portemonnee",
@@ -164,10 +152,9 @@
       "japanese": "ウォレットを続ける",
       "korean": "지갑으로 계속하기",
       "mandarin": "继续使用钱包",
-      "portuguese": "Continuar com carteira",
+      "portuguese": "Continuar com uma carteira",
       "spanish": "Conectar con la billetera",
-      "turkish": "Cüzdanla devam et",
-      "russian": "Продолжить с кошельком"
+      "turkish": "Cüzdanla devam et"
     },
     "external.connect-wallet": {
       "dutch": "Verbinden met portemonnee",
@@ -179,8 +166,7 @@
       "mandarin": "连接钱包",
       "portuguese": "Conectar carteira",
       "spanish": "Conectar billetera",
-      "turkish": "Cüzdanı Bağla",
-      "russian": "Подключить кошелек"
+      "turkish": "Cüzdanı Bağla"
     },
     "external.continue": {
       "dutch": "Ga verder met externe portemonnee",
@@ -192,8 +178,7 @@
       "mandarin": "继续使用外部钱包",
       "portuguese": "Continuar com carteira externa",
       "spanish": "Continuar con billetera externa",
-      "turkish": "Harici cüzdanla devam et",
-      "russian": "Продолжить с внешним кошельком"
+      "turkish": "Harici cüzdanla devam et"
     },
     "external.continue-custom": {
       "dutch": "Doorgaan met {{wallet}}",
@@ -205,8 +190,7 @@
       "mandarin": "继续使用{{wallet}}",
       "portuguese": "Continue com o {{wallet}}",
       "spanish": "Continuar con {{wallet}}",
-      "turkish": "{{wallet}} ile devam et",
-      "russian": "Продолжить с {{wallet}}"
+      "turkish": "{{wallet}} ile devam et"
     },
     "external.dont-have": {
       "dutch": "Heb niet",
@@ -218,8 +202,7 @@
       "mandarin": "没有",
       "portuguese": "Não tem",
       "spanish": "No tiene",
-      "turkish": "Yok",
-      "russian": "Нет"
+      "turkish": "Yok"
     },
     "external.get": {
       "dutch": "Krijgen",
@@ -231,8 +214,7 @@
       "mandarin": "获取",
       "portuguese": "Obter",
       "spanish": "Obtener",
-      "turkish": "Al",
-      "russian": "Получить"
+      "turkish": "Al"
     },
     "external.get-wallet": {
       "dutch": "Portemonnee krijgen",
@@ -244,8 +226,7 @@
       "mandarin": "获取钱包",
       "portuguese": "Obter carteira",
       "spanish": "Obtener billetera",
-      "turkish": "Cüzdan Al",
-      "russian": "Получить кошелек"
+      "turkish": "Cüzdan Al"
     },
     "external.install-browser-extension": {
       "dutch": "{{browser}}-extensie installeren",
@@ -256,8 +237,7 @@
       "mandarin": "安装{{browser}}扩展",
       "portuguese": "Instalar extensão {{browser}}",
       "spanish": "Instalar extensión {{browser}}",
-      "turkish": "{{browser}} uzantısını yükle",
-      "russian": "Установите расширение {{browser}}"
+      "turkish": "{{browser}} uzantısını yükle"
     },
     "external.install-mobile-app": {
       "dutch": "Installeer {{os}}-app",
@@ -268,8 +248,7 @@
       "mandarin": "安装{{os}}应用",
       "portuguese": "Instalar aplicativo {{os}}",
       "spanish": "Instalar aplicación {{os}}",
-      "turkish": "{{os}} uygulamasını yükle",
-      "russian": "Установите приложение {{os}}"
+      "turkish": "{{os}} uygulamasını yükle"
     },
     "external.installed": {
       "dutch": "Geïnstalleerd",
@@ -281,8 +260,7 @@
       "mandarin": "已安装",
       "portuguese": "Instalado",
       "spanish": "Instalado",
-      "turkish": "Yüklendi",
-      "russian": "Установлено"
+      "turkish": "Yüklendi"
     },
     "external.no-wallets-found": {
       "dutch": "Geen portefeuilles gevonden",
@@ -294,8 +272,7 @@
       "mandarin": "没有找到钱包",
       "portuguese": "Nenhuma carteira encontrada",
       "spanish": "No se encontraron billeteras",
-      "turkish": "Cüzdan bulunamadı",
-      "russian": "Кошельки не найдены"
+      "turkish": "Cüzdan bulunamadı"
     },
     "external.search-subtext": {
       "dutch": "Probeer in plaats daarvan te zoeken",
@@ -307,8 +284,7 @@
       "mandarin": "尝试改为搜索",
       "portuguese": "Tente pesquisar",
       "spanish": "Intenta buscar en su lugar",
-      "turkish": "Bunun yerine aramayı deneyin",
-      "russian": "Попробуйте поиск"
+      "turkish": "Bunun yerine aramayı deneyin"
     },
     "external.search-text": {
       "dutch": "Ziet u uw portemonnee niet?",
@@ -320,8 +296,7 @@
       "mandarin": "没看到你的钱包吗？",
       "portuguese": "Não vê sua carteira?",
       "spanish": "¿No ves tu billetera?",
-      "turkish": "Cüzdanınızı görmüyor musunuz?",
-      "russian": "Не видите ваш кошелек?"
+      "turkish": "Cüzdanınızı görmüyor musunuz?"
     },
     "external.search-wallet": {
       "dutch": "Zoeken door {{count}} portemonnees...",
@@ -333,8 +308,7 @@
       "mandarin": "搜索{{count}}个钱包...",
       "portuguese": "Pesquisar através de {{count}} carteiras...",
       "spanish": "Buscar a través de {{count}} billeteras...",
-      "turkish": "{{count}} cüzdan ara...",
-      "russian": "Поиск среди {{count}} кошельков..."
+      "turkish": "{{count}} cüzdan ara..."
     },
     "external.select-chain": {
       "dutch": "Ketting selecteren",
@@ -346,8 +320,7 @@
       "mandarin": "选择链",
       "portuguese": "Selecionar cadeia",
       "spanish": "Seleccionar cadena",
-      "turkish": "Zincir seç",
-      "russian": "Выберите цепочку"
+      "turkish": "Zincir seç"
     },
     "external.select-chain-description": {
       "dutch": "Deze {{wallet}} portemonnee ondersteunt meerdere ketens. Selecteer welke ketting u wilt verbinden",
@@ -359,8 +332,7 @@
       "mandarin": "这个 {{wallet}} 钱包支持多种链。选择您想要连接的链",
       "portuguese": "Este {{wallet}} carteira suporta várias cadeias. Selecione a cadeia que você gostaria de conectar",
       "spanish": "Este {{wallet}} billetera soporta varias cadenas. Seleccione la cadena que desea conectar",
-      "turkish": "Bu {{wallet}} cüzdan birden fazla zincir destekler. İstediğiniz zinciri seçin",
-      "russian": "Этот кошелек {{wallet}} поддерживает несколько цепочек. Выберите цепочку для подключения"
+      "turkish": "Bu {{wallet}} cüzdan birden fazla zincir destekler. İstediğiniz zinciri seçin"
     },
     "external.title": {
       "dutch": "Externe portemonnee",
@@ -372,8 +344,7 @@
       "mandarin": "外部钱包",
       "portuguese": "Carteira Externa",
       "spanish": "Billetera Externa",
-      "turkish": "Harici Cüzdan",
-      "russian": "Внешний кошелек"
+      "turkish": "Harici Cüzdan"
     },
     "external.walletconnect-connect": {
       "dutch": "Verbinden",
@@ -385,8 +356,7 @@
       "mandarin": "连接",
       "portuguese": "Conectar",
       "spanish": "Conectar",
-      "turkish": "Bağla",
-      "russian": "Подключить"
+      "turkish": "Bağla"
     },
     "external.walletconnect-copy": {
       "dutch": "Scan de QR-code met een WalletConnect-compatibele portemonnee of klik op de QR-code om de link naar je klembord te kopiëren.",
@@ -398,8 +368,7 @@
       "mandarin": "使用支持 WalletConnect 的钱包扫描 QR 码或点击复制链接",
       "portuguese": "Digitalize o código QR com uma carteira compatível com WalletConnect ou clique para copiar o link",
       "spanish": "Escanee el código QR con una billetera compatible con WalletConnect o haga clic para copiar el enlace",
-      "turkish": "WalletConnect destekli bir cüzdanla QR kodu tarayın veya bağlantıyı kopyalayın",
-      "russian": "Отсканируйте QR-код кошельком, поддерживающим WalletConnect, или нажмите, чтобы скопировать ссылку"
+      "turkish": "WalletConnect destekli bir cüzdanla QR kodu tarayın veya bağlantıyı kopyalayın"
     },
     "external.walletconnect-subtitle": {
       "dutch": "Scan de QR-code met een WalletConnect-compatibele portemonnee",
@@ -411,8 +380,7 @@
       "mandarin": "使用兼容 WalletConnect 的钱包扫描 QR 码",
       "portuguese": "Digitalize o código QR com uma carteira compatível com WalletConnect",
       "spanish": "Escanear el código QR con una billetera compatible con WalletConnect",
-      "turkish": "QR kodunu WalletConnect uyumlu bir cüzdanla tarayın",
-      "russian": "Отсканируйте QR-код совместимым с WalletConnect кошельком"
+      "turkish": "QR kodunu WalletConnect uyumlu bir cüzdanla tarayın"
     },
     "footer.and": {
       "dutch": "en",
@@ -424,8 +392,7 @@
       "mandarin": "和",
       "portuguese": "e",
       "spanish": "y",
-      "turkish": "ve",
-      "russian": "и"
+      "turkish": "ve"
     },
     "footer.by-signing-in": {
       "dutch": "Door in te loggen, gaat u akkoord met onze",
@@ -437,8 +404,7 @@
       "mandarin": "登录即表示您同意我们的",
       "portuguese": "Ao se conectar, você concorda com nossos",
       "spanish": "Al iniciar sesión, acepta nuestros",
-      "turkish": "Giriş yapmak, bizimle ilgili şartları kabul ettiğiniz anlamına gelir.",
-      "russian": "Войдя, вы соглашаетесь с нашими"
+      "turkish": "Giriş yapmak, bizimle ilgili şartları kabul ettiğiniz anlamına gelir."
     },
     "footer.message": {
       "dutch": "Zelfbeheerde login door",
@@ -450,8 +416,7 @@
       "mandarin": "自托管登录由",
       "portuguese": "Login de autocustódia por",
       "spanish": "Inicio de sesión con autocustodia por",
-      "turkish": "Öz-yönetimli giriş yapan:",
-      "russian": "Самостоятельный вход через"
+      "turkish": "Öz-yönetimli giriş yapan:"
     },
     "footer.message-new": {
       "dutch": "Zelfkusten via",
@@ -463,8 +428,7 @@
       "mandarin": "自我castody通过",
       "portuguese": "Autoconfiança via",
       "spanish": "Autocustodia a través de",
-      "turkish": "Kendi kendine velayet",
-      "russian": "Самостоятельное хранение через"
+      "turkish": "Kendi kendine velayet"
     },
     "footer.policy": {
       "dutch": "Privacybeleid",
@@ -476,8 +440,7 @@
       "mandarin": "隐私政策",
       "portuguese": "Política de Privacidade",
       "spanish": "Política de privacidad",
-      "turkish": "Gizlilik Politikası",
-      "russian": "Политика конфиденциальности"
+      "turkish": "Gizlilik Politikası"
     },
     "footer.privacy-policy": {
       "dutch": "Privacy Policy",
@@ -489,8 +452,7 @@
       "mandarin": "隐私政策",
       "portuguese": "Política de privacidade",
       "spanish": "Política de privacidad",
-      "turkish": "Gizlilik Politikası",
-      "russian": "Политика конфиденциальности"
+      "turkish": "Gizlilik Politikası"
     },
     "footer.terms": {
       "dutch": "Gebruiksvoorwaarden",
@@ -502,8 +464,7 @@
       "mandarin": "使用条款",
       "portuguese": "Termos de Uso",
       "spanish": "Términos de Uso",
-      "turkish": "Kullanım Şartları",
-      "russian": "Условия использования"
+      "turkish": "Kullanım Şartları"
     },
     "footer.terms-of-service": {
       "dutch": "Gebruiksvoorwaarden",
@@ -515,8 +476,7 @@
       "mandarin": "使用条款",
       "portuguese": "Termos de uso",
       "spanish": "Términos de uso",
-      "turkish": "Kullanım Şartları",
-      "russian": "Условия обслуживания"
+      "turkish": "Kullanım Şartları"
     },
     "footer.terms-service": {
       "dutch": "Gebruiksvoorwaarden",
@@ -528,21 +488,19 @@
       "mandarin": "服务条款",
       "portuguese": "Termos de Serviço",
       "spanish": "Términos de servicio",
-      "turkish": "Hizmet Şartları",
-      "russian": "Условия обслуживания"
+      "turkish": "Hizmet Şartları"
     },
     "footer.version": {
       "dutch": "Versie",
       "english": "Version",
       "french": "Version",
-      "german": "Versión",
+      "german": "Versión",
       "japanese": "バージョン",
       "korean": "버전",
       "mandarin": "版本",
       "portuguese": "Versão",
       "spanish": "Versión",
-      "turkish": "Versiyon",
-      "russian": "Версия"
+      "turkish": "Versiyon"
     },
     "getWallet": {
       "dutch": "Portemonnee ophalen",
@@ -554,8 +512,7 @@
       "mandarin": "获取钱包",
       "portuguese": "Obter carteira",
       "spanish": "Obtener billetera",
-      "turkish": "Cüzdanı al",
-      "russian": "Получить кошелек"
+      "turkish": "Cüzdanı al"
     },
     "header-subtitle": {
       "dutch": "Selecteer een van de volgende opties om door te gaan",
@@ -567,8 +524,7 @@
       "mandarin": "选择以下选项以继续",
       "portuguese": "Selecione uma das seguintes opções para continuar",
       "spanish": "Seleccione una de las siguientes opciones para continuar",
-      "turkish": "Devam etmek için seçeneklerden birini işaretle",
-      "russian": "Выберите один из следующих вариантов, чтобы продолжить"
+      "turkish": "Devam etmek için seçeneklerden birini işaretle"
     },
     "header-subtitle-name": {
       "dutch": "Uw {{appName}}-portemonnee met één klik",
@@ -580,8 +536,7 @@
       "mandarin": "一键点击您的 {{appName}} 钱包",
       "portuguese": "Sua carteira {{appName}} com um clique",
       "spanish": "Su billetera {{appName}} con un solo clic",
-      "turkish": "Tek tıklama ile {{appName}} cüzdanınız",
-      "russian": "Ваш кошелек {{appName}} в один клик"
+      "turkish": "Tek tıklama ile {{appName}} cüzdanınız"
     },
     "header-subtitle-new": {
       "dutch": "Uw blockchain-portemonnee met één klik",
@@ -593,8 +548,7 @@
       "mandarin": "一键点击您的区块链钱包",
       "portuguese": "Sua carteira de blockchain com um clique",
       "spanish": "Su billetera blockchain con un solo clic",
-      "turkish": "Tek tıklama ile blockchain cüzdanınız",
-      "russian": "Ваш блокчейн-кошелек в один клик"
+      "turkish": "Tek tıklama ile blockchain cüzdanınız"
     },
     "header-title": {
       "dutch": "Aanmelden",
@@ -606,8 +560,7 @@
       "mandarin": "登录",
       "portuguese": "Entrar",
       "spanish": "Iniciar sesión",
-      "turkish": "Giriş yap",
-      "russian": "Войти"
+      "turkish": "Giriş yap"
     },
     "header-tooltip-desc": {
       "dutch": "De portemonnee dient als een account om uw digitale activa op de blockchain op te slaan en te beheren.",
@@ -619,8 +572,7 @@
       "mandarin": "钱包作为一个账户用于在区块链上存储和管理您的数字资产。",
       "portuguese": "A carteira serve como uma conta para armazenar e gerenciar seus ativos digitais na blockchain.",
       "spanish": "La billetera sirve como una cuenta para almacenar y administrar sus activos digitales en la blockchain.",
-      "turkish": "Cüzdan, dijital varlıklarınızı blockchain'de saklama ve yönetme görevi görür.",
-      "russian": "Кошелек служит аккаунтом для хранения и управления цифровыми активами в блокчейне."
+      "turkish": "Cüzdan, dijital varlıklarınızı blockchain'de saklama ve yönetme görevi görür."
     },
     "header-tooltip-title": {
       "dutch": "Portemonnee",
@@ -632,8 +584,7 @@
       "mandarin": "钱包",
       "portuguese": "Carteira",
       "spanish": "Billetera",
-      "turkish": "Cüzdan",
-      "russian": "Кошелек"
+      "turkish": "Cüzdan"
     },
     "network.add-request": {
       "dutch": "Deze site vraagt om een netwerk toe te voegen",
@@ -645,8 +596,7 @@
       "mandarin": "此站点正在请求添加网络",
       "portuguese": "Este site está solicitando adicionar uma rede",
       "spanish": "Este sitio está solicitando agregar una red",
-      "turkish": "Bu site bir ağ eklemek istiyor",
-      "russian": "Этот сайт запрашивает добавление сети"
+      "turkish": "Bu site bir ağ eklemek istiyor"
     },
     "network.cancel": {
       "dutch": "Annuleren",
@@ -658,8 +608,7 @@
       "mandarin": "取消",
       "portuguese": "Cancelar",
       "spanish": "Cancelar",
-      "turkish": "İptal",
-      "russian": "Отмена"
+      "turkish": "İptal"
     },
     "network.from": {
       "dutch": "Van",
@@ -671,8 +620,7 @@
       "mandarin": "从",
       "portuguese": "De",
       "spanish": "De",
-      "turkish": "Nereden",
-      "russian": "От"
+      "turkish": "Nereden"
     },
     "network.proceed": {
       "dutch": "Doorgaan",
@@ -684,8 +632,7 @@
       "mandarin": "继续",
       "portuguese": "Prosseguir",
       "spanish": "Continuar",
-      "turkish": "Devam",
-      "russian": "Продолжить"
+      "turkish": "Devam"
     },
     "network.switch-request": {
       "dutch": "Deze site vraagt om over te schakelen naar een ander netwerk",
@@ -697,8 +644,7 @@
       "mandarin": "此站点正在请求切换网络",
       "portuguese": "Este site está solicitando trocar de rede",
       "spanish": "Este sitio está solicitando cambiar de red",
-      "turkish": "Bu site ağ değiştirmeyi talep ediyor",
-      "russian": "Этот сайт запрашивает переключение сети"
+      "turkish": "Bu site ağ değiştirmeyi talep ediyor"
     },
     "network.to": {
       "dutch": "Naar",
@@ -710,8 +656,7 @@
       "mandarin": "至",
       "portuguese": "Para",
       "spanish": "A",
-      "turkish": "Nereye",
-      "russian": "К"
+      "turkish": "Nereye"
     },
     "otp.email-subtext": {
       "dutch": "Voer de 6-cijferige verificatiecode in",
@@ -723,8 +668,7 @@
       "mandarin": "请输入6位验证码",
       "portuguese": "Por favor, insira o código de verificação de 6 dígitos",
       "spanish": "Por favor, ingrese el código de verificación de 6 dígitos",
-      "turkish": "6 haneli doğrulama kodunu giriniz",
-      "russian": "Пожалуйста, введите 6-значный код подтверждения"
+      "turkish": "6 haneli doğrulama kodunu giriniz"
     },
     "otp.email-subtext-example": {
       "dutch": "{{email}} adres is verstuurd",
@@ -736,8 +680,7 @@
       "mandarin": "{{email}} 发送的",
       "portuguese": "que foi enviado para o seu email {{email}}",
       "spanish": "que fue enviado a su email {{email}}",
-      "turkish": "{{email}} adresine gönderildi",
-      "russian": "который был отправлен на вашу почту {{email}}"
+      "turkish": "{{email}} adresine gönderildi"
     },
     "otp.email-title": {
       "dutch": "Email Verificatie",
@@ -749,8 +692,7 @@
       "mandarin": "电子邮件验证",
       "portuguese": "Verificação de email",
       "spanish": "Verificación de email",
-      "turkish": "Email Doğrulama",
-      "russian": "Проверка электронной почты"
+      "turkish": "Email Doğrulama"
     },
     "otp.mobile-subtext": {
       "dutch": "OTP Verificatie",
@@ -762,8 +704,7 @@
       "mandarin": "输入 OTP 验证",
       "portuguese": "Verifique o OTP enviado para",
       "spanish": "Verificación OTP",
-      "turkish": "OTP Doğrulama",
-      "russian": "Введите OTP, отправленный на"
+      "turkish": "OTP Doğrulama"
     },
     "otp.mobile-title": {
       "dutch": "OTP Verificatie",
@@ -775,8 +716,7 @@
       "mandarin": "OTP 验证",
       "portuguese": "Verificação OTP",
       "spanish": "Verificación OTP",
-      "turkish": "OTP Doğrulama",
-      "russian": "Проверка OTP"
+      "turkish": "OTP Doğrulama"
     },
     "otp.success": {
       "dutch": "U bent verbonden met uw account!",
@@ -788,8 +728,7 @@
       "mandarin": "您已连接到您的帐户！",
       "portuguese": "Você está conectado ao seu conta!",
       "spanish": "¡Estás conectado a tu cuenta!",
-      "turkish": "Hesabınıza bağlandınız!",
-      "russian": "Вы вошли в аккаунт!"
+      "turkish": "Hesabınıza bağlandınız!"
     },
     "passkey.add": {
       "dutch": "Passkey toevoegen",
@@ -801,21 +740,19 @@
       "mandarin": "添加Passkey",
       "portuguese": "Adicionar Passkey",
       "spanish": "Añadir Passkey",
-      "turkish": "Passkey ekle",
-      "russian": "Добавить Passkey"
+      "turkish": "Passkey ekle"
     },
     "passkey.haveExisting": {
       "dutch": "Heeft u een bestaande passkey?",
       "english": "Have an existing passkey?",
-      "french": "Vous disposez déjà d'un passkey ?",
+      "french": "Vous disposez déjà d'un passkey ?",
       "german": "Haben Sie bereits einen passkey?",
       "japanese": "既存の passkey をお持ちですか?",
       "korean": "기존 passkey가 있나요?",
       "mandarin": "已有 passkey 吗？",
       "portuguese": "Você já possui um passkey?",
       "spanish": "¿Tiene un passkey existente?",
-      "turkish": "Mevcut bir passkey'ınız mı var?",
-      "russian": "У вас уже есть passkey?"
+      "turkish": "Mevcut bir passkey'ınız mı var?"
     },
     "passkey.learn-more": {
       "dutch": "Kom meer te weten",
@@ -827,8 +764,7 @@
       "mandarin": "了解更多",
       "portuguese": "Saber mais",
       "spanish": "Aprende más",
-      "turkish": "Daha fazla bilgi edin",
-      "russian": "Узнать больше"
+      "turkish": "Daha fazla bilgi edin"
     },
     "passkey.or": {
       "dutch": "of",
@@ -840,8 +776,7 @@
       "mandarin": "或者",
       "portuguese": "ou",
       "spanish": "o",
-      "turkish": "veya",
-      "russian": "или"
+      "turkish": "veya"
     },
     "passkey.register-desc": {
       "dutch": "Met passkeys kunt u uw identiteit verifiëren via uw gezicht, vingerafdruk of beveiligingssleutels.",
@@ -853,8 +788,7 @@
       "mandarin": "使用passkeys，您可以通过面部、指纹或安全密钥验证您的身份。",
       "portuguese": "Com passkeys, você pode verificar sua identidade por meio de seu rosto, impressão digital ou chaves de segurança.",
       "spanish": "Con passkeys, puedes verificar tu identidad a través de tu rostro, huella digital o claves de seguridad.",
-      "turkish": "passkeys ile kimliğinizi yüzünüz, parmak iziniz veya güvenlik anahtarlarınız aracılığıyla doğrulayabilirsiniz.",
-      "russian": "С помощью passkeys вы можете подтвердить свою личность по лицу, отпечатку пальца или ключам безопасности."
+      "turkish": "passkeys ile kimliğinizi yüzünüz, parmak iziniz veya güvenlik anahtarlarınız aracılığıyla doğrulayabilirsiniz."
     },
     "passkey.register-title": {
       "dutch": "Registreer Passkey",
@@ -866,8 +800,7 @@
       "mandarin": "注册Passkey",
       "portuguese": "Registre-se Passkey",
       "spanish": "Registrarse Passkey",
-      "turkish": "Passkey'ı kaydedin",
-      "russian": "Зарегистрировать Passkey"
+      "turkish": "Passkey'ı kaydedin"
     },
     "passkey.use": {
       "dutch": "Ik heb een passkey",
@@ -879,8 +812,7 @@
       "mandarin": "我有一个Passkey",
       "portuguese": "Eu tenho uma passkey",
       "spanish": "Tengo una Passkey",
-      "turkish": "Bir passkey'im var",
-      "russian": "У меня есть passkey"
+      "turkish": "Bir passkey'im var"
     },
     "passwordless.title": {
       "dutch": "Doorgaan met {{title}}",
@@ -892,8 +824,7 @@
       "mandarin": "继续使用 {{title}}",
       "portuguese": "Continuar com {{title}}",
       "spanish": "Continuar con {{title}}",
-      "turkish": "{{title}} ile devam et",
-      "russian": "Продолжить с {{title}}"
+      "turkish": "{{title}} ile devam et"
     },
     "popup.phone-body": {
       "dutch": "Uw landcode wordt automatisch gedetecteerd, maar als u een telefoonnummer uit een ander land gebruikt, moet u handmatig de juiste landcode invoeren.",
@@ -905,8 +836,7 @@
       "mandarin": "您的国家代码将自动检测到，但如果您使用其他国家/地区的电话号码，您需要手动输入正确的国家代码。",
       "portuguese": "O código do seu país será detectado automaticamente, mas se estiver usando um número de telefone de um país diferente, você precisará inserir manualmente o código correto do país.",
       "spanish": "Su código de país se detectará automáticamente, pero si está utilizando un número de teléfono de otro país, deberá ingresar manualmente el código de país correcto.",
-      "turkish": "Ülke kodunuz otomatik olarak algılanacaktır, ancak farklı bir ülkeden bir telefon numarası kullanıyorsanız, doğru ülke kodunu manuel olarak girmeniz gerekir.",
-      "russian": "Код вашей страны будет определён автоматически, но если вы используете номер из другой страны, вам нужно вручную ввести правильный код страны."
+      "turkish": "Ülke kodunuz otomatik olarak algılanacaktır, ancak farklı bir ülkeden bir telefon numarası kullanıyorsanız, doğru ülke kodunu manuel olarak girmeniz gerekir."
     },
     "popup.phone-header": {
       "dutch": "Telefoonnummer en landcode",
@@ -918,8 +848,7 @@
       "mandarin": "电话号码和国家代码",
       "portuguese": "Número de telefone e código do país",
       "spanish": "Número de teléfono y código de país",
-      "turkish": "Telefon numarası ve ülke kodu",
-      "russian": "Номер телефона и код страны"
+      "turkish": "Telefon numarası ve ülke kodu"
     },
     "post-loading.connected": {
       "dutch": "U bent verbonden met uw account",
@@ -931,8 +860,7 @@
       "mandarin": "您与您的帐户有联系",
       "portuguese": "Você está conectado com sua conta",
       "spanish": "Estás conectado con tu cuenta",
-      "turkish": "Hesabınızla bağlandınız",
-      "russian": "Вы подключены к своему аккаунту"
+      "turkish": "Hesabınızla bağlandınız"
     },
     "post-loading.something-wrong": {
       "dutch": "Er is iets fout gegaan!",
@@ -944,8 +872,7 @@
       "mandarin": "出了些问题！",
       "portuguese": "Algo deu errado!",
       "spanish": "¡Algo salió mal!",
-      "turkish": "Bir şeyler ters gitti!",
-      "russian": "Что-то пошло не так!"
+      "turkish": "Bir şeyler ters gitti!"
     },
     "resendCode": {
       "dutch": "Code opnieuw verzenden",
@@ -957,8 +884,7 @@
       "mandarin": "重新发送代码",
       "portuguese": "Reenviar código",
       "spanish": "Reenviar código",
-      "turkish": "Kodu tekrar gönder",
-      "russian": "Отправить код повторно"
+      "turkish": "Kodu tekrar gönder"
     },
     "resendTimer": {
       "dutch": " Opnieuw verzenden in {{timer}} seconden",
@@ -970,8 +896,7 @@
       "mandarin": " {{timer}} 秒后重新发送",
       "portuguese": " Reenviar em {{timer}} segundos",
       "spanish": " Reenviar en {{timer}} segundos",
-      "turkish": " {{timer}} saniye sonra tekrar gönder",
-      "russian": " Повторно отправить через {{timer}} секунд"
+      "turkish": " {{timer}} saniye sonra tekrar gönder"
     },
     "social.continue": {
       "dutch": "Doorgaan met",
@@ -983,8 +908,7 @@
       "mandarin": "继续",
       "portuguese": "Continuar com",
       "spanish": "Continuar con",
-      "turkish": "Devam et: ",
-      "russian": "Продолжить с"
+      "turkish": "Devam et: "
     },
     "social.continueCustom": {
       "dutch": "Doorgaan met {{adapter}}",
@@ -996,8 +920,7 @@
       "mandarin": "继续使用{{adapter}}",
       "portuguese": "Continue com o {{adapter}}",
       "spanish": "Continuar con {{adapter}}",
-      "turkish": "{{adapter}} ile devam et",
-      "russian": "Продолжить с {{adapter}}"
+      "turkish": "{{adapter}} ile devam et"
     },
     "social.email": {
       "dutch": "E-mail",
@@ -1009,8 +932,7 @@
       "mandarin": "电子邮件",
       "portuguese": "Email",
       "spanish": "Correo electrónico",
-      "turkish": "E-posta",
-      "russian": "Электронная почта"
+      "turkish": "E-posta"
     },
     "social.email-continue": {
       "dutch": "Doorgaan met e-mail",
@@ -1022,8 +944,7 @@
       "mandarin": "继续使用电子邮件",
       "portuguese": "Continuar com email",
       "spanish": "Continuar con correo electrónico",
-      "turkish": "E-posta ile devam et",
-      "russian": "Продолжить с электронной почтой"
+      "turkish": "E-posta ile devam et"
     },
     "social.email-new": {
       "dutch": "naam@voorbeeld.com",
@@ -1035,8 +956,7 @@
       "mandarin": "name@example.com",
       "portuguese": "nome@exemplo.com",
       "spanish": "nombre@ejemplo.com",
-      "turkish": "isim@ornek.com",
-      "russian": "имя@пример.com"
+      "turkish": "isim@ornek.com"
     },
     "social.passwordless-cta": {
       "dutch": "Doorgaan",
@@ -1048,8 +968,7 @@
       "mandarin": "继续",
       "portuguese": "Continuar",
       "spanish": "Continuar",
-      "turkish": "Devam et",
-      "russian": "Продолжить"
+      "turkish": "Devam et"
     },
     "social.passwordless-login": {
       "dutch": "Log in",
@@ -1061,8 +980,7 @@
       "mandarin": "登录",
       "portuguese": "Conecte-se",
       "spanish": "Acceso",
-      "turkish": "Giriş yapmak",
-      "russian": "Вход"
+      "turkish": "Giriş yapmak"
     },
     "social.passwordless-title": {
       "dutch": "E-mail/Telefoon",
@@ -1074,8 +992,7 @@
       "mandarin": "电子邮件/电话",
       "portuguese": "Email/Telefone",
       "spanish": "Email/Teléfono",
-      "turkish": "E-posta/Telefon",
-      "russian": "Эл. почта/Телефон"
+      "turkish": "E-posta/Telefon"
     },
     "social.phone": {
       "dutch": "Telefoon",
@@ -1087,8 +1004,7 @@
       "mandarin": "电话",
       "portuguese": "Telefone",
       "spanish": "Teléfono",
-      "turkish": "Telefon",
-      "russian": "Телефон"
+      "turkish": "Telefon"
     },
     "social.policy": {
       "dutch": "We slaan geen gegevens op die verband houden met uw sociale logins.",
@@ -1100,8 +1016,7 @@
       "mandarin": "我们不存储与您的社交登录相关的任何数据。",
       "portuguese": "Não armazenamos nenhum dado relacionado ao seu login por rede social.",
       "spanish": "No almacenamos ningún dato relacionado con sus inicios de sesión sociales.",
-      "turkish": "Sosyal medya girişlerinizle ilgili hiçbir veriyi saklamıyoruz.",
-      "russian": "Мы не храним данные, связанные с вашими социальными входами."
+      "turkish": "Sosyal medya girişlerinizle ilgili hiçbir veriyi saklamıyoruz."
     },
     "social.sign-in": {
       "dutch": "Inloggen",
@@ -1113,8 +1028,7 @@
       "mandarin": "登录",
       "portuguese": "Entrar",
       "spanish": "Iniciar sesión",
-      "turkish": "Giriş yap",
-      "russian": "Войти"
+      "turkish": "Giriş yap"
     },
     "social.sms": {
       "dutch": "Mobiel",
@@ -1126,8 +1040,7 @@
       "mandarin": "移动",
       "portuguese": "Móvel",
       "spanish": "Móvil",
-      "turkish": "Mobil Telefon",
-      "russian": "Мобильный"
+      "turkish": "Mobil Telefon"
     },
     "social.sms-continue": {
       "dutch": "Doorgaan met mobiel",
@@ -1139,8 +1052,7 @@
       "mandarin": "继续使用移动设备",
       "portuguese": "Continuar com o celular",
       "spanish": "Continuar con móvil",
-      "turkish": "Telefon ile devam et",
-      "russian": "Продолжить с мобильного"
+      "turkish": "Telefon ile devam et"
     },
     "social.sms-invalid-number": {
       "dutch": "Ongeldig telefoonnummer",
@@ -1152,8 +1064,7 @@
       "mandarin": "无效的电话号码",
       "portuguese": "Número de telefone inválido",
       "spanish": "Número de teléfono inválido",
-      "turkish": "Geçersiz telefon numarası",
-      "russian": "Неверный номер телефона"
+      "turkish": "Geçersiz telefon numarası"
     },
     "social.sms-placeholder-text": {
       "dutch": "Bijv.:",
@@ -1165,8 +1076,7 @@
       "mandarin": "例如：",
       "portuguese": "Por exemplo:",
       "spanish": "Por ej.:",
-      "turkish": "Örneğin:",
-      "russian": "Напр.:"
+      "turkish": "Örneğin:"
     },
     "social.view-less": {
       "dutch": "Minder bekijken",
@@ -1178,8 +1088,7 @@
       "mandarin": "少查看",
       "portuguese": "Ver menos",
       "spanish": "Ver menos",
-      "turkish": "Daha az görüntüle",
-      "russian": "Показать меньше"
+      "turkish": "Daha az görüntüle"
     },
     "social.view-less-socials": {
       "dutch": "Bekijk minder socials",
@@ -1191,8 +1100,7 @@
       "mandarin": "查看更少socials",
       "portuguese": "Ver menos socials",
       "spanish": "Ver menos socials",
-      "turkish": "Daha az socials görüntüle",
-      "russian": "Показать меньше соцсетей"
+      "turkish": "Daha az socials görüntüle"
     },
     "social.view-more": {
       "dutch": "Meer bekijken",
@@ -1204,8 +1112,7 @@
       "mandarin": "查看更多",
       "portuguese": "Ver mais",
       "spanish": "Ver más",
-      "turkish": "Daha fazla görüntüle",
-      "russian": "Показать больше"
+      "turkish": "Daha fazla görüntüle"
     },
     "social.view-more-socials": {
       "dutch": "Bekijk meer socials",
@@ -1217,8 +1124,7 @@
       "mandarin": "查看更多socials",
       "portuguese": "Ver mais socials",
       "spanish": "Ver más socials",
-      "turkish": "Daha fazlasını görüntüle socials",
-      "russian": "Показать больше соцсетей"
+      "turkish": "Daha fazlasını görüntüle socials"
     }
   },
   "passwordless": {
@@ -1226,14 +1132,13 @@
       "dutch": "Ongeldige verificatielink of link verlopen",
       "english": "Invalid verification link or link expired",
       "french": "Lien de vérification invalide ou lien expiré",
-      "german": "Ungültiger Überprüfungsverbindung of Link ist abgelaufen",
+      "german": "Ungültiger Überprüfungsverbindung oder Link ist abgelaufen",
       "japanese": "無効な検証リンクまたはリンクが期限切れになりました",
       "korean": "유효하지 않은 인증 링크이거나 링크가 만료되었습니다",
       "mandarin": "无效的验证链接或链接已过期",
       "portuguese": "Link de verificação inválido ou link expirado",
-      "spanish": "Enlace de verificación inválido o expirado",
-      "turkish": "Hatalı doğrulama linki veya linkin süresi dolmuş",
-      "russian": "Неверная ссылка для проверки или ссылка истекла"
+      "spanish": "El enlace o el enlace de verificación ha expirado",
+      "turkish": "Hatalı ya da süresi geçmiş doğrulama linki"
     },
     "error-invalid-origin": {
       "dutch": "Er is iets misgegaan, foutcode: E002",
@@ -1245,8 +1150,7 @@
       "mandarin": "出问题了, 错误代码: E002",
       "portuguese": "Algo deu errado, código de erro: E002",
       "spanish": "Algo salió mal, código de error: E002",
-      "turkish": "Bir şeyler ters gitti, hata kodu: E002",
-      "russian": "Что-то пошло не так, код ошибки: E002"
+      "turkish": "Bir şeyler ters gitti, hata kodu: E002"
     },
     "error-invalid-otp": {
       "dutch": "Ongeldige OTP, probeer het opnieuw",
@@ -1258,8 +1162,7 @@
       "mandarin": "无效的OTP，请重试",
       "portuguese": "OTP inválido, por favor tente novamente",
       "spanish": "OTP no válido, intente nuevamente",
-      "turkish": "Hatalı OTP, lütfen tekrar deneyin.",
-      "russian": "Неверный OTP, пожалуйста, попробуйте снова"
+      "turkish": "Hatalı OTP, lütfen tekrar deneyin."
     },
     "error-invalid-params": {
       "dutch": "Ontbrekende of ongeldige parameters",
@@ -1271,8 +1174,7 @@
       "mandarin": "缺失或无效参数",
       "portuguese": "Parâmetros ausentes ou inválidos",
       "spanish": "Parámetros faltantes o no válidos",
-      "turkish": "Eksik ya da hatalı parametreler var.",
-      "russian": "Отсутствуют или недействительны параметры."
+      "turkish": "Eksik ya da hatalı parametreler var."
     },
     "error-max-retry-limit-reached": {
       "dutch": "U heeft de limiet voor verkeerde pogingen bereikt. Start de stroom opnieuw om de verificatie te voltooien.",
@@ -1284,8 +1186,7 @@
       "mandarin": "您已经达到了错误的尝试的极限。请再次重新启动流程以完成验证。",
       "portuguese": "Você atingiu o limite para tentativas erradas. Reinicie o fluxo novamente para concluir a verificação.",
       "spanish": "Has alcanzado el límite para intentos incorrectos. Reinicie el proceso para completar la verificación.",
-      "turkish": "Hatalı deneme limitine ulaştınız. Doğrulamayı tamamlamak için lütfen akışı baştan başlatın.",
-      "russian": "Вы достигли лимита неверных попыток. Пожалуйста, перезапустите процесс, чтобы завершить проверку."
+      "turkish": "Hatalı deneme limitine ulaştınız. Doğrulamayı tamamlamak için lütfen akışı baştan başlatın."
     },
     "error-new-link-generated-heading": {
       "dutch": "Nieuwe verificatielink gegenereerd",
@@ -1297,8 +1198,7 @@
       "mandarin": "生成的新验证链接",
       "portuguese": "Novo link de verificação gerado",
       "spanish": "Nuevo enlace de verificación generado",
-      "turkish": "Yeni doğrulama linki oluşturuldu.",
-      "russian": "Создана новая ссылка для проверки"
+      "turkish": "Yeni doğrulama linki oluşturuldu."
     },
     "error-no-mail-generated": {
       "dutch": "Geen e-mail gegenereerd. Start eerst de wachtwoordloze flow.",
@@ -1310,8 +1210,7 @@
       "mandarin": "没有生成邮件。请先启动无密码流。",
       "portuguese": "Nenhum correio gerado. Inicie o fluxo sem senha primeiro.",
       "spanish": "No se generó el correo. Inicie primero el proceso sin contraseña.",
-      "turkish": "E-posta oluşturulmadı. Lütfen önce şifresiz akışı başlatın.",
-      "russian": "Письмо не было создано. Пожалуйста, сначала запустите безпарольный поток."
+      "turkish": "E-posta oluşturulmadı. Lütfen önce şifresiz akışı başlatın."
     },
     "error-no-sms-generated": {
       "dutch": "Geen OTP gegenereerd. Start eerst de wachtwoordloze flow.",
@@ -1323,8 +1222,7 @@
       "mandarin": "没有生成OTP。请先启动无密码流。",
       "portuguese": "Nenhum OTP gerado. Inicie o fluxo sem senha primeiro.",
       "spanish": "No se generó OTP. Inicie primero el proceso sin contraseña.",
-      "turkish": "OTP oluşturulmadı. Lütfen önce şifresiz akışı başlatın.",
-      "russian": "OTP не был создан. Пожалуйста, сначала запустите безпарольный поток."
+      "turkish": "OTP oluşturulmadı. Lütfen önce şifresiz akışı başlatın."
     },
     "error-otp-expired": {
       "dutch": "OTP verlopen",
@@ -1336,8 +1234,7 @@
       "mandarin": "OTP过期",
       "portuguese": "OTP expirou",
       "spanish": "OTP expiró",
-      "turkish": "OTP'nin süresi geçti.",
-      "russian": "OTP истек"
+      "turkish": "OTP'nin süresi geçti."
     },
     "error-plan-limit-reached": {
       "dutch": "E411. Limiet bereikt",
@@ -1349,8 +1246,7 @@
       "mandarin": "E411. 限制已达到",
       "portuguese": "E411. Limite atingido",
       "spanish": "E411. Límite alcanzado",
-      "turkish": "E411. Sınır aşıldı",
-      "russian": "E411. Достигнут предел"
+      "turkish": "E411. Sınır aşıldı"
     },
     "error-recaptcha-verification-failed": {
       "dutch": "Er is iets misgegaan tijdens het verifiëren. Probeer het opnieuw door de pagina te laden.",
@@ -1362,8 +1258,7 @@
       "mandarin": "Captcha 验证失败。请再试一次。",
       "portuguese": "A verificação Captcha falhou. Por favor, tente novamente.",
       "spanish": "La verificación de Captcha ha fallado. Por favor, inténtelo de nuevo.",
-      "turkish": "Captcha doğrulama hatası. Lütfen tekrar deneyin.",
-      "russian": "Проверка Captcha не удалась. Пожалуйста, попробуйте снова."
+      "turkish": "Captcha doğrulama hatası. Lütfen tekrar deneyin."
     },
     "error-sending-sms-failed": {
       "dutch": "Er is een fout opgetreden bij het verzenden van een sms. Probeer het opnieuw.",
@@ -1372,11 +1267,10 @@
       "german": "Es gab einen Fehler beim Senden einer SMS. Bitte versuche es erneut.",
       "japanese": "SMSの送信エラーがありました。もう一度やり直してください。",
       "korean": "SMS 전송 중 오류가 발생했습니다. 다시 시도해 주세요.",
-      "mandarin": "发送短信时出错。请再试一次。",
+      "mandarin": "发送短信的错误。请再试一遍。",
       "portuguese": "Houve um erro de envio de um SMS. Por favor, tente novamente.",
       "spanish": "Hubo un error al enviar el SMS. Inténtalo de nuevo.",
-      "turkish": "SMS gönderilirken bir hata oldu. Lütfen tekrar deneyin.",
-      "russian": "Ошибка при отправке SMS. Пожалуйста, попробуйте снова."
+      "turkish": "SMS gönderilirken bir hata oldu. Lütfen tekrar deneyin."
     },
     "something-wrong-error": {
       "dutch": "Er is iets misgegaan",
@@ -1388,8 +1282,7 @@
       "mandarin": "出问题了",
       "portuguese": "Algo deu errado",
       "spanish": "Algo salió mal",
-      "turkish": "Bir şeyler ters gitti",
-      "russian": "Что-то пошло не так"
+      "turkish": "Bir şeyler ters gitti"
     }
   }
 }

--- a/Web3Auth-locale/locale-common.json
+++ b/Web3Auth-locale/locale-common.json
@@ -10,7 +10,8 @@
       "mandarin": "验证您的{{adapter}}帐户以继续",
       "portuguese": "Verifique a sua conta {{adapter}} para continuar",
       "spanish": "Verifica tu cuenta {{adapter}} para continuar",
-      "turkish": "Devam etmek için {{adapter}} hesabınızı doğrula"
+      "turkish": "Devam etmek için {{adapter}} hesabınızı doğrula",
+      "russian": "Подтвердите ваш аккаунт {{adapter}}, чтобы продолжить"
     },
     "adapter-loader.message1": {
       "dutch": "Verifieer uw {{adapter}}",
@@ -22,7 +23,8 @@
       "mandarin": "在您的{{adapter}}上验证",
       "portuguese": "Verifique o(a) seu/sua {{adapter}}",
       "spanish": "Verifique su {{adapter}}",
-      "turkish": "{{adapter}} doğrula"
+      "turkish": "{{adapter}} doğrula",
+      "russian": "Подтвердите ваш {{adapter}}"
     },
     "adapter-loader.message2": {
       "dutch": "account om door te gaan",
@@ -34,7 +36,8 @@
       "mandarin": "帐号继续",
       "portuguese": "conta para continuar",
       "spanish": "cuenta para continuar",
-      "turkish": "devam edecek hesap"
+      "turkish": "devam edecek hesap",
+      "russian": "аккаунт, чтобы продолжить"
     },
     "allChains": {
       "dutch": "Alle ketens",
@@ -46,7 +49,8 @@
       "mandarin": "所有链",
       "portuguese": "Todas as cadeias",
       "spanish": "Todas las cadenas",
-      "turkish": "Tüm zincirler"
+      "turkish": "Tüm zincirler",
+      "russian": "Все цепочки"
     },
     "connect-wallet.more-wallets": {
       "dutch": "Meer portemonnees",
@@ -58,7 +62,8 @@
       "mandarin": "查看更多钱包",
       "portuguese": "Mais carteiras",
       "spanish": "Más carteras",
-      "turkish": "Daha fazla cüzdan"
+      "turkish": "Daha fazla cüzdan",
+      "russian": "Другие кошельки"
     },
     "connectYourWallet": {
       "dutch": "Uw portemonnee verbinden",
@@ -70,7 +75,8 @@
       "mandarin": "连接您的钱包",
       "portuguese": "Conecte seu portefeuille",
       "spanish": "Conecte su portefeuille",
-      "turkish": "Cüzdanınızı bağlayın"
+      "turkish": "Cüzdanınızı bağlayın",
+      "russian": "Подключите ваш кошелек"
     },
     "errors-invalid-email": {
       "dutch": "Ongeldig e-mailadres",
@@ -82,7 +88,8 @@
       "mandarin": "无效的电子邮件",
       "portuguese": "E-mail inválido",
       "spanish": "Correo electrónico no válido",
-      "turkish": "Geçersiz E-posta"
+      "turkish": "Geçersiz E-posta",
+      "russian": "Неверный адрес электронной почты"
     },
     "errors-invalid-number": {
       "dutch": "Ongeldig telefoonnummer",
@@ -94,7 +101,8 @@
       "mandarin": "电话号码无效",
       "portuguese": "Número de telefone inválido",
       "spanish": "Número de teléfono no válido",
-      "turkish": "Geçersiz Telefon Numarası"
+      "turkish": "Geçersiz Telefon Numarası",
+      "russian": "Неверный номер телефона"
     },
     "errors-invalid-number-email": {
       "dutch": "Ongeldig e-mailadres of telefoonnummer",
@@ -106,7 +114,8 @@
       "mandarin": "无效的电子邮件或电话号码",
       "portuguese": "Email ou número de telefone inválido",
       "spanish": "Correo electrónico o número de teléfono no válido",
-      "turkish": "Geçersiz E-posta veya Telefon Numarası"
+      "turkish": "Geçersiz E-posta veya Telefon Numarası",
+      "russian": "Неверный адрес электронной почты или номер телефона"
     },
     "errors-required": {
       "dutch": "Vereist",
@@ -118,7 +127,8 @@
       "mandarin": "必填",
       "portuguese": "Obrigatório",
       "spanish": "Campo obligatorio",
-      "turkish": "Zorunlu"
+      "turkish": "Zorunlu",
+      "russian": "Обязательно"
     },
     "external.all-wallets": {
       "dutch": "Alle portemonnees",
@@ -130,7 +140,8 @@
       "mandarin": "所有钱包",
       "portuguese": "Todas as carteiras",
       "spanish": "Todas las billeteras",
-      "turkish": "Tüm cüzdanlar"
+      "turkish": "Tüm cüzdanlar",
+      "russian": "Все кошельки"
     },
     "external.back": {
       "dutch": "Terug",
@@ -142,7 +153,8 @@
       "mandarin": "返回",
       "portuguese": "Voltar",
       "spanish": "Atrás",
-      "turkish": "Geri"
+      "turkish": "Geri",
+      "russian": "Назад"
     },
     "external.connect": {
       "dutch": "Ga verder met een portemonnee",
@@ -154,7 +166,8 @@
       "mandarin": "继续使用钱包",
       "portuguese": "Continuar com uma carteira",
       "spanish": "Conectar con la billetera",
-      "turkish": "Cüzdanla devam et"
+      "turkish": "Cüzdanla devam et",
+      "russian": "Продолжить с кошельком"
     },
     "external.connect-wallet": {
       "dutch": "Verbinden met portemonnee",
@@ -166,7 +179,8 @@
       "mandarin": "连接钱包",
       "portuguese": "Conectar carteira",
       "spanish": "Conectar billetera",
-      "turkish": "Cüzdanı Bağla"
+      "turkish": "Cüzdanı Bağla",
+      "russian": "Подключить кошелек"
     },
     "external.continue": {
       "dutch": "Ga verder met externe portemonnee",
@@ -178,7 +192,8 @@
       "mandarin": "继续使用外部钱包",
       "portuguese": "Continuar com carteira externa",
       "spanish": "Continuar con billetera externa",
-      "turkish": "Harici cüzdanla devam et"
+      "turkish": "Harici cüzdanla devam et",
+      "russian": "Продолжить с внешним кошельком"
     },
     "external.continue-custom": {
       "dutch": "Doorgaan met {{wallet}}",
@@ -190,7 +205,8 @@
       "mandarin": "继续使用{{wallet}}",
       "portuguese": "Continue com o {{wallet}}",
       "spanish": "Continuar con {{wallet}}",
-      "turkish": "{{wallet}} ile devam et"
+      "turkish": "{{wallet}} ile devam et",
+      "russian": "Продолжить с {{wallet}}"
     },
     "external.dont-have": {
       "dutch": "Heb niet",
@@ -202,7 +218,8 @@
       "mandarin": "没有",
       "portuguese": "Não tem",
       "spanish": "No tiene",
-      "turkish": "Yok"
+      "turkish": "Yok",
+      "russian": "Нет"
     },
     "external.get": {
       "dutch": "Krijgen",
@@ -214,7 +231,8 @@
       "mandarin": "获取",
       "portuguese": "Obter",
       "spanish": "Obtener",
-      "turkish": "Al"
+      "turkish": "Al",
+      "russian": "Получить"
     },
     "external.get-wallet": {
       "dutch": "Portemonnee krijgen",
@@ -226,7 +244,8 @@
       "mandarin": "获取钱包",
       "portuguese": "Obter carteira",
       "spanish": "Obtener billetera",
-      "turkish": "Cüzdan Al"
+      "turkish": "Cüzdan Al",
+      "russian": "Получить кошелек"
     },
     "external.install-browser-extension": {
       "dutch": "{{browser}}-extensie installeren",
@@ -237,7 +256,8 @@
       "mandarin": "安装{{browser}}扩展",
       "portuguese": "Instalar extensão {{browser}}",
       "spanish": "Instalar extensión {{browser}}",
-      "turkish": "{{browser}} uzantısını yükle"
+      "turkish": "{{browser}} uzantısını yükle",
+      "russian": "Установите расширение {{browser}}"
     },
     "external.install-mobile-app": {
       "dutch": "Installeer {{os}}-app",
@@ -248,7 +268,8 @@
       "mandarin": "安装{{os}}应用",
       "portuguese": "Instalar aplicativo {{os}}",
       "spanish": "Instalar aplicación {{os}}",
-      "turkish": "{{os}} uygulamasını yükle"
+      "turkish": "{{os}} uygulamasını yükle",
+      "russian": "Установите приложение {{os}}"
     },
     "external.installed": {
       "dutch": "Geïnstalleerd",
@@ -260,7 +281,8 @@
       "mandarin": "已安装",
       "portuguese": "Instalado",
       "spanish": "Instalado",
-      "turkish": "Yüklendi"
+      "turkish": "Yüklendi",
+      "russian": "Установлено"
     },
     "external.no-wallets-found": {
       "dutch": "Geen portefeuilles gevonden",
@@ -272,7 +294,8 @@
       "mandarin": "没有找到钱包",
       "portuguese": "Nenhuma carteira encontrada",
       "spanish": "No se encontraron billeteras",
-      "turkish": "Cüzdan bulunamadı"
+      "turkish": "Cüzdan bulunamadı",
+      "russian": "Кошельки не найдены"
     },
     "external.search-subtext": {
       "dutch": "Probeer in plaats daarvan te zoeken",
@@ -284,7 +307,8 @@
       "mandarin": "尝试改为搜索",
       "portuguese": "Tente pesquisar",
       "spanish": "Intenta buscar en su lugar",
-      "turkish": "Bunun yerine aramayı deneyin"
+      "turkish": "Bunun yerine aramayı deneyin",
+      "russian": "Попробуйте поиск"
     },
     "external.search-text": {
       "dutch": "Ziet u uw portemonnee niet?",
@@ -296,7 +320,8 @@
       "mandarin": "没看到你的钱包吗？",
       "portuguese": "Não vê sua carteira?",
       "spanish": "¿No ves tu billetera?",
-      "turkish": "Cüzdanınızı görmüyor musunuz?"
+      "turkish": "Cüzdanınızı görmüyor musunuz?",
+      "russian": "Не видите ваш кошелек?"
     },
     "external.search-wallet": {
       "dutch": "Zoeken door {{count}} portemonnees...",
@@ -308,7 +333,8 @@
       "mandarin": "搜索{{count}}个钱包...",
       "portuguese": "Pesquisar através de {{count}} carteiras...",
       "spanish": "Buscar a través de {{count}} billeteras...",
-      "turkish": "{{count}} cüzdan ara..."
+      "turkish": "{{count}} cüzdan ara...",
+      "russian": "Поиск среди {{count}} кошельков..."
     },
     "external.select-chain": {
       "dutch": "Ketting selecteren",
@@ -320,7 +346,8 @@
       "mandarin": "选择链",
       "portuguese": "Selecionar cadeia",
       "spanish": "Seleccionar cadena",
-      "turkish": "Zincir seç"
+      "turkish": "Zincir seç",
+      "russian": "Выберите цепочку"
     },
     "external.select-chain-description": {
       "dutch": "Deze {{wallet}} portemonnee ondersteunt meerdere ketens. Selecteer welke ketting u wilt verbinden",
@@ -332,7 +359,8 @@
       "mandarin": "这个 {{wallet}} 钱包支持多种链。选择您想要连接的链",
       "portuguese": "Este {{wallet}} carteira suporta várias cadeias. Selecione a cadeia que você gostaria de conectar",
       "spanish": "Este {{wallet}} billetera soporta varias cadenas. Seleccione la cadena que desea conectar",
-      "turkish": "Bu {{wallet}} cüzdan birden fazla zincir destekler. İstediğiniz zinciri seçin"
+      "turkish": "Bu {{wallet}} cüzdan birden fazla zincir destekler. İstediğiniz zinciri seçin",
+      "russian": "Этот кошелек {{wallet}} поддерживает несколько цепочек. Выберите цепочку для подключения"
     },
     "external.title": {
       "dutch": "Externe portemonnee",
@@ -344,7 +372,8 @@
       "mandarin": "外部钱包",
       "portuguese": "Carteira Externa",
       "spanish": "Billetera Externa",
-      "turkish": "Harici Cüzdan"
+      "turkish": "Harici Cüzdan",
+      "russian": "Внешний кошелек"
     },
     "external.walletconnect-connect": {
       "dutch": "Verbinden",
@@ -356,7 +385,8 @@
       "mandarin": "连接",
       "portuguese": "Conectar",
       "spanish": "Conectar",
-      "turkish": "Bağla"
+      "turkish": "Bağla",
+      "russian": "Подключить"
     },
     "external.walletconnect-copy": {
       "dutch": "Scan de QR-code met een WalletConnect-compatibele portemonnee of klik op de QR-code om de link naar je klembord te kopiëren.",
@@ -368,7 +398,8 @@
       "mandarin": "使用支持 WalletConnect 的钱包扫描 QR 码或点击复制链接",
       "portuguese": "Digitalize o código QR com uma carteira compatível com WalletConnect ou clique para copiar o link",
       "spanish": "Escanee el código QR con una billetera compatible con WalletConnect o haga clic para copiar el enlace",
-      "turkish": "WalletConnect destekli bir cüzdanla QR kodu tarayın veya bağlantıyı kopyalayın"
+      "turkish": "WalletConnect destekli bir cüzdanla QR kodu tarayın veya bağlantıyı kopyalayın",
+      "russian": "Отсканируйте QR-код кошельком, поддерживающим WalletConnect, или нажмите, чтобы скопировать ссылку"
     },
     "external.walletconnect-subtitle": {
       "dutch": "Scan de QR-code met een WalletConnect-compatibele portemonnee",
@@ -380,7 +411,8 @@
       "mandarin": "使用兼容 WalletConnect 的钱包扫描 QR 码",
       "portuguese": "Digitalize o código QR com uma carteira compatível com WalletConnect",
       "spanish": "Escanear el código QR con una billetera compatible con WalletConnect",
-      "turkish": "QR kodunu WalletConnect uyumlu bir cüzdanla tarayın"
+      "turkish": "QR kodunu WalletConnect uyumlu bir cüzdanla tarayın",
+      "russian": "Отсканируйте QR-код совместимым с WalletConnect кошельком"
     },
     "footer.and": {
       "dutch": "en",
@@ -392,7 +424,8 @@
       "mandarin": "和",
       "portuguese": "e",
       "spanish": "y",
-      "turkish": "ve"
+      "turkish": "ve",
+      "russian": "и"
     },
     "footer.by-signing-in": {
       "dutch": "Door in te loggen, gaat u akkoord met onze",
@@ -404,7 +437,8 @@
       "mandarin": "登录即表示您同意我们的",
       "portuguese": "Ao se conectar, você concorda com nossos",
       "spanish": "Al iniciar sesión, acepta nuestros",
-      "turkish": "Giriş yapmak, bizimle ilgili şartları kabul ettiğiniz anlamına gelir."
+      "turkish": "Giriş yapmak, bizimle ilgili şartları kabul ettiğiniz anlamına gelir.",
+      "russian": "Войдя, вы соглашаетесь с нашими"
     },
     "footer.message": {
       "dutch": "Zelfbeheerde login door",
@@ -416,7 +450,8 @@
       "mandarin": "自托管登录由",
       "portuguese": "Login de autocustódia por",
       "spanish": "Inicio de sesión con autocustodia por",
-      "turkish": "Öz-yönetimli giriş yapan:"
+      "turkish": "Öz-yönetimli giriş yapan:",
+      "russian": "Самостоятельный вход через"
     },
     "footer.message-new": {
       "dutch": "Zelfkusten via",
@@ -428,7 +463,8 @@
       "mandarin": "自我castody通过",
       "portuguese": "Autoconfiança via",
       "spanish": "Autocustodia a través de",
-      "turkish": "Kendi kendine velayet"
+      "turkish": "Kendi kendine velayet",
+      "russian": "Самостоятельное хранение через"
     },
     "footer.policy": {
       "dutch": "Privacybeleid",
@@ -440,7 +476,8 @@
       "mandarin": "隐私政策",
       "portuguese": "Política de Privacidade",
       "spanish": "Política de privacidad",
-      "turkish": "Gizlilik Politikası"
+      "turkish": "Gizlilik Politikası",
+      "russian": "Политика конфиденциальности"
     },
     "footer.privacy-policy": {
       "dutch": "Privacy Policy",
@@ -452,7 +489,8 @@
       "mandarin": "隐私政策",
       "portuguese": "Política de privacidade",
       "spanish": "Política de privacidad",
-      "turkish": "Gizlilik Politikası"
+      "turkish": "Gizlilik Politikası",
+      "russian": "Политика конфиденциальности"
     },
     "footer.terms": {
       "dutch": "Gebruiksvoorwaarden",
@@ -464,7 +502,8 @@
       "mandarin": "使用条款",
       "portuguese": "Termos de Uso",
       "spanish": "Términos de Uso",
-      "turkish": "Kullanım Şartları"
+      "turkish": "Kullanım Şartları",
+      "russian": "Условия использования"
     },
     "footer.terms-of-service": {
       "dutch": "Gebruiksvoorwaarden",
@@ -476,7 +515,8 @@
       "mandarin": "使用条款",
       "portuguese": "Termos de uso",
       "spanish": "Términos de uso",
-      "turkish": "Kullanım Şartları"
+      "turkish": "Kullanım Şartları",
+      "russian": "Условия обслуживания"
     },
     "footer.terms-service": {
       "dutch": "Gebruiksvoorwaarden",
@@ -488,7 +528,8 @@
       "mandarin": "服务条款",
       "portuguese": "Termos de Serviço",
       "spanish": "Términos de servicio",
-      "turkish": "Hizmet Şartları"
+      "turkish": "Hizmet Şartları",
+      "russian": "Условия обслуживания"
     },
     "footer.version": {
       "dutch": "Versie",
@@ -500,7 +541,8 @@
       "mandarin": "版本",
       "portuguese": "Versão",
       "spanish": "Versión",
-      "turkish": "Versiyon"
+      "turkish": "Versiyon",
+      "russian": "Версия"
     },
     "getWallet": {
       "dutch": "Portemonnee ophalen",
@@ -512,7 +554,8 @@
       "mandarin": "获取钱包",
       "portuguese": "Obter carteira",
       "spanish": "Obtener billetera",
-      "turkish": "Cüzdanı al"
+      "turkish": "Cüzdanı al",
+      "russian": "Получить кошелек"
     },
     "header-subtitle": {
       "dutch": "Selecteer een van de volgende opties om door te gaan",
@@ -524,7 +567,8 @@
       "mandarin": "选择以下选项以继续",
       "portuguese": "Selecione uma das seguintes opções para continuar",
       "spanish": "Seleccione una de las siguientes opciones para continuar",
-      "turkish": "Devam etmek için seçeneklerden birini işaretle"
+      "turkish": "Devam etmek için seçeneklerden birini işaretle",
+      "russian": "Выберите один из следующих вариантов, чтобы продолжить"
     },
     "header-subtitle-name": {
       "dutch": "Uw {{appName}}-portemonnee met één klik",
@@ -536,7 +580,8 @@
       "mandarin": "一键点击您的 {{appName}} 钱包",
       "portuguese": "Sua carteira {{appName}} com um clique",
       "spanish": "Su billetera {{appName}} con un solo clic",
-      "turkish": "Tek tıklama ile {{appName}} cüzdanınız"
+      "turkish": "Tek tıklama ile {{appName}} cüzdanınız",
+      "russian": "Ваш кошелек {{appName}} в один клик"
     },
     "header-subtitle-new": {
       "dutch": "Uw blockchain-portemonnee met één klik",
@@ -548,7 +593,8 @@
       "mandarin": "一键点击您的区块链钱包",
       "portuguese": "Sua carteira de blockchain com um clique",
       "spanish": "Su billetera blockchain con un solo clic",
-      "turkish": "Tek tıklama ile blockchain cüzdanınız"
+      "turkish": "Tek tıklama ile blockchain cüzdanınız",
+      "russian": "Ваш блокчейн-кошелек в один клик"
     },
     "header-title": {
       "dutch": "Aanmelden",
@@ -560,7 +606,8 @@
       "mandarin": "登录",
       "portuguese": "Entrar",
       "spanish": "Iniciar sesión",
-      "turkish": "Giriş yap"
+      "turkish": "Giriş yap",
+      "russian": "Войти"
     },
     "header-tooltip-desc": {
       "dutch": "De portemonnee dient als een account om uw digitale activa op de blockchain op te slaan en te beheren.",
@@ -572,7 +619,8 @@
       "mandarin": "钱包作为一个账户用于在区块链上存储和管理您的数字资产。",
       "portuguese": "A carteira serve como uma conta para armazenar e gerenciar seus ativos digitais na blockchain.",
       "spanish": "La billetera sirve como una cuenta para almacenar y administrar sus activos digitales en la blockchain.",
-      "turkish": "Cüzdan, dijital varlıklarınızı blockchain'de saklama ve yönetme görevi görür."
+      "turkish": "Cüzdan, dijital varlıklarınızı blockchain'de saklama ve yönetme görevi görür.",
+      "russian": "Кошелек служит аккаунтом для хранения и управления цифровыми активами в блокчейне."
     },
     "header-tooltip-title": {
       "dutch": "Portemonnee",
@@ -584,7 +632,8 @@
       "mandarin": "钱包",
       "portuguese": "Carteira",
       "spanish": "Billetera",
-      "turkish": "Cüzdan"
+      "turkish": "Cüzdan",
+      "russian": "Кошелек"
     },
     "network.add-request": {
       "dutch": "Deze site vraagt om een netwerk toe te voegen",
@@ -596,7 +645,8 @@
       "mandarin": "此站点正在请求添加网络",
       "portuguese": "Este site está solicitando adicionar uma rede",
       "spanish": "Este sitio está solicitando agregar una red",
-      "turkish": "Bu site bir ağ eklemek istiyor"
+      "turkish": "Bu site bir ağ eklemek istiyor",
+      "russian": "Этот сайт запрашивает добавление сети"
     },
     "network.cancel": {
       "dutch": "Annuleren",
@@ -608,7 +658,8 @@
       "mandarin": "取消",
       "portuguese": "Cancelar",
       "spanish": "Cancelar",
-      "turkish": "İptal"
+      "turkish": "İptal",
+      "russian": "Отмена"
     },
     "network.from": {
       "dutch": "Van",
@@ -620,7 +671,8 @@
       "mandarin": "从",
       "portuguese": "De",
       "spanish": "De",
-      "turkish": "Nereden"
+      "turkish": "Nereden",
+      "russian": "От"
     },
     "network.proceed": {
       "dutch": "Doorgaan",
@@ -632,7 +684,8 @@
       "mandarin": "继续",
       "portuguese": "Prosseguir",
       "spanish": "Continuar",
-      "turkish": "Devam"
+      "turkish": "Devam",
+      "russian": "Продолжить"
     },
     "network.switch-request": {
       "dutch": "Deze site vraagt om over te schakelen naar een ander netwerk",
@@ -644,7 +697,8 @@
       "mandarin": "此站点正在请求切换网络",
       "portuguese": "Este site está solicitando trocar de rede",
       "spanish": "Este sitio está solicitando cambiar de red",
-      "turkish": "Bu site ağ değiştirmeyi talep ediyor"
+      "turkish": "Bu site ağ değiştirmeyi talep ediyor",
+      "russian": "Этот сайт запрашивает переключение сети"
     },
     "network.to": {
       "dutch": "Naar",
@@ -656,7 +710,8 @@
       "mandarin": "至",
       "portuguese": "Para",
       "spanish": "A",
-      "turkish": "Nereye"
+      "turkish": "Nereye",
+      "russian": "К"
     },
     "otp.email-subtext": {
       "dutch": "Voer de 6-cijferige verificatiecode in",
@@ -668,7 +723,8 @@
       "mandarin": "请输入6位验证码",
       "portuguese": "Por favor, insira o código de verificação de 6 dígitos",
       "spanish": "Por favor, ingrese el código de verificación de 6 dígitos",
-      "turkish": "6 haneli doğrulama kodunu giriniz"
+      "turkish": "6 haneli doğrulama kodunu giriniz",
+      "russian": "Пожалуйста, введите 6-значный код подтверждения"
     },
     "otp.email-subtext-example": {
       "dutch": "{{email}} adres is verstuurd",
@@ -680,7 +736,8 @@
       "mandarin": "{{email}} 发送的",
       "portuguese": "que foi enviado para o seu email {{email}}",
       "spanish": "que fue enviado a su email {{email}}",
-      "turkish": "{{email}} adresine gönderildi"
+      "turkish": "{{email}} adresine gönderildi",
+      "russian": "который был отправлен на вашу почту {{email}}"
     },
     "otp.email-title": {
       "dutch": "Email Verificatie",
@@ -692,7 +749,8 @@
       "mandarin": "电子邮件验证",
       "portuguese": "Verificação de email",
       "spanish": "Verificación de email",
-      "turkish": "Email Doğrulama"
+      "turkish": "Email Doğrulama",
+      "russian": "Проверка электронной почты"
     },
     "otp.mobile-subtext": {
       "dutch": "OTP Verificatie",
@@ -704,7 +762,8 @@
       "mandarin": "输入 OTP 验证",
       "portuguese": "Verifique o OTP enviado para",
       "spanish": "Verificación OTP",
-      "turkish": "OTP Doğrulama"
+      "turkish": "OTP Doğrulama",
+      "russian": "Введите OTP, отправленный на"
     },
     "otp.mobile-title": {
       "dutch": "OTP Verificatie",
@@ -716,7 +775,8 @@
       "mandarin": "OTP 验证",
       "portuguese": "Verificação OTP",
       "spanish": "Verificación OTP",
-      "turkish": "OTP Doğrulama"
+      "turkish": "OTP Doğrulama",
+      "russian": "Проверка OTP"
     },
     "otp.success": {
       "dutch": "U bent verbonden met uw account!",
@@ -728,7 +788,8 @@
       "mandarin": "您已连接到您的帐户！",
       "portuguese": "Você está conectado ao seu conta!",
       "spanish": "¡Estás conectado a tu cuenta!",
-      "turkish": "Hesabınıza bağlandınız!"
+      "turkish": "Hesabınıza bağlandınız!",
+      "russian": "Вы вошли в аккаунт!"
     },
     "passkey.add": {
       "dutch": "Passkey toevoegen",
@@ -740,7 +801,8 @@
       "mandarin": "添加Passkey",
       "portuguese": "Adicionar Passkey",
       "spanish": "Añadir Passkey",
-      "turkish": "Passkey ekle"
+      "turkish": "Passkey ekle",
+      "russian": "Добавить Passkey"
     },
     "passkey.haveExisting": {
       "dutch": "Heeft u een bestaande passkey?",
@@ -752,7 +814,8 @@
       "mandarin": "已有 passkey 吗？",
       "portuguese": "Você já possui um passkey?",
       "spanish": "¿Tiene un passkey existente?",
-      "turkish": "Mevcut bir passkey'ınız mı var?"
+      "turkish": "Mevcut bir passkey'ınız mı var?",
+      "russian": "У вас уже есть passkey?"
     },
     "passkey.learn-more": {
       "dutch": "Kom meer te weten",
@@ -764,7 +827,8 @@
       "mandarin": "了解更多",
       "portuguese": "Saber mais",
       "spanish": "Aprende más",
-      "turkish": "Daha fazla bilgi edin"
+      "turkish": "Daha fazla bilgi edin",
+      "russian": "Узнать больше"
     },
     "passkey.or": {
       "dutch": "of",
@@ -776,7 +840,8 @@
       "mandarin": "或者",
       "portuguese": "ou",
       "spanish": "o",
-      "turkish": "veya"
+      "turkish": "veya",
+      "russian": "или"
     },
     "passkey.register-desc": {
       "dutch": "Met passkeys kunt u uw identiteit verifiëren via uw gezicht, vingerafdruk of beveiligingssleutels.",
@@ -788,7 +853,8 @@
       "mandarin": "使用passkeys，您可以通过面部、指纹或安全密钥验证您的身份。",
       "portuguese": "Com passkeys, você pode verificar sua identidade por meio de seu rosto, impressão digital ou chaves de segurança.",
       "spanish": "Con passkeys, puedes verificar tu identidad a través de tu rostro, huella digital o claves de seguridad.",
-      "turkish": "passkeys ile kimliğinizi yüzünüz, parmak iziniz veya güvenlik anahtarlarınız aracılığıyla doğrulayabilirsiniz."
+      "turkish": "passkeys ile kimliğinizi yüzünüz, parmak iziniz veya güvenlik anahtarlarınız aracılığıyla doğrulayabilirsiniz.",
+      "russian": "С помощью passkeys вы можете подтвердить свою личность по лицу, отпечатку пальца или ключам безопасности."
     },
     "passkey.register-title": {
       "dutch": "Registreer Passkey",
@@ -800,7 +866,8 @@
       "mandarin": "注册Passkey",
       "portuguese": "Registre-se Passkey",
       "spanish": "Registrarse Passkey",
-      "turkish": "Passkey'ı kaydedin"
+      "turkish": "Passkey'ı kaydedin",
+      "russian": "Зарегистрировать Passkey"
     },
     "passkey.use": {
       "dutch": "Ik heb een passkey",
@@ -812,7 +879,8 @@
       "mandarin": "我有一个Passkey",
       "portuguese": "Eu tenho uma passkey",
       "spanish": "Tengo una Passkey",
-      "turkish": "Bir passkey'im var"
+      "turkish": "Bir passkey'im var",
+      "russian": "У меня есть passkey"
     },
     "passwordless.title": {
       "dutch": "Doorgaan met {{title}}",
@@ -824,7 +892,8 @@
       "mandarin": "继续使用 {{title}}",
       "portuguese": "Continuar com {{title}}",
       "spanish": "Continuar con {{title}}",
-      "turkish": "{{title}} ile devam et"
+      "turkish": "{{title}} ile devam et",
+      "russian": "Продолжить с {{title}}"
     },
     "popup.phone-body": {
       "dutch": "Uw landcode wordt automatisch gedetecteerd, maar als u een telefoonnummer uit een ander land gebruikt, moet u handmatig de juiste landcode invoeren.",
@@ -836,7 +905,8 @@
       "mandarin": "您的国家代码将自动检测到，但如果您使用其他国家/地区的电话号码，您需要手动输入正确的国家代码。",
       "portuguese": "O código do seu país será detectado automaticamente, mas se estiver usando um número de telefone de um país diferente, você precisará inserir manualmente o código correto do país.",
       "spanish": "Su código de país se detectará automáticamente, pero si está utilizando un número de teléfono de otro país, deberá ingresar manualmente el código de país correcto.",
-      "turkish": "Ülke kodunuz otomatik olarak algılanacaktır, ancak farklı bir ülkeden bir telefon numarası kullanıyorsanız, doğru ülke kodunu manuel olarak girmeniz gerekir."
+      "turkish": "Ülke kodunuz otomatik olarak algılanacaktır, ancak farklı bir ülkeden bir telefon numarası kullanıyorsanız, doğru ülke kodunu manuel olarak girmeniz gerekir.",
+      "russian": "Код вашей страны будет определён автоматически, но если вы используете номер из другой страны, вам нужно вручную ввести правильный код страны."
     },
     "popup.phone-header": {
       "dutch": "Telefoonnummer en landcode",
@@ -848,7 +918,8 @@
       "mandarin": "电话号码和国家代码",
       "portuguese": "Número de telefone e código do país",
       "spanish": "Número de teléfono y código de país",
-      "turkish": "Telefon numarası ve ülke kodu"
+      "turkish": "Telefon numarası ve ülke kodu",
+      "russian": "Номер телефона и код страны"
     },
     "post-loading.connected": {
       "dutch": "U bent verbonden met uw account",
@@ -860,7 +931,8 @@
       "mandarin": "您与您的帐户有联系",
       "portuguese": "Você está conectado com sua conta",
       "spanish": "Estás conectado con tu cuenta",
-      "turkish": "Hesabınızla bağlandınız"
+      "turkish": "Hesabınızla bağlandınız",
+      "russian": "Вы подключены к своему аккаунту"
     },
     "post-loading.something-wrong": {
       "dutch": "Er is iets fout gegaan!",
@@ -872,7 +944,8 @@
       "mandarin": "出了些问题！",
       "portuguese": "Algo deu errado!",
       "spanish": "¡Algo salió mal!",
-      "turkish": "Bir şeyler ters gitti!"
+      "turkish": "Bir şeyler ters gitti!",
+      "russian": "Что-то пошло не так!"
     },
     "resendCode": {
       "dutch": "Code opnieuw verzenden",
@@ -884,7 +957,8 @@
       "mandarin": "重新发送代码",
       "portuguese": "Reenviar código",
       "spanish": "Reenviar código",
-      "turkish": "Kodu tekrar gönder"
+      "turkish": "Kodu tekrar gönder",
+      "russian": "Отправить код повторно"
     },
     "resendTimer": {
       "dutch": " Opnieuw verzenden in {{timer}} seconden",
@@ -896,7 +970,8 @@
       "mandarin": " {{timer}} 秒后重新发送",
       "portuguese": " Reenviar em {{timer}} segundos",
       "spanish": " Reenviar en {{timer}} segundos",
-      "turkish": " {{timer}} saniye sonra tekrar gönder"
+      "turkish": " {{timer}} saniye sonra tekrar gönder",
+      "russian": " Повторно отправить через {{timer}} секунд"
     },
     "social.continue": {
       "dutch": "Doorgaan met",
@@ -908,7 +983,8 @@
       "mandarin": "继续",
       "portuguese": "Continuar com",
       "spanish": "Continuar con",
-      "turkish": "Devam et: "
+      "turkish": "Devam et: ",
+      "russian": "Продолжить с"
     },
     "social.continueCustom": {
       "dutch": "Doorgaan met {{adapter}}",
@@ -920,7 +996,8 @@
       "mandarin": "继续使用{{adapter}}",
       "portuguese": "Continue com o {{adapter}}",
       "spanish": "Continuar con {{adapter}}",
-      "turkish": "{{adapter}} ile devam et"
+      "turkish": "{{adapter}} ile devam et",
+      "russian": "Продолжить с {{adapter}}"
     },
     "social.email": {
       "dutch": "E-mail",
@@ -932,7 +1009,8 @@
       "mandarin": "电子邮件",
       "portuguese": "Email",
       "spanish": "Correo electrónico",
-      "turkish": "E-posta"
+      "turkish": "E-posta",
+      "russian": "Электронная почта"
     },
     "social.email-continue": {
       "dutch": "Doorgaan met e-mail",
@@ -944,7 +1022,8 @@
       "mandarin": "继续使用电子邮件",
       "portuguese": "Continuar com email",
       "spanish": "Continuar con correo electrónico",
-      "turkish": "E-posta ile devam et"
+      "turkish": "E-posta ile devam et",
+      "russian": "Продолжить с электронной почтой"
     },
     "social.email-new": {
       "dutch": "naam@voorbeeld.com",
@@ -956,7 +1035,8 @@
       "mandarin": "name@example.com",
       "portuguese": "nome@exemplo.com",
       "spanish": "nombre@ejemplo.com",
-      "turkish": "isim@ornek.com"
+      "turkish": "isim@ornek.com",
+      "russian": "имя@пример.com"
     },
     "social.passwordless-cta": {
       "dutch": "Doorgaan",
@@ -968,7 +1048,8 @@
       "mandarin": "继续",
       "portuguese": "Continuar",
       "spanish": "Continuar",
-      "turkish": "Devam et"
+      "turkish": "Devam et",
+      "russian": "Продолжить"
     },
     "social.passwordless-login": {
       "dutch": "Log in",
@@ -980,7 +1061,8 @@
       "mandarin": "登录",
       "portuguese": "Conecte-se",
       "spanish": "Acceso",
-      "turkish": "Giriş yapmak"
+      "turkish": "Giriş yapmak",
+      "russian": "Вход"
     },
     "social.passwordless-title": {
       "dutch": "E-mail/Telefoon",
@@ -992,7 +1074,8 @@
       "mandarin": "电子邮件/电话",
       "portuguese": "Email/Telefone",
       "spanish": "Email/Teléfono",
-      "turkish": "E-posta/Telefon"
+      "turkish": "E-posta/Telefon",
+      "russian": "Эл. почта/Телефон"
     },
     "social.phone": {
       "dutch": "Telefoon",
@@ -1004,7 +1087,8 @@
       "mandarin": "电话",
       "portuguese": "Telefone",
       "spanish": "Teléfono",
-      "turkish": "Telefon"
+      "turkish": "Telefon",
+      "russian": "Телефон"
     },
     "social.policy": {
       "dutch": "We slaan geen gegevens op die verband houden met uw sociale logins.",
@@ -1016,7 +1100,8 @@
       "mandarin": "我们不存储与您的社交登录相关的任何数据。",
       "portuguese": "Não armazenamos nenhum dado relacionado ao seu login por rede social.",
       "spanish": "No almacenamos ningún dato relacionado con sus inicios de sesión sociales.",
-      "turkish": "Sosyal medya girişlerinizle ilgili hiçbir veriyi saklamıyoruz."
+      "turkish": "Sosyal medya girişlerinizle ilgili hiçbir veriyi saklamıyoruz.",
+      "russian": "Мы не храним данные, связанные с вашими социальными входами."
     },
     "social.sign-in": {
       "dutch": "Inloggen",
@@ -1028,7 +1113,8 @@
       "mandarin": "登录",
       "portuguese": "Entrar",
       "spanish": "Iniciar sesión",
-      "turkish": "Giriş yap"
+      "turkish": "Giriş yap",
+      "russian": "Войти"
     },
     "social.sms": {
       "dutch": "Mobiel",
@@ -1040,7 +1126,8 @@
       "mandarin": "移动",
       "portuguese": "Móvel",
       "spanish": "Móvil",
-      "turkish": "Mobil Telefon"
+      "turkish": "Mobil Telefon",
+      "russian": "Мобильный"
     },
     "social.sms-continue": {
       "dutch": "Doorgaan met mobiel",
@@ -1052,7 +1139,8 @@
       "mandarin": "继续使用移动设备",
       "portuguese": "Continuar com o celular",
       "spanish": "Continuar con móvil",
-      "turkish": "Telefon ile devam et"
+      "turkish": "Telefon ile devam et",
+      "russian": "Продолжить с мобильного"
     },
     "social.sms-invalid-number": {
       "dutch": "Ongeldig telefoonnummer",
@@ -1064,7 +1152,8 @@
       "mandarin": "无效的电话号码",
       "portuguese": "Número de telefone inválido",
       "spanish": "Número de teléfono inválido",
-      "turkish": "Geçersiz telefon numarası"
+      "turkish": "Geçersiz telefon numarası",
+      "russian": "Неверный номер телефона"
     },
     "social.sms-placeholder-text": {
       "dutch": "Bijv.:",
@@ -1076,7 +1165,8 @@
       "mandarin": "例如：",
       "portuguese": "Por exemplo:",
       "spanish": "Por ej.:",
-      "turkish": "Örneğin:"
+      "turkish": "Örneğin:",
+      "russian": "Напр.:"
     },
     "social.view-less": {
       "dutch": "Minder bekijken",
@@ -1088,7 +1178,8 @@
       "mandarin": "少查看",
       "portuguese": "Ver menos",
       "spanish": "Ver menos",
-      "turkish": "Daha az görüntüle"
+      "turkish": "Daha az görüntüle",
+      "russian": "Показать меньше"
     },
     "social.view-less-socials": {
       "dutch": "Bekijk minder socials",
@@ -1100,7 +1191,8 @@
       "mandarin": "查看更少socials",
       "portuguese": "Ver menos socials",
       "spanish": "Ver menos socials",
-      "turkish": "Daha az socials görüntüle"
+      "turkish": "Daha az socials görüntüle",
+      "russian": "Показать меньше соцсетей"
     },
     "social.view-more": {
       "dutch": "Meer bekijken",
@@ -1112,7 +1204,8 @@
       "mandarin": "查看更多",
       "portuguese": "Ver mais",
       "spanish": "Ver más",
-      "turkish": "Daha fazla görüntüle"
+      "turkish": "Daha fazla görüntüle",
+      "russian": "Показать больше"
     },
     "social.view-more-socials": {
       "dutch": "Bekijk meer socials",
@@ -1124,7 +1217,8 @@
       "mandarin": "查看更多socials",
       "portuguese": "Ver mais socials",
       "spanish": "Ver más socials",
-      "turkish": "Daha fazlasını görüntüle socials"
+      "turkish": "Daha fazlasını görüntüle socials",
+      "russian": "Показать больше соцсетей"
     }
   },
   "passwordless": {
@@ -1138,7 +1232,8 @@
       "mandarin": "无效的验证链接或链接已过期",
       "portuguese": "Link de verificação inválido ou link expirado",
       "spanish": "El enlace o el enlace de verificación ha expirado",
-      "turkish": "Hatalı ya da süresi geçmiş doğrulama linki"
+      "turkish": "Hatalı ya da süresi geçmiş doğrulama linki",
+      "russian": "Неверная ссылка для проверки или ссылка истекла"
     },
     "error-invalid-origin": {
       "dutch": "Er is iets misgegaan, foutcode: E002",
@@ -1150,7 +1245,8 @@
       "mandarin": "出问题了, 错误代码: E002",
       "portuguese": "Algo deu errado, código de erro: E002",
       "spanish": "Algo salió mal, código de error: E002",
-      "turkish": "Bir şeyler ters gitti, hata kodu: E002"
+      "turkish": "Bir şeyler ters gitti, hata kodu: E002",
+      "russian": "Что-то пошло не так, код ошибки: E002"
     },
     "error-invalid-otp": {
       "dutch": "Ongeldige OTP, probeer het opnieuw",
@@ -1162,7 +1258,8 @@
       "mandarin": "无效的OTP，请重试",
       "portuguese": "OTP inválido, por favor tente novamente",
       "spanish": "OTP no válido, intente nuevamente",
-      "turkish": "Hatalı OTP, lütfen tekrar deneyin."
+      "turkish": "Hatalı OTP, lütfen tekrar deneyin.",
+      "russian": "Неверный OTP, пожалуйста, попробуйте снова"
     },
     "error-invalid-params": {
       "dutch": "Ontbrekende of ongeldige parameters",
@@ -1174,7 +1271,8 @@
       "mandarin": "缺失或无效参数",
       "portuguese": "Parâmetros ausentes ou inválidos",
       "spanish": "Parámetros faltantes o no válidos",
-      "turkish": "Eksik ya da hatalı parametreler var."
+      "turkish": "Eksik ya da hatalı parametreler var.",
+      "russian": "Отсутствуют или недействительны параметры."
     },
     "error-max-retry-limit-reached": {
       "dutch": "U heeft de limiet voor verkeerde pogingen bereikt. Start de stroom opnieuw om de verificatie te voltooien.",
@@ -1186,7 +1284,8 @@
       "mandarin": "您已经达到了错误的尝试的极限。请再次重新启动流程以完成验证。",
       "portuguese": "Você atingiu o limite para tentativas erradas. Reinicie o fluxo novamente para concluir a verificação.",
       "spanish": "Has alcanzado el límite para intentos incorrectos. Reinicie el proceso para completar la verificación.",
-      "turkish": "Hatalı deneme limitine ulaştınız. Doğrulamayı tamamlamak için lütfen akışı baştan başlatın."
+      "turkish": "Hatalı deneme limitine ulaştınız. Doğrulamayı tamamlamak için lütfen akışı baştan başlatın.",
+      "russian": "Вы достигли лимита неверных попыток. Пожалуйста, перезапустите процесс, чтобы завершить проверку."
     },
     "error-new-link-generated-heading": {
       "dutch": "Nieuwe verificatielink gegenereerd",
@@ -1198,7 +1297,8 @@
       "mandarin": "生成的新验证链接",
       "portuguese": "Novo link de verificação gerado",
       "spanish": "Nuevo enlace de verificación generado",
-      "turkish": "Yeni doğrulama linki oluşturuldu."
+      "turkish": "Yeni doğrulama linki oluşturuldu.",
+      "russian": "Создана новая ссылка для проверки"
     },
     "error-no-mail-generated": {
       "dutch": "Geen e-mail gegenereerd. Start eerst de wachtwoordloze flow.",
@@ -1210,7 +1310,8 @@
       "mandarin": "没有生成邮件。请先启动无密码流。",
       "portuguese": "Nenhum correio gerado. Inicie o fluxo sem senha primeiro.",
       "spanish": "No se generó el correo. Inicie primero el proceso sin contraseña.",
-      "turkish": "E-posta oluşturulmadı. Lütfen önce şifresiz akışı başlatın."
+      "turkish": "E-posta oluşturulmadı. Lütfen önce şifresiz akışı başlatın.",
+      "russian": "Письмо не было создано. Пожалуйста, сначала запустите безпарольный поток."
     },
     "error-no-sms-generated": {
       "dutch": "Geen OTP gegenereerd. Start eerst de wachtwoordloze flow.",
@@ -1222,7 +1323,8 @@
       "mandarin": "没有生成OTP。请先启动无密码流。",
       "portuguese": "Nenhum OTP gerado. Inicie o fluxo sem senha primeiro.",
       "spanish": "No se generó OTP. Inicie primero el proceso sin contraseña.",
-      "turkish": "OTP oluşturulmadı. Lütfen önce şifresiz akışı başlatın."
+      "turkish": "OTP oluşturulmadı. Lütfen önce şifresiz akışı başlatın.",
+      "russian": "OTP не был создан. Пожалуйста, сначала запустите безпарольный поток."
     },
     "error-otp-expired": {
       "dutch": "OTP verlopen",
@@ -1234,7 +1336,8 @@
       "mandarin": "OTP过期",
       "portuguese": "OTP expirou",
       "spanish": "OTP expiró",
-      "turkish": "OTP'nin süresi geçti."
+      "turkish": "OTP'nin süresi geçti.",
+      "russian": "OTP истек"
     },
     "error-plan-limit-reached": {
       "dutch": "E411. Limiet bereikt",
@@ -1246,7 +1349,8 @@
       "mandarin": "E411. 限制已达到",
       "portuguese": "E411. Limite atingido",
       "spanish": "E411. Límite alcanzado",
-      "turkish": "E411. Sınır aşıldı"
+      "turkish": "E411. Sınır aşıldı",
+      "russian": "E411. Достигнут предел"
     },
     "error-recaptcha-verification-failed": {
       "dutch": "Er is iets misgegaan tijdens het verifiëren. Probeer het opnieuw door de pagina te laden.",
@@ -1258,7 +1362,8 @@
       "mandarin": "Captcha 验证失败。请再试一次。",
       "portuguese": "A verificação Captcha falhou. Por favor, tente novamente.",
       "spanish": "La verificación de Captcha ha fallado. Por favor, inténtelo de nuevo.",
-      "turkish": "Captcha doğrulama hatası. Lütfen tekrar deneyin."
+      "turkish": "Captcha doğrulama hatası. Lütfen tekrar deneyin.",
+      "russian": "Проверка Captcha не удалась. Пожалуйста, попробуйте снова."
     },
     "error-sending-sms-failed": {
       "dutch": "Er is een fout opgetreden bij het verzenden van een sms. Probeer het opnieuw.",
@@ -1270,7 +1375,8 @@
       "mandarin": "发送短信的错误。请再试一遍。",
       "portuguese": "Houve um erro de envio de um SMS. Por favor, tente novamente.",
       "spanish": "Hubo un error al enviar el SMS. Inténtalo de nuevo.",
-      "turkish": "SMS gönderilirken bir hata oldu. Lütfen tekrar deneyin."
+      "turkish": "SMS gönderilirken bir hata oldu. Lütfen tekrar deneyin.",
+      "russian": "Ошибка при отправке SMS. Пожалуйста, попробуйте снова."
     },
     "something-wrong-error": {
       "dutch": "Er is iets misgegaan",
@@ -1282,7 +1388,8 @@
       "mandarin": "出问题了",
       "portuguese": "Algo deu errado",
       "spanish": "Algo salió mal",
-      "turkish": "Bir şeyler ters gitti"
+      "turkish": "Bir şeyler ters gitti",
+      "russian": "Что-то пошло не так"
     }
   }
 }


### PR DESCRIPTION
## Motivation and Context

Web3auth currently doesn't support Russian language. So we have add russian localization so we can use it in our project also other developers and companies can use it to reach to a wider customer/user range.

## Description
Added russian texts into all the files inside the following folders:
- Openlogin-locale
- Wallet-service-locale
- Web3Auth-locale


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] My code follows the code style of this project. (run lint)
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code requires a db migration.
