### PR TITLE
change all wallet to other wallet

### DIFF
--- a/Web3Auth-locale/locale-common.json
+++ b/Web3Auth-locale/locale-common.json
@@ -326,17 +326,17 @@
       "turkish": "Zorunlu"
     },
     "external.all-wallets": {
-      "amharic": "ሁሉም ዋሌቶች",
-      "dutch": "Alle portemonnees",
-      "english": "All Wallets",
-      "french": "Toutes les billeteras",
-      "german": "Alle Geldbörsen",
-      "japanese": "すべてのウォレット",
-      "korean": "모든 지갑",
-      "mandarin": "所有钱包",
-      "portuguese": "Todas as carteiras",
-      "spanish": "Todas las billeteras",
-      "turkish": "Tüm cüzdanlar"
+      "amharic": "የሌላዎች ዋሌቶች",
+      "dutch": "Andere portemonnees",
+      "english": "Other wallets",
+      "french": "Autres portefeuilles",
+      "german": "Andere Wallets",
+      "japanese": "他のウォレット",
+      "korean": "다른 지갑",
+      "mandarin": "其他钱包",
+      "portuguese": "Outras carteiras",
+      "spanish": "Otras billeteras",
+      "turkish": "Diğer cüzdanlar"
     },
     "external.back": {
       "amharic": "ወደ ኋላ",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Jira Link:
https://consensyssoftware.atlassian.net/browse/EMBED-446

## Description
<!--- Describe your changes in detail -->

Copywriting update base on this [**PR**](https://github.com/Web3Auth/web3auth-web/pull/2529)

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code requires a db migration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only locale updates with no logic or key renames; low risk aside from possible product/UX expectation that the label now means “other” rather than “all.”
> 
> **Overview**
> Updates the **`modal.external.all-wallets`** copy in `locale-common.json` so the external-wallet UI label reads **“Other wallets”** instead of **“All Wallets”** in every supported locale (English plus amharic, dutch, french, german, japanese, korean, mandarin, portuguese, spanish, turkish).
> 
> This is a **wording-only** change; the locale key is unchanged, so consumers still resolve the same string id with new translations (e.g. French **Autres portefeuilles**, German **Andere Wallets**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0af0c87b1365d5611d3aa99f912a9174dceb52d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->